### PR TITLE
Phase F-4d: 멀티턴 + 후속질문 + 모바일 + localStorage (F-4 프론트 완성)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -1857,9 +1857,33 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 - `feat(frontend)`: F-4c 차트/비교표 렌더 + (문서 별도)
 
 ### 다음
-- **4d**: 멀티턴(chat_history 전송 — 백엔드 최근 10턴), 에러 UI 개선, 모바일 반응형, localStorage 영속, 후속질문 칩(src/ui/chat.py:_get_followup_suggestions 규칙 복제).
+- 4d로 이어짐.
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a 골격 + F-4b 스트리밍 + F-4c 차트/비교표. 백엔드 테스트 655개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+## Phase F-4d: 멀티턴 + 후속질문 + 모바일 + localStorage (2026-06-08)
+
+프론트 채팅의 마지막 다듬기. **F-4 프론트 채팅 완성.**
+
+### 변경 (frontend)
+- **멀티턴**: handleSend에서 완료된 대화(content 있고 isError 아님)를 `chat_history`로 streamChat 전달. 백엔드는 최근 10턴 사용 → "그 회사 PER은?" 같은 대명사 참조 동작.
+- **후속질문 칩** (`lib/followup.ts`): streamChat의 onToolCall로 `toolsUsed[]` 수집 + 질문에서 종목명 추출(하드코딩 목록) → `src/ui/chat.py:_get_followup_suggestions` 규칙 복제(최대 3개). 마지막 assistant 답변 아래 칩, 클릭 시 handleSend 재호출.
+- **localStorage 영속** (`STORAGE_KEY="etfrag.messages.v1"`): mount 시 복원(hydrated 가드), 변경 시 저장. **structured(base64 차트)·status는 제외** — 이미지 200KB+라 ~5MB 쿼터 초과 방지, 텍스트 대화(role/content/questionType/model/followups)만. 차트는 재방문 시 사라지지만 텍스트 답변은 유지.
+- **대화 초기화 버튼**: 헤더 우상단, setMessages([]) + localStorage.removeItem.
+- **모바일 반응형**: max-w-3xl, `px-3 sm:px-4`, 헤더 부제 `hidden sm:block`, 입력바 `sticky bottom-0 bg-white`.
+
+### 검증
+- `npm run build` 통과. e2e: **멀티턴** chat_history로 대명사 참조 정답 확인 ("그 회사 PER은?" + 삼성전자 히스토리 → PER 49.81배). 프론트 컴파일/서빙(HTTP 200) 정상.
+
+### 커밋 (브랜치 phase-f-4d-polish, main에서 분기)
+- `feat(frontend)`: F-4d 멀티턴 + 후속질문 + 모바일 + localStorage + (문서 별도)
+
+### Phase F-4 프론트 완성 — 다음 큰 단계
+- **6탭 UI 이식**: 현재 프론트는 종합 채팅만. Streamlit의 기술/재무/비교/전망/섹터 탭은 추후 React로.
+- **F-1 잔여**: WebSocket, SQLite→PostgreSQL, JWT/OAuth2 인증, 유저별 관심종목/히스토리 서버 저장.
+- **F-2**: KIS 실시간(계좌 개설 — 신분증 필요로 보류 중). **F-3**: KoELECTRA 감성. **F-5**: Railway/Render 배포(콜드스타트·유휴정지 해소).
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a~d 프론트 채팅 완성(스트리밍·차트·멀티턴·모바일). 백엔드 테스트 655개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -252,7 +252,8 @@
   - [x] **F-1 백엔드 골격** (2026-06-08): `api/` 패키지 — FastAPI `/health`·`/chat`·`/stream`(SSE). 기존 agent(`run_agent`/`stream_agent`)를 Streamlit 없이 래핑, 동기 호출은 threadpool 경유. Streamlit 앱과 병행.
   - [x] **F-4a 프론트 골격** (2026-06-08): `frontend/` Next.js 16(App Router/TS/Tailwind v4) — health 게이트 + 비스트리밍 `/chat` 채팅 UI.
   - [x] **F-4b SSE 스트리밍** (2026-06-08): `/stream` SSE 실시간 토큰 타이핑(@microsoft/fetch-event-source) + react-markdown/remark-gfm + 도구 상태줄.
