### PR TITLE
Phase F-4c: structured_data 차트/비교표 렌더

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -1831,10 +1831,35 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 - (문서 별도)
 
 ### 다음
-- **4c**: structured_data 렌더 (comparison_table 표 / technical·portfolio_chart base64 img, next/image 아님). 타입/수집은 4b에서 이미 됨 → 렌더 컴포넌트만.
 - **4d**: 멀티턴(chat_history 전송), 에러 UI 개선, 모바일 반응형, localStorage, 후속질문 칩.
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a 프론트 골격 + F-4b SSE 스트리밍. 백엔드 테스트 655개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+## Phase F-4c: structured_data 차트/비교표 렌더 (2026-06-08)
+
+4b에서 수집만 하던 `message.structured[]`를 실제로 렌더. 백엔드 차트(base64 PNG)·비교표가 답변에 인라인 표시.
+
+### 백엔드 structured_data 실제 형태 (curl로 확인)
+- **technical_chart**: `{__type__, image_b64(~218KB PNG), name}` — 차트 1장 (가격+MA+볼린저 / RSI / 거래량+MACD)
+- **portfolio_chart**: `{__type__, image_b64, names[]}` — wealth curve + drawdown
+- **comparison_table**: `{__type__, items[2], comparison_chart_b64}` — items에 name/ticker/close/change_pct/return_*/per/pbr/eps/bps/market_cap/div/dps/asset_type/revenue/operating_margin/... + nav/deviation(ETF). asset_type으로 etf/stock 구분.
+
+### 신규 파일 (frontend/src/components)
+- **StructuredData.tsx**: `__type__` 스위치. 차트류 → base64 `<img>` (`data:image/png;base64,...`, **next/image 아님** — data URI 최적화 불가, eslint no-img-element 인라인 disable). comparison_table → ComparisonTable + 선택적 상대수익률 차트.
+- **ComparisonTable.tsx**: items[]를 **항목별 2열로 전치**(행=지표, 열=종목). 값 있는 필드만 행 표시 → ETF(nav/괴리율)·주식(PER/PBR/재무) 자동 분기. 한국어 라벨 + 단위 포맷(조/억원, 배, %, 원).
+- **ChatMessage**: assistant 메시지 본문 아래 `structured[]` 렌더 연결.
+- **globals.css**: `.comparison-table` 스타일.
+
+### 검증
+- `npm run build` 통과. e2e: 백엔드 technical_chart structured_data 이벤트 1개 + 프론트 dev 컴파일/서빙(HTTP 200) 정상. (브라우저 DOM 렌더는 curl 완전검증 불가하나 빌드+SSE흐름+서빙으로 계약 검증.)
+
+### 커밋 (브랜치 phase-f-4c-charts, main에서 분기)
+- `feat(frontend)`: F-4c 차트/비교표 렌더 + (문서 별도)
+
+### 다음
+- **4d**: 멀티턴(chat_history 전송 — 백엔드 최근 10턴), 에러 UI 개선, 모바일 반응형, localStorage 영속, 후속질문 칩(src/ui/chat.py:_get_followup_suggestions 규칙 복제).
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a 골격 + F-4b 스트리밍 + F-4c 차트/비교표. 백엔드 테스트 655개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -251,7 +251,8 @@
 - [ ] **Phase F: SaaS 전환** — FastAPI + React/Next.js + KIS 실시간 시세 + KoELECTRA 감성 분석
   - [x] **F-1 백엔드 골격** (2026-06-08): `api/` 패키지 — FastAPI `/health`·`/chat`·`/stream`(SSE). 기존 agent(`run_agent`/`stream_agent`)를 Streamlit 없이 래핑, 동기 호출은 threadpool 경유. Streamlit 앱과 병행.
   - [x] **F-4a 프론트 골격** (2026-06-08): `frontend/` Next.js 16(App Router/TS/Tailwind v4) — health 게이트 + 비스트리밍 `/chat` 채팅 UI.
