### PR TITLE
Phase F: 프론트 탭 — 네비게이션 + 자동완성 + 기술적 분석

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -1919,9 +1919,30 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 - `feat(api)`: require_ready+모델 / `feat(api)`: tabs 라우터 / `test(api)`: 15개 / (문서 별도)
 
 ### 다음
-- **프론트 탭 페이지**: Next.js App Router 라우트(`/technical`,`/financial`,`/comparison`,`/outlook`,`/sector`) + 공통 네비 + 종목 자동완성(이 API 소비). URL 라우트 방식.
+- 프론트 탭 페이지로 이어짐.
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4a~d 프론트 채팅 + 탭 REST API(api/tabs.py). 백엔드 테스트 670개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+## Phase F: 프론트 탭 — 공통 인프라 + 기술적 분석 (2026-06-08)
+
+`/tabs/*` API 위에 Next.js 탭 페이지 시작. **URL 라우트 방식**(App Router). 공통 인프라 + 첫 탭만, 나머지 4탭은 같은 패턴 반복.
+
+### 변경 (frontend/src)
+- **components/NavBar.tsx**: 6탭(채팅/기술/재무/비교/전망/섹터) URL 라우트 링크. `usePathname`로 활성 표시. layout.tsx 전역 적용 → 모든 페이지 상단 탭 스트립.
+- **components/TickerSearch.tsx**: 디바운스(250ms) 자동완성 입력 → `searchTickers`(/tabs/tickers). "이름 (티커)" 정규식 파싱 → `onSelect{name,ticker,raw}`. 바깥 클릭 시 드롭다운 닫기.
+- **lib/api.ts**: `searchTickers(q,limit)`, `getTechnical(ticker,days)`(404→null). **lib/types**: `TechnicalResponse`(summary는 Record<string,unknown> 느슨한 타입 — 복잡 중첩), `TickerSearchResponse`.
+- **app/technical/page.tsx**: TickerSearch + 기간 버튼(6개월~5년) + 핵심지표 8칸(종가/추세/RSI/MACD/MA5/MA20/MA60/볼린저%B) + base64 차트. summary 중첩값은 `obj()`/`n()` 헬퍼로 안전 추출.
+
+### 검증
+- `npm run build` 통과(/technical 라우트 등록). e2e: 페이지 한국어 UI 렌더, 자동완성 API(삼성전자→ETF목록), 기술분석 API(삼성전자 RSI 63.3 + 218KB 차트), NavBar 전역 표시 확인.
+
+### 커밋 (브랜치 phase-f-front-tabs, main에서 분기)
+- `feat(frontend)`: 네비 + 자동완성 + 기술분석 탭 + (문서 별도)
+
+### 다음
+- **나머지 4탭**: `/financial`(재무 테이블+차트), `/comparison`(2종목 TickerSearch 2개+비교/밸류차트), `/outlook`(4축 전망 카드+시나리오), `/sector`(섹터 차트+상세). 전부 같은 패턴(TickerSearch + lib/api 함수 + 페이지). lib/api에 getFinancial/postComparison/getOutlook/getSector 추가.
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4 프론트 채팅 + 탭 REST API + 프론트 탭(공통+기술분석). 백엔드 테스트 670개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -254,7 +254,8 @@
   - [x] **F-4b SSE 스트리밍** (2026-06-08): `/stream` SSE 실시간 토큰 타이핑(@microsoft/fetch-event-source) + react-markdown/remark-gfm + 도구 상태줄.
   - [x] **F-4c 차트/비교표** (2026-06-08): structured_data 인라인 렌더 — technical/portfolio_chart base64 PNG, comparison_table 항목별 전치 표(+상대수익률 차트).
   - [x] **F-4d 멀티턴/마감** (2026-06-08): chat_history 멀티턴(대명사 참조) + 후속질문 칩 + localStorage 영속(텍스트만) + 대화 초기화 + 모바일 반응형. **F-4 프론트 채팅 완성.**
-  - [x] **탭 REST API** (2026-06-08): `api/tabs.py` — `/tabs/{technical,financial,comparison,outlook,sector,tickers}` 엔드포인트. Streamlit 탭 함수를 Streamlit 없이 래핑(기존 함수 재사용). 테스트 670개. 후속: 프론트 탭 페이지(Next.js 라우트), F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포.
+  - [x] **탭 REST API** (2026-06-08): `api/tabs.py` — `/tabs/{technical,financial,comparison,outlook,sector,tickers}` 엔드포인트. Streamlit 탭 함수를 Streamlit 없이 래핑(기존 함수 재사용). 테스트 670개.
+  - [x] **프론트 탭(공통+기술분석)** (2026-06-08): NavBar(6탭 URL 라우트) + TickerSearch(디바운스 자동완성) + `/technical` 페이지(지표+차트). 후속: 재무/비교/전망/섹터 4탭 같은 패턴 반복, F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/frontend/src/app/layout.tsx
+++ b/ETF_RAG/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import NavBar from "@/components/NavBar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,10 @@ export default function RootLayout({
       lang="ko"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <NavBar />
