### PR TITLE
Phase F: 5개 데이터 탭 REST API (api/tabs.py)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -1885,5 +1885,43 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a~d 프론트 채팅 완성(스트리밍·차트·멀티턴·모바일). 백엔드 테스트 655개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+## Phase F: 5개 데이터 탭 REST API (2026-06-08)
+
+프론트 탭 이식 전, 백엔드에 탭별 데이터 API 추가. Streamlit 탭(src/ui/tabs.py)이 호출하는 기존 동기 함수를 Streamlit 없이 래핑. **백엔드 먼저, 프론트 탭 페이지는 다음 단계.**
+
+### 신규 파일 / 변경
+- **api/deps.py**: `require_ready(request: Request)` FastAPI 의존성 — 라우터 공유 가드(503). 라우터는 app 참조가 없어 Request에서 app.state 추출.
+- **api/models.py**: `TickerSearchResponse`, `ComparisonRequest`.
+- **api/tabs.py** (신규): `APIRouter(prefix="/tabs", dependencies=[Depends(require_ready)])`, 7개 엔드포인트.
+- **api/main.py**: `app.include_router(tabs_router)`.
+
+### 엔드포인트 (전부 기존 함수 래핑, run_in_threadpool, None→404)
+- GET `/tabs/technical?ticker&days` — get_technical_summary + generate_technical_chart
+- GET `/tabs/financial?ticker&quarters` — DB_PATH.exists() 가드 + get_financial_data + chart
+- POST `/tabs/comparison{tickers[2],days}` — comparison/valuation 차트 + 항목 데이터
+- GET `/tabs/outlook?ticker&horizon` — summary+structured 조립 → build_price_outlook
+- GET `/tabs/sector?sector?` — _build_sector_stats(복제) + overview/detail 차트
+- GET `/tabs/tickers?q&limit` — get_available_tickers 부분매칭+cap
+- GET `/tabs/tickers/resolve?q` — _find_structured_data
+
+### 핵심 설계 결정
+- **name 출처**: get_technical_summary는 name 키 없음 → `_find_structured_data(query)`로 ticker/name 먼저 해석 후 summary/chart 호출 (Streamlit 탭의 _resolve_ticker 패턴 복제).
+- **여러 동기 호출은 sync 헬퍼로 묶어 run_in_threadpool 1회** (summary+chart, outlook 조립 등).
+- **복잡 중첩 dict은 response_model=None** (dict 그대로 반환 — 14키 Pydantic 재모델링 ROI 낮음). 단순한 것만 thin model.
+- **src/ui/tabs.py는 streamlit import → API에서 import 금지.** _build_sector_stats(~15줄, streamlit 무관)만 복제.
+- 차트는 base64 str을 JSON 본문에 포함(218KB 등, 채팅 structured_data와 동일).
+
+### 검증
+- `pytest tests/test_api_tabs.py`: 15개. 전체 **670개**(655+15, 회귀 0).
+- 실서버 스모크(uvicorn, 실데이터): resolve(삼성전자→005930,PER49.81), technical(11지표+218KB차트), outlook(composite0.709/B/3시나리오), sector(29섹터,전기·전자338종목), comparison(차트76KB+밸류25KB), financial(HTTP200), tickers(부분매칭). **단, curl URL에 한글 직접 넣으면 "Invalid HTTP request" → --data-urlencode 필요** (브라우저/프론트는 자동 인코딩하므로 무관).
+
+### 커밋 (브랜치 phase-f-tabs-api, main에서 분기)
+- `feat(api)`: require_ready+모델 / `feat(api)`: tabs 라우터 / `test(api)`: 15개 / (문서 별도)
+
+### 다음
+- **프론트 탭 페이지**: Next.js App Router 라우트(`/technical`,`/financial`,`/comparison`,`/outlook`,`/sector`) + 공통 네비 + 종목 자동완성(이 API 소비). URL 라우트 방식.
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a~d 프론트 채팅 + 탭 REST API(api/tabs.py). 백엔드 테스트 670개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -253,7 +253,8 @@
   - [x] **F-4a 프론트 골격** (2026-06-08): `frontend/` Next.js 16(App Router/TS/Tailwind v4) — health 게이트 + 비스트리밍 `/chat` 채팅 UI.
   - [x] **F-4b SSE 스트리밍** (2026-06-08): `/stream` SSE 실시간 토큰 타이핑(@microsoft/fetch-event-source) + react-markdown/remark-gfm + 도구 상태줄.
   - [x] **F-4c 차트/비교표** (2026-06-08): structured_data 인라인 렌더 — technical/portfolio_chart base64 PNG, comparison_table 항목별 전치 표(+상대수익률 차트).