-  - [x] **F-4b SSE 스트리밍** (2026-06-08): `/stream` SSE 실시간 토큰 타이핑(@microsoft/fetch-event-source) + react-markdown/remark-gfm + 도구 상태줄. 후속: 4c 차트(structured_data) / 4d 멀티턴·모바일.
+  - [x] **F-4b SSE 스트리밍** (2026-06-08): `/stream` SSE 실시간 토큰 타이핑(@microsoft/fetch-event-source) + react-markdown/remark-gfm + 도구 상태줄.
+  - [x] **F-4c 차트/비교표** (2026-06-08): structured_data 인라인 렌더 — technical/portfolio_chart base64 PNG, comparison_table 항목별 전치 표(+상대수익률 차트). 후속: 4d 멀티턴·모바일·후속질문.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/frontend/src/app/globals.css
+++ b/ETF_RAG/frontend/src/app/globals.css
@@ -109,3 +109,19 @@ body {
   margin: 0.5em 0;
   color: #6b7280;
 }
+
+/* structured_data 비교표 */
+.comparison-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.comparison-table th,
+.comparison-table td {
+  border: 1px solid #e5e7eb;
+  padding: 0.35em 0.6em;
+  white-space: nowrap;
+}
+.comparison-table thead th {
+  background: #f3f4f6;
+  font-weight: 600;
+}

--- a/ETF_RAG/frontend/src/components/ChatMessage.tsx
+++ b/ETF_RAG/frontend/src/components/ChatMessage.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { UiMessage } from "@/lib/types";
 import { questionTypeLabel } from "@/lib/labels";
+import StructuredDataView from "./StructuredData";
 
 export default function ChatMessage({ message }: { message: UiMessage }) {
   const isUser = message.role === "user";
@@ -43,6 +44,12 @@ export default function ChatMessage({ message }: { message: UiMessage }) {
             </div>
           )
         )}
+
+        {/* 차트/비교표 (structured_data) */}
+        {!isUser &&
+          message.structured?.map((d, i) => (
+            <StructuredDataView key={i} data={d} />
+          ))}
       </div>
     </div>
   );