+        {children}
+      </body>
     </html>
   );
 }

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { getTechnical } from "@/lib/api";
+import type { TechnicalResponse } from "@/lib/types";
+import TickerSearch from "@/components/TickerSearch";
+
+const PERIODS: { label: string; days: number }[] = [
+  { label: "6개월", days: 120 },
+  { label: "1년", days: 250 },
+  { label: "3년", days: 750 },
+  { label: "5년", days: 1250 },
+];
+
+// summary에서 안전하게 값 추출
+function n(v: unknown): string {
+  if (typeof v === "number") return v.toLocaleString("ko-KR");
+  return "-";
+}
+function obj(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+
+export default function TechnicalPage() {
+  const [days, setDays] = useState(120);
+  const [data, setData] = useState<TechnicalResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<{ name: string; ticker: string } | null>(null);
+
+  const run = async (ticker: string, d: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getTechnical(ticker, d);
+      if (!res) setError("해당 종목의 기술적 데이터를 찾을 수 없어요.");
+      setData(res);
+    } catch {
+      setError("데이터를 가져오지 못했어요. 백엔드 상태를 확인해주세요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onSelect = (sel: { name: string; ticker: string }) => {
+    setSelected(sel);
+    run(sel.ticker, days);
+  };
+
+  const onPeriod = (d: number) => {
+    setDays(d);
+    if (selected) run(selected.ticker, d);
+  };
+
+  const s = data?.summary ?? {};
+  const ma = obj(s.ma);
+  const macd = obj(s.macd);
+  const boll = obj(s.bollinger);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-3 py-5 sm:px-4">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">📊 기술적 분석</h1>
+      <p className="mb-4 text-xs text-gray-500">
+        이동평균·RSI·MACD·볼린저밴드 등 지표와 차트
+      </p>
+
+      <TickerSearch onSelect={onSelect} />
+
+      {selected && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {PERIODS.map((p) => (
+            <button
+              key={p.days}
+              type="button"
+              onClick={() => onPeriod(p.days)}
+              className={[
+                "rounded-full px-3 py-1 text-xs",
+                days === p.days
+                  ? "bg-blue-600 text-white"
+                  : "border border-gray-300 text-gray-600 hover:bg-gray-100",
+              ].join(" ")}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {loading && (
+        <p className="mt-6 text-center text-sm text-gray-400">분석 중…</p>
+      )}
+      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+
+      {data && !loading && (
+        <div className="mt-5">
+          <div className="mb-3 flex items-baseline gap-2">
+            <h2 className="text-base font-semibold">{data.name}</h2>
+            <span className="text-xs text-gray-400">{data.ticker}</span>
+          </div>
+
+          {/* 핵심 지표 */}
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <Metric label="종가" value={`${n(s.close)}원`} />
+            <Metric label="추세" value={String(s.trend ?? "-")} />
+            <Metric label="RSI(14)" value={n(s.rsi)} />
+            <Metric label="MACD" value={n(macd.macd)} />
+            <Metric label="MA5" value={n(ma.ma5)} />
+            <Metric label="MA20" value={n(ma.ma20)} />
+            <Metric label="MA60" value={n(ma.ma60)} />
+            <Metric label="볼린저 %B" value={n(boll.pct_b)} />
+          </div>
+
+          {/* 차트 */}
+          {data.chart_b64 && (
+            <img
+              // eslint-disable-next-line @next/next/no-img-element
+              src={`data:image/png;base64,${data.chart_b64}`}
+              alt={`${data.name} 기술적 분석 차트`}
+              className="mt-4 w-full rounded-lg border border-gray-200"
+            />
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 px-3 py-2">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className="text-sm font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/components/NavBar.tsx
+++ b/ETF_RAG/frontend/src/components/NavBar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { href: "/", label: "💬 채팅" },
+  { href: "/technical", label: "📊 기술적 분석" },
+  { href: "/financial", label: "📑 재무제표" },
+  { href: "/comparison", label: "⚖️ 비교" },
+  { href: "/outlook", label: "🔮 전망" },
+  { href: "/sector", label: "🏭 섹터" },
+];
+
+export default function NavBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="border-b border-gray-200">
+      <div className="mx-auto flex max-w-3xl items-center gap-1 overflow-x-auto px-3 py-2 sm:px-4">
+        {TABS.map((t) => {
+          const active = t.href === pathname;
+          return (
+            <Link
+              key={t.href}
+              href={t.href}
+              className={[
+                "shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+                active
+                  ? "bg-blue-600 text-white"
+                  : "text-gray-600 hover:bg-gray-100",
+              ].join(" ")}
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/ETF_RAG/frontend/src/components/TickerSearch.tsx
+++ b/ETF_RAG/frontend/src/components/TickerSearch.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { searchTickers } from "@/lib/api";
+
+// "삼성전자 (005930)" → {name, ticker}
+function parseOption(opt: string): { name: string; ticker: string } {
+  const m = opt.match(/^(.*)\s+\(([^)]+)\)\s*$/);
+  if (m) return { name: m[1], ticker: m[2] };
+  return { name: opt, ticker: opt };
+}
+
+export default function TickerSearch({
+  onSelect,
+  placeholder = "종목명 또는 티커 검색…",
+}: {
+  onSelect: (sel: { name: string; ticker: string; raw: string }) => void;
+  placeholder?: string;
+}) {
+  const [query, setQuery] = useState("");
+  const [options, setOptions] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  // 디바운스 검색 (250ms)
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setOptions([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      const opts = await searchTickers(q, 20);
+      setOptions(opts);
+      setOpen(true);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  // 바깥 클릭 시 닫기
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  const pick = (opt: string) => {
+    const { name, ticker } = parseOption(opt);
+    setQuery(name);
+    setOpen(false);
+    onSelect({ name, ticker, raw: opt });
+  };
+
+  return (
+    <div ref={boxRef} className="relative">
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => options.length && setOpen(true)}
+        placeholder={placeholder}
+        className="w-full rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+      />
+      {open && options.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-72 w-full overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg">
+          {options.map((opt) => (
+            <li key={opt}>
+              <button
+                type="button"
+                onClick={() => pick(opt)}
+                className="block w-full px-4 py-2 text-left text-sm hover:bg-blue-50"
+              >
+                {opt}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -8,6 +8,8 @@ import type {
   QuestionType,
   StreamCallbacks,
   StructuredData,
+  TechnicalResponse,
+  TickerSearchResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
@@ -103,4 +105,34 @@ export function streamChat(
   });
 
   return () => ctrl.abort();
+}
+
+// ── 탭 API ──────────────────────────────────────────────
+
+/** 종목 자동완성 ("이름 (티커)" 옵션 리스트) */
+export async function searchTickers(
+  q: string,
+  limit = 20,
+): Promise<string[]> {
+  const url = new URL(`${API_BASE}/tabs/tickers`);
+  if (q) url.searchParams.set("q", q);
+  url.searchParams.set("limit", String(limit));
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) return [];
+  const body = (await res.json()) as TickerSearchResponse;
+  return body.options;
+}
+
+/** 기술적 분석 — 지표 summary + 차트 base64. 404면 null. */
+export async function getTechnical(
+  ticker: string,
+  days = 120,
+): Promise<TechnicalResponse | null> {
+  const url = new URL(`${API_BASE}/tabs/technical`);
+  url.searchParams.set("ticker", ticker);
+  url.searchParams.set("days", String(days));
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`technical ${res.status}`);
+  return (await res.json()) as TechnicalResponse;
 }

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -31,6 +31,20 @@ export interface Health {
   error: string | null;
 }
 
+// ── 탭 API ──────────────────────────────────────────────
+/** /tabs/technical 응답 (summary는 복잡 중첩 dict — 느슨한 타입) */
+export interface TechnicalResponse {
+  ticker: string;
+  name: string;
+  summary: Record<string, unknown>;
+  chart_b64: string | null;
+}
+
+/** 종목 검색 옵션 ("이름 (티커)") */
+export interface TickerSearchResponse {
+  options: string[];
+}
+
 // ── SSE structured_data 변형 (data를 JSON.parse한 결과) ──
 export interface ComparisonItem {
   name: string;


### PR DESCRIPTION
## Context

`/tabs/*` 백엔드 API(PR #26) 위에 Next.js 탭 페이지를 시작. **공통 인프라 + 첫 탭(기술적 분석)**만 — 패턴 확립 후 나머지 4탭 반복. URL 라우트 방식(App Router).

## 변경 (frontend/src)

- **NavBar.tsx**: 6탭(채팅/기술/재무/비교/전망/섹터) URL 라우트 링크, `usePathname` 활성 표시. layout 전역 적용.
- **TickerSearch.tsx**: 디바운스(250ms) 자동완성 → `/tabs/tickers`, "이름 (티커)" 파싱 → onSelect. 바깥클릭 닫기.
- **lib/api.ts**: `searchTickers`, `getTechnical`(404→null). **lib/types**: TechnicalResponse/TickerSearchResponse.
- **app/technical/page.tsx**: TickerSearch + 기간 버튼 + 핵심지표 8칸 + base64 차트.

## 검증

- `npm run build` 통과(/technical 라우트 등록)
- e2e: 페이지 렌더, 자동완성·기술분석 API 동작(삼성전자 RSI 63.3 + 218KB 차트), NavBar 전역 표시

## 다음

나머지 4탭(`/financial`,`/comparison`,`/outlook`,`/sector`) 같은 패턴 반복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)