-  - [x] **F-4d 멀티턴/마감** (2026-06-08): chat_history 멀티턴(대명사 참조) + 후속질문 칩 + localStorage 영속(텍스트만) + 대화 초기화 + 모바일 반응형. **F-4 프론트 채팅 완성.** 후속: 6탭 UI 이식, F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포.
+  - [x] **F-4d 멀티턴/마감** (2026-06-08): chat_history 멀티턴(대명사 참조) + 후속질문 칩 + localStorage 영속(텍스트만) + 대화 초기화 + 모바일 반응형. **F-4 프론트 채팅 완성.**
+  - [x] **탭 REST API** (2026-06-08): `api/tabs.py` — `/tabs/{technical,financial,comparison,outlook,sector,tickers}` 엔드포인트. Streamlit 탭 함수를 Streamlit 없이 래핑(기존 함수 재사용). 테스트 670개. 후속: 프론트 탭 페이지(Next.js 라우트), F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/api/deps.py
+++ b/ETF_RAG/api/deps.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from fastapi import HTTPException, Request
+
 from src.llm.client import get_api_key
 from src.data.db_downloader import ensure_db
 from src.data.loader import (
@@ -35,6 +37,20 @@ class AppState:
     """앱 초기화 상태. /health가 읽고, /chat·/stream이 ready를 가드로 사용."""
     ready: bool = False
     error: Optional[str] = None
+
+
+def require_ready(request: Request) -> None:
+    """라우터용 공유 가드 의존성. ready 아니면 503.
+
+    라우터는 app 참조가 없으므로 Request에서 app.state를 꺼낸다.
+    (main.py의 _require_ready와 동일 동작 — /chat·/stream은 그대로 둠.)
+    """
+    state: AppState = request.app.state.app_state
+    if not state.ready:
+        raise HTTPException(
+            status_code=503,
+            detail=f"초기화 중/실패: {state.error or 'initializing'}",
+        )
 
 
 def run_init() -> None:

--- a/ETF_RAG/api/main.py
+++ b/ETF_RAG/api/main.py
@@ -29,6 +29,7 @@ from src.llm.agent import run_agent, stream_agent
 
 from api.deps import AppState, run_init
 from api.models import ChatRequest, ChatResponse, HealthResponse
+from api.tabs import router as tabs_router
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# 5개 데이터 탭 + 자동완성 엔드포인트 (/tabs/*)
+app.include_router(tabs_router)
 
 
 def _require_ready() -> None:

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -26,3 +26,12 @@ class ChatResponse(BaseModel):
 class HealthResponse(BaseModel):
     ready: bool
     error: Optional[str] = None
+
+
+class TickerSearchResponse(BaseModel):
+    options: List[str]
+
+
+class ComparisonRequest(BaseModel):
+    tickers: List[str] = Field(..., min_length=2, max_length=2)
+    days: int = Field(120, ge=20, le=2500)

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -1,0 +1,235 @@
+"""5개 데이터 탭 + 종목 자동완성 REST 엔드포인트 (Phase F).
+
+Streamlit 탭(src/ui/tabs.py)이 호출하는 기존 동기 함수들을 Streamlit 없이 래핑한다.
+src/ui/tabs.py는 streamlit 의존이라 import 금지 — _build_sector_stats는 복제.
+
+모든 래핑 대상 함수는 동기이고 실패 시 None/[]를 반환(예외 아님) → run_in_threadpool로
+이벤트 루프 보호, None이면 404. summary는 name을 안 주므로 _find_structured_data로 먼저 해석.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.concurrency import run_in_threadpool
+
+from api.deps import require_ready
+from api.models import ComparisonRequest, TickerSearchResponse
+from src.data.technical import get_technical_summary
+from src.data.predictor import build_price_outlook
+from src.data.chart_generator import (
+    generate_technical_chart,
+    generate_comparison_chart,
+    generate_valuation_chart,
+    generate_financial_chart,
+    generate_sector_overview_chart,
+    generate_sector_detail_chart,
+)
+from src.data.database import get_connection, get_financial_data, DB_PATH
+from src.llm.tools import (
+    get_available_tickers,
+    get_sector_index,
+    _find_structured_data,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/tabs", tags=["tabs"], dependencies=[Depends(require_ready)])
+
+
+# ── 섹터 집계 (src/ui/tabs.py:_build_sector_stats 복제 — streamlit 의존 없음) ──
+def _build_sector_stats(sector_index: dict) -> list:
+    stats = []
+    for sector, stocks in sector_index.items():
+        if not stocks:
+            continue
+        total_cap = sum(s.get("market_cap", 0) for s in stocks)
+        weighted_change = 0.0
+        if total_cap > 0:
+            weighted_change = (
+                sum(s.get("change_pct", 0) * s.get("market_cap", 0) for s in stocks)
+                / total_cap
+            )
+        pers = [s["per"] for s in stocks if s.get("per") and s["per"] > 0]
+        median_per = sorted(pers)[len(pers) // 2] if pers else 0
+        stats.append({
+            "sector": sector,
+            "count": len(stocks),
+            "market_cap": total_cap,
+            "change_pct": round(weighted_change, 2),
+            "median_per": round(median_per, 1),
+            "up_count": sum(1 for s in stocks if s.get("change_pct", 0) > 0),
+            "down_count": sum(1 for s in stocks if s.get("change_pct", 0) < 0),
+        })
+    stats.sort(key=lambda x: x["market_cap"], reverse=True)
+    return stats
+
+
+# ── Technical ──────────────────────────────────────────────────────
+def _technical_blocking(query: str, days: int) -> Optional[dict]:
+    data = _find_structured_data(query)
+    if not data:
+        return None
+    ticker = data.get("ticker") or query
+    name = data.get("name") or query
+    summary = get_technical_summary(ticker)
+    if summary is None:
+        return None
+    return {
+        "ticker": ticker,
+        "name": name,
+        "summary": summary,
+        "chart_b64": generate_technical_chart(ticker, name, days=days),
+    }
+
+
+@router.get("/technical", response_model=None)
+async def technical(
+    ticker: str = Query(..., min_length=1),
+    days: int = Query(120, ge=20, le=2500),
+):
+    result = await run_in_threadpool(_technical_blocking, ticker, days)
+    if result is None:
+        raise HTTPException(404, f"'{ticker}' 기술적 데이터를 찾을 수 없습니다.")
+    return result
+
+
+# ── Financial ──────────────────────────────────────────────────────
+def _financial_blocking(query: str, quarters: int) -> Optional[dict]:
+    if not DB_PATH.exists():
+        return None
+    data = _find_structured_data(query)
+    ticker = (data or {}).get("ticker") or query
+    name = (data or {}).get("name") or query
+    conn = get_connection()
+    try:
+        rows = get_financial_data(conn, ticker, quarters=quarters)
+    finally:
+        conn.close()
+    if not rows:
+        return None
+    return {
+        "ticker": ticker,
+        "name": name,
+        "rows": rows,
+        "chart_b64": generate_financial_chart(rows, name),
+    }
+
+
+@router.get("/financial", response_model=None)
+async def financial(
+    ticker: str = Query(..., min_length=1),
+    quarters: int = Query(8, ge=1, le=200),
+):
+    result = await run_in_threadpool(_financial_blocking, ticker, quarters)
+    if result is None:
+        raise HTTPException(404, f"'{ticker}' 재무 데이터를 찾을 수 없습니다.")
+    return result
+
+
+# ── Comparison ─────────────────────────────────────────────────────
+def _comparison_blocking(tickers: list, days: int) -> Optional[dict]:
+    resolved = [_find_structured_data(t) for t in tickers]
+    if any(d is None for d in resolved):
+        return None
+    names = [d.get("name") or tickers[i] for i, d in enumerate(resolved)]
+    codes = [d.get("ticker") or tickers[i] for i, d in enumerate(resolved)]
+
+    # 밸류에이션 비교 차트 (tabs.py:581 형식)
+    val_metrics = {}
+    for key, label in [("per", "PER (배)"), ("pbr", "PBR (배)"), ("div", "배당수익률 (%)")]:
+        v1, v2 = resolved[0].get(key), resolved[1].get(key)
+        if v1 is not None or v2 is not None:
+            val_metrics[label] = (v1 or 0, v2 or 0)
+
+    return {
+        "items": resolved,
+        "comparison_chart_b64": generate_comparison_chart(codes, names, days=days),
+        "valuation_chart_b64": (
+            generate_valuation_chart(names[0], names[1], val_metrics)
+            if val_metrics
+            else None
+        ),
+    }
+
+
+@router.post("/comparison", response_model=None)
+async def comparison(req: ComparisonRequest):
+    result = await run_in_threadpool(_comparison_blocking, req.tickers, req.days)
+    if result is None:
+        raise HTTPException(404, "비교할 종목을 찾을 수 없습니다.")
+    return result
+
+
+# ── Outlook ────────────────────────────────────────────────────────
+def _outlook_blocking(query: str, horizon: str) -> Optional[dict]:
+    data = _find_structured_data(query)
+    ticker = (data or {}).get("ticker") or query
+    name = (data or {}).get("name") or query
+    summary = get_technical_summary(ticker)
+    if summary is None:
+        return None
+    # structured_data(None 가능 — 펀더멘털 축만 degrade)
+    return build_price_outlook(
+        ticker, name, horizon=horizon, summary=summary, structured_data=data
+    )
+
+
+@router.get("/outlook", response_model=None)
+async def outlook(
+    ticker: str = Query(..., min_length=1),
+    horizon: str = Query("1m"),
+):
+    result = await run_in_threadpool(_outlook_blocking, ticker, horizon)
+    if not result:
+        raise HTTPException(404, f"'{ticker}' 전망을 생성할 수 없습니다.")
+    return result
+
+
+# ── Sector ─────────────────────────────────────────────────────────
+def _sector_blocking(sector: Optional[str]) -> Optional[dict]:
+    sector_index = get_sector_index()
+    if not sector_index:
+        return None
+    stats = _build_sector_stats(sector_index)
+    out = {
+        "stats": stats,
+        "overview_chart_b64": generate_sector_overview_chart(stats),
+    }
+    if sector:
+        stocks = sector_index.get(sector)
+        if not stocks:
+            return None  # 알 수 없는 섹터
+        out["sector"] = sector
+        out["detail_chart_b64"] = generate_sector_detail_chart(sector, stocks)
+        out["stocks"] = stocks
+    return out
+
+
+@router.get("/sector", response_model=None)
+async def sector(sector: Optional[str] = Query(None)):
+    result = await run_in_threadpool(_sector_blocking, sector)
+    if result is None:
+        raise HTTPException(404, "섹터 데이터를 찾을 수 없습니다.")
+    return result
+
+
+# ── 종목 자동완성 / 해석 ────────────────────────────────────────────
+@router.get("/tickers", response_model=TickerSearchResponse)
+async def tickers(
+    q: Optional[str] = Query(None),
+    limit: int = Query(30, ge=1, le=200),
+):
+    options = await run_in_threadpool(get_available_tickers)
+    if q:
+        ql = q.lower()
+        options = [o for o in options if ql in o.lower()]
+    return TickerSearchResponse(options=options[:limit])
+
+
+@router.get("/tickers/resolve", response_model=None)
+async def resolve(q: str = Query(..., min_length=1)):
+    data = await run_in_threadpool(_find_structured_data, q)
+    if not data:
+        raise HTTPException(404, f"'{q}'을(를) 찾을 수 없습니다.")
+    return data

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -1,0 +1,201 @@
+"""5개 탭 + 자동완성 REST 엔드포인트 테스트 (Phase F).
+
+API_SKIP_INIT=1로 실제 init 우회 → 래핑 대상 함수는 api.tabs import 사이트에서 patch.
+"""
+
+import os
+
+os.environ["API_SKIP_INIT"] = "1"
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import app  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_sse_global():
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit_event = None
+    yield
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ── Technical ──────────────────────────────────────────────────────
+def test_technical_returns_summary_and_chart(client):
+    structured = {"ticker": "005930", "name": "삼성전자", "per": 12.0}
+    summary = {"close": 70000, "rsi": 55.0, "trend": "상승"}
+    with patch("api.tabs._find_structured_data", return_value=structured), patch(
+        "api.tabs.get_technical_summary", return_value=summary
+    ), patch("api.tabs.generate_technical_chart", return_value="BASE64PNG"):
+        r = client.get("/tabs/technical", params={"ticker": "삼성전자"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ticker"] == "005930"
+    assert body["name"] == "삼성전자"
+    assert body["summary"]["rsi"] == 55.0
+    assert body["chart_b64"] == "BASE64PNG"
+
+
+def test_technical_404_when_unresolved(client):
+    with patch("api.tabs._find_structured_data", return_value=None):
+        r = client.get("/tabs/technical", params={"ticker": "ZZZ"})
+    assert r.status_code == 404
+
+
+def test_technical_404_when_no_summary(client):
+    with patch(
+        "api.tabs._find_structured_data",
+        return_value={"ticker": "005930", "name": "삼성전자"},
+    ), patch("api.tabs.get_technical_summary", return_value=None):
+        r = client.get("/tabs/technical", params={"ticker": "삼성전자"})
+    assert r.status_code == 404
+
+
+# ── Outlook ────────────────────────────────────────────────────────
+def test_outlook_assembles_summary_and_structured(client):
+    structured = {"ticker": "005930", "name": "삼성전자", "per": 12.0}
+    summary = {"close": 70000}
+    outlook = {"composite_score": 0.3, "confidence_grade": "B", "scenarios": {}}
+    with patch("api.tabs._find_structured_data", return_value=structured), patch(
+        "api.tabs.get_technical_summary", return_value=summary
+    ), patch("api.tabs.build_price_outlook", return_value=outlook) as m:
+        r = client.get(
+            "/tabs/outlook", params={"ticker": "삼성전자", "horizon": "1m"}
+        )
+    assert r.status_code == 200
+    assert r.json()["confidence_grade"] == "B"
+    # summary / structured_data가 키워드로 전달됐는지
+    kwargs = m.call_args.kwargs
+    assert kwargs["summary"] == summary
+    assert kwargs["structured_data"] == structured
+
+
+def test_outlook_404_when_no_summary(client):
+    with patch("api.tabs._find_structured_data", return_value={"ticker": "X", "name": "X"}), patch(
+        "api.tabs.get_technical_summary", return_value=None
+    ):
+        r = client.get("/tabs/outlook", params={"ticker": "X"})
+    assert r.status_code == 404
+
+
+# ── Financial ──────────────────────────────────────────────────────
+def test_financial_returns_rows_and_chart(client):
+    rows = [
+        {"fiscal_year": 2025, "fiscal_quarter": 1, "revenue": 1_000_000_000_000, "operating_margin": 10.0}
+    ]
+    with patch("api.tabs.DB_PATH") as db, patch("api.tabs._find_structured_data", return_value={"ticker": "005930", "name": "삼성전자"}), patch(
+        "api.tabs.get_connection", return_value=MagicMock()
+    ), patch("api.tabs.get_financial_data", return_value=rows), patch(
+        "api.tabs.generate_financial_chart", return_value="PNG"
+    ):
+        db.exists.return_value = True
+        r = client.get("/tabs/financial", params={"ticker": "005930"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["rows"][0]["fiscal_year"] == 2025
+    assert body["chart_b64"] == "PNG"
+
+
+def test_financial_404_when_db_missing(client):
+    with patch("api.tabs.DB_PATH") as db:
+        db.exists.return_value = False
+        r = client.get("/tabs/financial", params={"ticker": "005930"})
+    assert r.status_code == 404
+
+
+# ── Comparison ─────────────────────────────────────────────────────
+def test_comparison_two_tickers(client):
+    d1 = {"ticker": "005930", "name": "삼성전자", "per": 12.0, "pbr": 1.2}
+    d2 = {"ticker": "000660", "name": "SK하이닉스", "per": 8.0, "pbr": 1.5}
+    with patch("api.tabs._find_structured_data", side_effect=[d1, d2]), patch(
+        "api.tabs.generate_comparison_chart", return_value="CMP"
+    ), patch("api.tabs.generate_valuation_chart", return_value="VAL"):
+        r = client.post(
+            "/tabs/comparison", json={"tickers": ["삼성전자", "SK하이닉스"]}
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["comparison_chart_b64"] == "CMP"
+    assert body["valuation_chart_b64"] == "VAL"
+
+
+def test_comparison_404_when_one_unresolved(client):
+    d1 = {"ticker": "005930", "name": "삼성전자"}
+    with patch("api.tabs._find_structured_data", side_effect=[d1, None]):
+        r = client.post("/tabs/comparison", json={"tickers": ["삼성전자", "ZZZ"]})
+    assert r.status_code == 404
+
+
+# ── Sector ─────────────────────────────────────────────────────────
+def test_sector_overview(client):
+    sector_index = {
+        "전기·전자": [
+            {"name": "삼성전자", "ticker": "005930", "market_cap": 5e14, "change_pct": 1.0, "per": 12.0},
+            {"name": "SK하이닉스", "ticker": "000660", "market_cap": 1e14, "change_pct": -0.5, "per": 8.0},
+        ]
+    }
+    with patch("api.tabs.get_sector_index", return_value=sector_index), patch(
+        "api.tabs.generate_sector_overview_chart", return_value="OVR"
+    ):
+        r = client.get("/tabs/sector")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["overview_chart_b64"] == "OVR"
+    assert body["stats"][0]["sector"] == "전기·전자"
+    assert body["stats"][0]["count"] == 2
+    assert body["stats"][0]["up_count"] == 1
+
+
+def test_sector_detail(client):
+    sector_index = {"전기·전자": [{"name": "삼성전자", "ticker": "005930", "market_cap": 5e14, "change_pct": 1.0, "per": 12.0}]}
+    with patch("api.tabs.get_sector_index", return_value=sector_index), patch(
+        "api.tabs.generate_sector_overview_chart", return_value="OVR"
+    ), patch("api.tabs.generate_sector_detail_chart", return_value="DET"):
+        r = client.get("/tabs/sector", params={"sector": "전기·전자"})
+    assert r.status_code == 200
+    assert r.json()["detail_chart_b64"] == "DET"
+
+
+def test_sector_404_unknown(client):
+    with patch("api.tabs.get_sector_index", return_value={"A": [{"market_cap": 1, "change_pct": 0}]}), patch(
+        "api.tabs.generate_sector_overview_chart", return_value="OVR"
+    ):
+        r = client.get("/tabs/sector", params={"sector": "없는섹터"})
+    assert r.status_code == 404
+
+
+# ── Tickers ────────────────────────────────────────────────────────
+def test_tickers_filters_and_caps(client):
+    opts = [f"삼성전자{i} (0059{i:02d})" for i in range(40)] + ["LG (003550)"]
+    with patch("api.tabs.get_available_tickers", return_value=opts):
+        r = client.get("/tabs/tickers", params={"q": "삼성", "limit": 30})
+    body = r.json()
+    assert len(body["options"]) == 30
+    assert all("삼성" in o for o in body["options"])
+
+
+def test_tickers_resolve_404(client):
+    with patch("api.tabs._find_structured_data", return_value=None):
+        r = client.get("/tabs/tickers/resolve", params={"q": "ZZZ"})
+    assert r.status_code == 404
+
+
+# ── 가드 ───────────────────────────────────────────────────────────
+def test_tabs_require_ready_503(client):
+    # ready=False면 503 (require_ready 의존성)
+    app.state.app_state.ready = False
+    try:
+        r = client.get("/tabs/tickers")
+        assert r.status_code == 503
+    finally:
+        app.state.app_state.ready = True


### PR DESCRIPTION
## Context

프론트 6탭 이식 전, 백엔드에 탭별 데이터 API를 추가. Streamlit 탭(src/ui/tabs.py)이 호출하는 기존 동기 함수들을 Streamlit 없이 REST로 래핑한다. 신규 로직 거의 없음(섹터 집계만 복제), 신규 의존성 0.

## 엔드포인트 (`/tabs/*`, require_ready 가드, run_in_threadpool, None→404)

| Method | Path | 래핑 대상 |
|---|---|---|
| GET | `/technical` | get_technical_summary + generate_technical_chart |
| GET | `/financial` | get_financial_data(DB) + generate_financial_chart |
| POST | `/comparison` | comparison/valuation 차트 + 항목 |
| GET | `/outlook` | summary+structured 조립 → build_price_outlook |
| GET | `/sector` | _build_sector_stats(복제) + overview/detail 차트 |
| GET | `/tickers` | get_available_tickers 부분매칭+cap |
| GET | `/tickers/resolve` | _find_structured_data |

## 핵심 설계

- **name 해석**: get_technical_summary는 name 키 없음 → `_find_structured_data`로 ticker/name 먼저 해석 후 호출 (Streamlit _resolve_ticker 패턴).
- 여러 동기 호출은 sync 헬퍼로 묶어 run_in_threadpool 1회.
- 복잡 중첩 dict은 response_model=None(dict 그대로). 단순한 것만 thin model.
- **src/ui/tabs.py는 streamlit import → API import 금지**, _build_sector_stats만 복제.
- require_ready를 api/deps.py 공유 의존성으로 (라우터는 Request에서 app.state 추출).

## 검증

- `pytest tests/test_api_tabs.py`: 15개. 전체 **670개** 통과(+15, 회귀 0).
- 실서버 스모크(실데이터): resolve(삼성전자→005930/PER49.81), technical(11지표+218KB차트), outlook(composite0.709/B), sector(29섹터/전기·전자338종목), comparison(차트), financial(200), tickers(부분매칭).

## 다음

프론트 탭 페이지(Next.js App Router 라우트 + 자동완성)에서 이 API 소비.

🤖 Generated with [Claude Code](https://claude.com/claude-code)