-  - [x] **F-4c 차트/비교표** (2026-06-08): structured_data 인라인 렌더 — technical/portfolio_chart base64 PNG, comparison_table 항목별 전치 표(+상대수익률 차트). 후속: 4d 멀티턴·모바일·후속질문.
+  - [x] **F-4c 차트/비교표** (2026-06-08): structured_data 인라인 렌더 — technical/portfolio_chart base64 PNG, comparison_table 항목별 전치 표(+상대수익률 차트).
+  - [x] **F-4d 멀티턴/마감** (2026-06-08): chat_history 멀티턴(대명사 참조) + 후속질문 칩 + localStorage 영속(텍스트만) + 대화 초기화 + 모바일 반응형. **F-4 프론트 채팅 완성.** 후속: 6탭 UI 이식, F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/frontend/src/app/page.tsx
+++ b/ETF_RAG/frontend/src/app/page.tsx
@@ -2,22 +2,57 @@
 
 import { useEffect, useRef, useState } from "react";
 import { getHealth, streamChat } from "@/lib/api";
-import type { Health, UiMessage } from "@/lib/types";
+import type { ChatHistoryItem, Health, UiMessage } from "@/lib/types";
 import { toolLabel } from "@/lib/labels";
+import { getFollowupSuggestions } from "@/lib/followup";
 import MessageList from "@/components/MessageList";
 import ChatInput from "@/components/ChatInput";