--- a/ETF_RAG/frontend/src/components/ComparisonTable.tsx
+++ b/ETF_RAG/frontend/src/components/ComparisonTable.tsx
@@ -1,0 +1,88 @@
+import type { ComparisonItem } from "@/lib/types";
+
+// 표에 보여줄 필드 정의 (라벨 + 포맷터). 값이 모든 항목에서 없으면 행 생략.
+type FieldDef = {
+  key: string;
+  label: string;
+  fmt: (v: unknown) => string;
+};
+
+const won = (v: unknown) =>
+  typeof v === "number" ? `${v.toLocaleString("ko-KR")}원` : "-";
+const pct = (v: unknown) =>
+  typeof v === "number" ? `${v > 0 ? "+" : ""}${v.toFixed(2)}%` : "-";
+const num = (v: unknown) =>
+  typeof v === "number" ? v.toLocaleString("ko-KR") : "-";
+const x = (v: unknown) =>
+  typeof v === "number" ? `${v.toFixed(2)}배` : "-";
+
+const marketCap = (v: unknown) => {
+  if (typeof v !== "number") return "-";
+  const 조 = 1_0000_0000_0000;
+  const 억 = 1_0000_0000;
+  if (v >= 조) return `${(v / 조).toFixed(1)}조원`;
+  if (v >= 억) return `${Math.round(v / 억).toLocaleString("ko-KR")}억원`;
+  return won(v);
+};
+
+const FIELDS: FieldDef[] = [
+  { key: "close", label: "종가", fmt: won },
+  { key: "change_pct", label: "등락률", fmt: pct },
+  { key: "return_1m", label: "1개월 수익률", fmt: pct },
+  { key: "return_1y", label: "1년 수익률", fmt: pct },
+  { key: "market_cap", label: "시가총액", fmt: marketCap },
+  { key: "per", label: "PER", fmt: x },
+  { key: "pbr", label: "PBR", fmt: x },
+  { key: "div", label: "배당수익률", fmt: pct },
+  { key: "nav", label: "NAV", fmt: won }, // ETF
+  { key: "deviation", label: "괴리율", fmt: pct }, // ETF
+  { key: "operating_margin", label: "영업이익률", fmt: pct },
+  { key: "volume", label: "거래량", fmt: num },
+];
+
+export default function ComparisonTable({
+  items,
+}: {
+  items: ComparisonItem[];
+}) {
+  if (!items?.length) return null;
+
+  // 어느 항목에든 값이 있는 필드만 행으로
+  const rows = FIELDS.filter((f) =>
+    items.some((it) => it[f.key] !== undefined && it[f.key] !== null),
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="comparison-table text-xs">
+        <thead>
+          <tr>
+            <th className="text-left">항목</th>
+            {items.map((it, i) => (
+              <th key={i} className="text-right">
+                {it.name}
+                {it.ticker ? (
+                  <span className="block font-normal text-gray-400">
+                    {it.ticker}
+                  </span>
+                ) : null}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((f) => (
+            <tr key={f.key}>
+              <td className="text-left text-gray-500">{f.label}</td>
+              {items.map((it, i) => (
+                <td key={i} className="text-right tabular-nums">
+                  {f.fmt(it[f.key])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/components/StructuredData.tsx
+++ b/ETF_RAG/frontend/src/components/StructuredData.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable @next/next/no-img-element */
+// base64 data URI는 next/image로 최적화 불가 → 일반 <img> 사용.
+import type { StructuredData } from "@/lib/types";
+import ComparisonTable from "./ComparisonTable";
+
+function ChartImage({ b64, alt }: { b64: string; alt: string }) {
+  return (
+    <img
+      src={`data:image/png;base64,${b64}`}
+      alt={alt}
+      className="mt-2 w-full rounded-lg border border-gray-200"
+    />
+  );
+}
+
+export default function StructuredDataView({ data }: { data: StructuredData }) {
+  switch (data.__type__) {
+    case "comparison_table":
+      return (
+        <div className="mt-2">
+          <ComparisonTable items={data.items} />
+          {data.comparison_chart_b64 && (
+            <ChartImage b64={data.comparison_chart_b64} alt="상대 수익률 추이" />
+          )}
+        </div>
+      );
+    case "technical_chart":
+      return <ChartImage b64={data.image_b64} alt={`${data.name} 기술적 분석 차트`} />;
+    case "portfolio_chart":
+      return (
+        <ChartImage
+          b64={data.image_b64}
+          alt={`포트폴리오 차트 (${data.names.join(", ")})`}
+        />
+      );
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Context

F-4b(SSE 스트리밍)에서 `message.structured[]`로 수집만 하던 차트/비교표 데이터를 실제로 렌더. 백엔드가 내보내는 base64 차트와 비교표가 답변에 인라인 표시되어, 기술적 분석/비교 질문에서 "진짜 서비스" 같은 시각적 결과가 나온다.

## 변경 내용

**신규 컴포넌트** (`frontend/src/components/`):
- **StructuredData.tsx** — `__type__` 스위치:
  - technical_chart / portfolio_chart → base64 PNG `<img>` (next/image 아님 — data URI 최적화 불가)
  - comparison_table → ComparisonTable + 선택적 상대수익률 차트(comparison_chart_b64)
- **ComparisonTable.tsx** — items[]를 **항목별 2열 전치 표**(행=지표, 열=종목). 값 있는 필드만 행 → ETF(NAV/괴리율)·주식(PER/PBR/재무) 자동 분기. 한국어 라벨 + 단위(조/억원, 배, %, 원).

**수정**:
- ChatMessage: assistant 본문 아래 `structured[]` 렌더 연결.
- globals.css: `.comparison-table` 스타일.

## 검증

- 백엔드 structured_data 실제 형태 curl 확인: technical_chart=`{image_b64(218KB), name}`, comparison_table=`{items[2], comparison_chart_b64}`.
- `npm run build` 통과(타입 0). e2e: 백엔드 structured_data 이벤트 + 프론트 컴파일/서빙(HTTP 200) 정상.

## 메모

- 다음 4d: 멀티턴(chat_history) · 모바일 반응형 · 후속질문 칩 · 에러 UI 개선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)