+
+const STORAGE_KEY = "etfrag.messages.v1";
 
 export default function Home() {
   const [health, setHealth] = useState<Health | null>(null);
   const [messages, setMessages] = useState<UiMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // mount 시 /health 폴링 — ready가 될 때까지 3초 간격 재시도
+  // mount 시 localStorage 복원 (1회)
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) setMessages(JSON.parse(raw) as UiMessage[]);
+    } catch {
+      /* 손상 시 무시 */
+    }
+    setHydrated(true);
+  }, []);
+
+  // 대화 변경 시 영속. base64 차트(structured)·전이 상태(status)는 제외 —
+  // 이미지가 200KB+라 localStorage(~5MB) 초과 위험. 텍스트 대화만 보존.
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      const slim = messages
+        .filter((m) => m.content)
+        .map((m) => ({
+          role: m.role,
+          content: m.content,
+          questionType: m.questionType,
+          model: m.model,
+          isError: m.isError,
+          followups: m.followups,
+        }));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(slim));
+    } catch {
+      /* 용량 초과 등 무시 */
+    }
+  }, [messages, hydrated]);
+
+  // mount 시 /health 폴링 — ready까지 3초 간격 재시도
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout>;
-
     const poll = async () => {
       try {
         const h = await getHealth();
@@ -31,7 +66,6 @@ export default function Home() {
       }
     };
     poll();
-
     return () => {
       cancelled = true;
       clearTimeout(timer);
@@ -48,7 +82,6 @@ export default function Home() {
 
   const inputDisabled = !health?.ready || isLoading;
 
-  // 마지막(진행 중) assistant 메시지를 불변 업데이트
   const patchLastAssistant = (patch: Partial<UiMessage>) => {
     setMessages((prev) => {
       const next = [...prev];
@@ -61,7 +94,11 @@ export default function Home() {
   };
 
   const handleSend = (question: string) => {
-    // user 메시지 + 빈 assistant placeholder push
+    // 멀티턴: 직전까지 완료된 대화를 chat_history로 (현재 user/placeholder 추가 전 기준)
+    const history: ChatHistoryItem[] = messages
+      .filter((m) => m.content && !m.isError)
+      .map((m) => ({ role: m.role, content: m.content }));
+
     setMessages((prev) => [
       ...prev,
       { role: "user", content: question },
@@ -69,11 +106,18 @@ export default function Home() {
     ]);
     setIsLoading(true);
 
-    // 4b: 멀티턴 생략 — 빈 히스토리 전송. (4d에서 실제 chat_history)
-    streamChat(question, [], {
-      onQuestionType: (t) => patchLastAssistant({ questionType: t }),
-      onToolCall: (c) =>
-        patchLastAssistant({ status: `${toolLabel(c.name)} 중…` }),
+    const toolsUsed: string[] = [];
+    let qType = "";
+
+    streamChat(question, history, {
+      onQuestionType: (t) => {
+        qType = t;
+        patchLastAssistant({ questionType: t });
+      },
+      onToolCall: (c) => {
+        toolsUsed.push(c.name);
+        patchLastAssistant({ status: `${toolLabel(c.name)} 중…` });
+      },
       onStructuredData: (d) =>
         setMessages((prev) => {
           const next = [...prev];
@@ -87,14 +131,18 @@ export default function Home() {
           return next;
         }),
       onToken: (cumulative) =>
-        // 누적 텍스트 → replace (델타 아님)
         patchLastAssistant({ content: cumulative, status: undefined }),
       onDone: (d) => {
+        const followups = getFollowupSuggestions(
+          question,
+          toolsUsed,
+          d.question_type || qType,
+        );
         patchLastAssistant({
-          // done.answer가 마지막 토큰보다 길면 우선 (CoV 보정 등)
           model: d.model,
           questionType: d.question_type,
           status: undefined,
+          followups,
         });
         setMessages((prev) => {
           const next = [...prev];
@@ -111,14 +159,20 @@ export default function Home() {
         setIsLoading(false);
       },
       onError: (msg) => {
-        patchLastAssistant({
-          content: msg,
-          isError: true,
-          status: undefined,
-        });
+        patchLastAssistant({ content: msg, isError: true, status: undefined });
         setIsLoading(false);
       },
     });
+  };
+
+  const handleReset = () => {
+    if (isLoading) return;
+    setMessages([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* 무시 */
+    }
   };
 
   const statusText = !health
@@ -127,22 +181,41 @@ export default function Home() {
       ? "준비 완료"
       : `백엔드 준비 중… ${health.error ? `(${health.error})` : ""}`;
 
+  // 마지막 assistant 메시지의 후속질문 (스트리밍 끝났을 때만)
+  const lastMsg = messages[messages.length - 1];
+  const followups =
+    !isLoading && lastMsg?.role === "assistant" && !lastMsg.isError
+      ? (lastMsg.followups ?? [])
+      : [];
+
   return (
-    <main className="mx-auto flex h-full w-full max-w-3xl flex-col px-4">
-      <header className="border-b border-gray-200 py-4">
-        <h1 className="text-lg font-bold text-gray-900">
-          📈 투자 AI 어시스턴트
-        </h1>
-        <p className="text-xs text-gray-500">
-          ETF · 주식 · 기술적 분석 · 재무제표 · 가격 전망
-        </p>
-        <p
-          className={`mt-1 text-xs ${
-            health?.ready ? "text-green-600" : "text-amber-600"
-          }`}
-        >
-          {statusText}
-        </p>
+    <main className="mx-auto flex h-full w-full max-w-3xl flex-col px-3 sm:px-4">
+      <header className="flex items-start justify-between border-b border-gray-200 py-3 sm:py-4">
+        <div>
+          <h1 className="text-base font-bold text-gray-900 sm:text-lg">
+            📈 투자 AI 어시스턴트
+          </h1>
+          <p className="hidden text-xs text-gray-500 sm:block">
+            ETF · 주식 · 기술적 분석 · 재무제표 · 가격 전망
+          </p>
+          <p
+            className={`mt-0.5 text-xs ${
+              health?.ready ? "text-green-600" : "text-amber-600"
+            }`}
+          >
+            {statusText}
+          </p>
+        </div>
+        {messages.length > 0 && (
+          <button
+            type="button"
+            onClick={handleReset}
+            disabled={isLoading}
+            className="shrink-0 rounded-lg border border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-40"
+          >
+            🗑️ 대화 초기화
+          </button>
+        )}
       </header>
 
       <div ref={scrollRef} className="flex-1 overflow-y-auto py-4">
@@ -156,7 +229,23 @@ export default function Home() {
         )}
       </div>
 
-      <div className="border-t border-gray-200 py-4">
+      {followups.length > 0 && (
+        <div className="flex flex-wrap gap-2 pb-2">
+          {followups.map((f, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => handleSend(f)}
+              disabled={inputDisabled}
+              className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs text-blue-700 hover:bg-blue-100 disabled:opacity-40"
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="sticky bottom-0 border-t border-gray-200 bg-white py-3 sm:py-4">
         <ChatInput
           disabled={inputDisabled}
           onSend={handleSend}

--- a/ETF_RAG/frontend/src/lib/followup.ts
+++ b/ETF_RAG/frontend/src/lib/followup.ts
@@ -1,0 +1,58 @@
+// 후속 질문 제안 — 백엔드 src/ui/chat.py:_get_followup_suggestions 규칙을 클라이언트 복제.
+// tool_call 이벤트로 수집한 도구 이름 + 질문에서 추출한 종목명 기반, 최대 3개.
+
+const COMMON_STOCKS = [
+  "삼성전자",
+  "SK하이닉스",
+  "현대차",
+  "LG에너지솔루션",
+  "카카오",
+  "네이버",
+  "셀트리온",
+  "기아",
+  "포스코홀딩스",
+  "삼성SDI",
+];
+const COMMON_ETFS = ["KODEX 200", "TIGER 200", "KODEX 레버리지", "TIGER 미국S&P500"];
+
+export function getFollowupSuggestions(
+  question: string,
+  toolsUsed: string[],
+  questionType: string,
+): string[] {
+  const stockNames = COMMON_STOCKS.filter((n) => question.includes(n));
+  const etfNames = COMMON_ETFS.filter((n) => question.includes(n));
+  const target = stockNames[0] ?? etfNames[0] ?? "";
+
+  const out: string[] = [];
+  const has = (t: string) => toolsUsed.includes(t);
+
+  if (has("search_stock") || has("search_etf")) {
+    if (target) {
+      out.push(`${target} 기술적 분석해줘`);
+      out.push(`${target} 앞으로 전망은?`);
+    }
+  } else if (has("get_technical_indicators")) {
+    if (target) {
+      out.push(`${target} 재무제표 보여줘`);
+      out.push(`${target} 최근 실적은 어때?`);
+    }
+  } else if (has("predict_price_outlook")) {
+    if (target) out.push(`${target} 기술적 분석해줘`);
+  } else if (has("compare_etfs") || has("compare_stocks")) {
+    if (stockNames[0]) out.push(`${stockNames[0]} 기술적 분석해줘`);
+  } else if (has("get_financial_statements")) {
+    if (target) {
+      out.push(`${target} 기술적 분석해줘`);
+      out.push(`${target} 앞으로 전망은?`);
+    }
+  }
+
+  if (questionType === "simple" && target) {
+    const s = `${target} 기술적 분석해줘`;
+    if (!out.includes(s)) out.push(s);
+  }
+  if (out.length === 0 && target) out.push(`${target} 기술적 분석해줘`);
+
+  return out.slice(0, 3);
+}

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -85,6 +85,7 @@ export interface UiMessage {
   questionType?: QuestionType;
   model?: string;
   isError?: boolean;
-  structured?: StructuredData[]; // 4c에서 렌더 (4b는 수집만)
+  structured?: StructuredData[]; // 4c 렌더
   status?: string; // 스트리밍 중 상태줄 텍스트
+  followups?: string[]; // 4d: 후속 질문 제안 (assistant 완료 시)
 }


### PR DESCRIPTION
## Context

F-4 프론트 채팅의 마지막 단계. 멀티턴 대화·후속질문·모바일·영속을 더해 **프론트 채팅 완성**.

## 변경 내용 (frontend)

- **멀티턴**: 완료된 대화를 `chat_history`로 streamChat 전달 → "그 회사 PER은?" 대명사 참조 동작(백엔드 최근 10턴).
- **후속질문 칩** (`lib/followup.ts`): tool_call로 도구 수집 + 종목명 추출 → `src/ui/chat.py:_get_followup_suggestions` 규칙 복제(최대 3개). 답변 아래 칩, 클릭 시 재전송.
- **localStorage 영속**: 텍스트 대화만 저장(structured base64 차트·status 제외 — ~5MB 쿼터 초과 방지). 새로고침 시 복원.
- **대화 초기화 버튼** (헤더 우상단) + localStorage 클리어.
- **모바일 반응형**: max-w-3xl, px 분기, 헤더 부제 모바일 숨김, 입력바 sticky bottom.

## 검증

- `npm run build` 통과(타입 0)
- e2e: **멀티턴** chat_history로 대명사 참조 정답 확인("그 회사 PER은?" + 삼성전자 히스토리 → PER 49.81배). 프론트 컴파일/서빙 정상.

## 다음 (F-4 이후)

6탭 UI 이식 · F-1 잔여(인증/Postgres/WebSocket) · F-2 KIS · F-5 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)