### PR TITLE
Phase F: 프론트 탭 완성 — 재무/비교/전망/섹터

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -1940,9 +1940,35 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 - `feat(frontend)`: 네비 + 자동완성 + 기술분석 탭 + (문서 별도)
 
 ### 다음
-- **나머지 4탭**: `/financial`(재무 테이블+차트), `/comparison`(2종목 TickerSearch 2개+비교/밸류차트), `/outlook`(4축 전망 카드+시나리오), `/sector`(섹터 차트+상세). 전부 같은 패턴(TickerSearch + lib/api 함수 + 페이지). lib/api에 getFinancial/postComparison/getOutlook/getSector 추가.
+- 나머지 4탭으로 이어짐.
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + F-4 프론트 채팅 + 탭 REST API + 프론트 탭(공통+기술분석). 백엔드 테스트 670개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+## Phase F: 프론트 탭 완성 — 재무/비교/전망/섹터 (2026-06-08)
+
+기술분석 탭 패턴 반복으로 나머지 4탭 완성. **F-4 프론트 6탭(채팅+기술/재무/비교/전망/섹터) = Streamlit 기능 패리티 달성.**
+
+### 변경 (frontend/src)
+- **lib/api.ts**: `getFinancial(t,quarters)` / `postComparison([t1,t2],days)` / `getOutlook(t,horizon)` / `getSector(sector?)` — 전부 404→null. **lib/types**: FinancialResponse/ComparisonResponse/OutlookResponse(느슨)/SectorResponse(+SectorStat/FinancialRow).
+- **components/ChartImage.tsx**: base64 PNG `<img>` 공통 컴포넌트(next/image 아님, eslint disable).
+- **app/financial/page.tsx**: TickerSearch + 분기 재무 테이블(억원/영업이익률/매출YoY) + 실적 차트. (주식만 — ETF는 404)
+- **app/comparison/page.tsx**: TickerSearch 2개(각 선택 시 둘 다 차면 비교) + ComparisonTable(채팅 컴포넌트 재사용) + 비교/밸류 차트.
+- **app/outlook/page.tsx**: TickerSearch + horizon(1m/3m/6m/1y) + 종합점수/신뢰등급/현재가 + 4축 카드(기술/펀더멘털/통계/Prophet, key_factors) + 시나리오 3종(상승/중립/하락 확률·목표) + 리스크 + 면책.
+- **app/sector/page.tsx**: mount 시 개요 자동 로드 + 업종 selectbox→상세 차트 + 섹터 요약표 상위20(등락률 빨강/파랑).
+
+### 검증
+- `npm run build` 통과(6라우트: /, /technical, /financial, /comparison, /outlook, /sector). e2e: 4페이지 한국어 렌더 + financial(삼성전자 8분기+차트)/sector(29섹터+차트) API 동작.
+
+### 커밋 (브랜치 phase-f-front-tabs2, main에서 분기)
+- `feat(frontend)`: 4탭 + (문서 별도)
+
+### Phase F-4 완성 정리 — 다음 큰 단계
+프론트가 Streamlit 6탭 기능을 모두 커버. 남은 Phase F:
+- **F-5 배포(Railway/Render)**: 실제 URL + 콜드스타트·유휴정지 해소. 다음 우선순위 후보.
+- **F-1 잔여**: 인증(JWT/소셜) + PostgreSQL + 유저별 저장 + WebSocket.
+- **F-2 KIS 실시간**(신분증 보류), **F-3 KoELECTRA 감성**.
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + 탭 REST API + F-4 프론트 6탭 완성(채팅+기술/재무/비교/전망/섹터, Streamlit 패리티). 백엔드 테스트 670개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -255,7 +255,8 @@
   - [x] **F-4c 차트/비교표** (2026-06-08): structured_data 인라인 렌더 — technical/portfolio_chart base64 PNG, comparison_table 항목별 전치 표(+상대수익률 차트).
   - [x] **F-4d 멀티턴/마감** (2026-06-08): chat_history 멀티턴(대명사 참조) + 후속질문 칩 + localStorage 영속(텍스트만) + 대화 초기화 + 모바일 반응형. **F-4 프론트 채팅 완성.**
   - [x] **탭 REST API** (2026-06-08): `api/tabs.py` — `/tabs/{technical,financial,comparison,outlook,sector,tickers}` 엔드포인트. Streamlit 탭 함수를 Streamlit 없이 래핑(기존 함수 재사용). 테스트 670개.
-  - [x] **프론트 탭(공통+기술분석)** (2026-06-08): NavBar(6탭 URL 라우트) + TickerSearch(디바운스 자동완성) + `/technical` 페이지(지표+차트). 후속: 재무/비교/전망/섹터 4탭 같은 패턴 반복, F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포.
+  - [x] **프론트 탭(공통+기술분석)** (2026-06-08): NavBar(6탭 URL 라우트) + TickerSearch(디바운스 자동완성) + `/technical` 페이지(지표+차트).
+  - [x] **프론트 탭 완성(재무/비교/전망/섹터)** (2026-06-08): 나머지 4탭 같은 패턴. **F-4 프론트 6탭(채팅+5데이터) 완성 — Streamlit 기능 패리티 달성.** 후속: F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포(Railway).
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/frontend/src/app/comparison/page.tsx
+++ b/ETF_RAG/frontend/src/app/comparison/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { postComparison } from "@/lib/api";
+import type { ComparisonResponse, ComparisonItem } from "@/lib/types";
+import TickerSearch from "@/components/TickerSearch";
+import ChartImage from "@/components/ChartImage";
+import ComparisonTable from "@/components/ComparisonTable";
+
+export default function ComparisonPage() {
+  const [t1, setT1] = useState<{ name: string; ticker: string } | null>(null);
+  const [t2, setT2] = useState<{ name: string; ticker: string } | null>(null);
+  const [data, setData] = useState<ComparisonResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (a: { ticker: string }, b: { ticker: string }) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await postComparison([a.ticker, b.ticker]);
+      if (!res) setError("비교할 종목을 찾을 수 없어요.");
+      setData(res);
+    } catch {
+      setError("데이터를 가져오지 못했어요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pick1 = (sel: { name: string; ticker: string }) => {
+    setT1(sel);
+    if (t2) run(sel, t2);
+  };
+  const pick2 = (sel: { name: string; ticker: string }) => {
+    setT2(sel);
+    if (t1) run(t1, sel);
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-3 py-5 sm:px-4">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">⚖️ 비교 분석</h1>
+      <p className="mb-4 text-xs text-gray-500">두 종목의 시세·밸류에이션·상대 수익률</p>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <div className="mb-1 text-xs text-gray-500">종목 1</div>
+          <TickerSearch onSelect={pick1} />
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-gray-500">종목 2</div>
+          <TickerSearch onSelect={pick2} />
+        </div>
+      </div>
+
+      {loading && <p className="mt-6 text-center text-sm text-gray-400">비교 중…</p>}
+      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+
+      {data && !loading && (
+        <div className="mt-5">
+          <ComparisonTable items={data.items as ComparisonItem[]} />
+          <ChartImage b64={data.comparison_chart_b64} alt="상대 수익률 추이" />
+          <ChartImage b64={data.valuation_chart_b64} alt="밸류에이션 비교" />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { getFinancial } from "@/lib/api";
+import type { FinancialResponse } from "@/lib/types";
+import TickerSearch from "@/components/TickerSearch";
+import ChartImage from "@/components/ChartImage";
+
+// 억원 단위
+function eok(v: number | null | undefined): string {
+  if (typeof v !== "number") return "-";
+  return `${Math.round(v / 1_0000_0000).toLocaleString("ko-KR")}억`;
+}
+function pct(v: number | null | undefined): string {
+  return typeof v === "number" ? `${v.toFixed(1)}%` : "-";
+}
+
+export default function FinancialPage() {
+  const [data, setData] = useState<FinancialResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSelect = async (sel: { ticker: string }) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getFinancial(sel.ticker, 12);
+      if (!res) setError("재무 데이터를 찾을 수 없어요. (재무제표는 상장 주식만 제공)");
+      setData(res);
+    } catch {
+      setError("데이터를 가져오지 못했어요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-3 py-5 sm:px-4">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">📑 재무제표</h1>
+      <p className="mb-4 text-xs text-gray-500">분기별 매출·영업이익·순이익·마진</p>
+
+      <TickerSearch onSelect={onSelect} placeholder="종목명 또는 티커 (주식만)" />
+
+      {loading && <p className="mt-6 text-center text-sm text-gray-400">조회 중…</p>}
+      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+
+      {data && !loading && (
+        <div className="mt-5">
+          <h2 className="mb-3 text-base font-semibold">
+            {data.name} <span className="text-xs text-gray-400">{data.ticker}</span>
+          </h2>
+
+          <div className="overflow-x-auto">
+            <table className="comparison-table text-xs">
+              <thead>
+                <tr>
+                  <th className="text-left">분기</th>
+                  <th className="text-right">매출액</th>
+                  <th className="text-right">영업이익</th>
+                  <th className="text-right">순이익</th>
+                  <th className="text-right">영업이익률</th>
+                  <th className="text-right">매출 YoY</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.rows.map((r, i) => (
+                  <tr key={i}>
+                    <td className="text-left">
+                      {r.fiscal_year} Q{r.fiscal_quarter}
+                    </td>
+                    <td className="text-right tabular-nums">{eok(r.revenue)}</td>
+                    <td className="text-right tabular-nums">{eok(r.operating_profit)}</td>
+                    <td className="text-right tabular-nums">{eok(r.net_income)}</td>
+                    <td className="text-right tabular-nums">{pct(r.operating_margin)}</td>
+                    <td className="text-right tabular-nums">{pct(r.revenue_growth_yoy)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <ChartImage b64={data.chart_b64} alt={`${data.name} 실적 추이`} />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/ETF_RAG/frontend/src/app/outlook/page.tsx
+++ b/ETF_RAG/frontend/src/app/outlook/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { getOutlook } from "@/lib/api";
+import type { OutlookResponse } from "@/lib/types";
+import TickerSearch from "@/components/TickerSearch";
+
+const HORIZONS = ["1m", "3m", "6m", "1y"];
+
+function str(v: unknown): string {
+  return v == null ? "-" : String(v);
+}
+function axisFactors(axis: Record<string, unknown> | undefined): string[] {
+  const f = axis?.key_factors;
+  return Array.isArray(f) ? (f as string[]) : [];
+}
+
+export default function OutlookPage() {
+  const [horizon, setHorizon] = useState("1m");
+  const [selected, setSelected] = useState<{ ticker: string } | null>(null);
+  const [data, setData] = useState<OutlookResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (ticker: string, h: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getOutlook(ticker, h);
+      if (!res) setError("전망을 생성할 수 없어요.");
+      setData(res);
+    } catch {
+      setError("데이터를 가져오지 못했어요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onSelect = (sel: { ticker: string }) => {
+    setSelected(sel);
+    run(sel.ticker, horizon);
+  };
+  const onHorizon = (h: string) => {
+    setHorizon(h);
+    if (selected) run(selected.ticker, h);
+  };
+
+  const scenarios = data?.scenarios ?? {};
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-3 py-5 sm:px-4">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">🔮 가격 전망</h1>
+      <p className="mb-4 text-xs text-gray-500">
+        기술적·펀더멘털·통계·Prophet 4축 종합 + 시나리오
+      </p>
+
+      <TickerSearch onSelect={onSelect} />
+
+      {selected && (
+        <div className="mt-3 flex gap-2">
+          {HORIZONS.map((h) => (
+            <button
+              key={h}
+              type="button"
+              onClick={() => onHorizon(h)}
+              className={[
+                "rounded-full px-3 py-1 text-xs",
+                horizon === h
+                  ? "bg-blue-600 text-white"
+                  : "border border-gray-300 text-gray-600 hover:bg-gray-100",
+              ].join(" ")}
+            >
+              {h}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {loading && <p className="mt-6 text-center text-sm text-gray-400">분석 중…</p>}
+      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+
+      {data && !loading && (
+        <div className="mt-5 space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <Metric label="종합 점수" value={str(data.composite_score)} />
+            <Metric label="신뢰 등급" value={str(data.confidence_grade)} />
+            <Metric label="현재가" value={`${str(data.current_price)}원`} />
+          </div>
+
+          {/* 4축 */}
+          <div className="grid gap-2 sm:grid-cols-2">
+            <Axis title="기술적" axis={data.technical} />
+            <Axis title="펀더멘털" axis={data.fundamental} />
+            <Axis title="통계(회귀)" axis={data.statistical} />
+            <Axis title="Prophet" axis={data.prophet} />
+          </div>
+
+          {/* 시나리오 */}
+          <div className="grid grid-cols-3 gap-2">
+            {(["bullish", "neutral", "bearish"] as const).map((k) => {
+              const sc = scenarios[k];
+              const label = { bullish: "🔼 상승", neutral: "➖ 중립", bearish: "🔽 하락" }[k];
+              return (
+                <div key={k} className="rounded-lg border border-gray-200 p-3 text-xs">
+                  <div className="font-semibold">{label}</div>
+                  <div className="mt-1 text-gray-500">
+                    확률 {sc?.probability != null ? `${Math.round(sc.probability * 100)}%` : "-"}
+                  </div>
+                  <div className="text-gray-500">
+                    목표 {sc?.target_return != null ? `${sc.target_return}%` : "-"}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* 리스크 */}
+          {Array.isArray(data.risk_factors) && data.risk_factors.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs">
+              <div className="mb-1 font-semibold text-amber-800">⚠️ 리스크 요인</div>
+              <ul className="list-disc pl-4 text-amber-700">
+                {data.risk_factors.map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <p className="text-xs text-gray-400">
+            📌 데이터 기반 참고 정보입니다. 투자 판단 전 추가 조사와 전문가 상담을 권장합니다.
+          </p>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 px-3 py-2">
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className="text-sm font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function Axis({
+  title,
+  axis,
+}: {
+  title: string;
+  axis: Record<string, unknown> | undefined;
+}) {
+  const factors = axisFactors(axis);
+  return (
+    <div className="rounded-lg border border-gray-200 p-3">
+      <div className="flex items-baseline justify-between">
+        <span className="text-sm font-semibold">{title}</span>
+        <span className="text-xs text-gray-500">{str(axis?.signal)}</span>
+      </div>
+      {factors.length > 0 && (
+        <ul className="mt-1 list-disc pl-4 text-xs text-gray-600">
+          {factors.slice(0, 4).map((f, i) => (
+            <li key={i}>{f}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/app/sector/page.tsx
+++ b/ETF_RAG/frontend/src/app/sector/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSector } from "@/lib/api";
+import type { SectorResponse } from "@/lib/types";
+import ChartImage from "@/components/ChartImage";
+
+function jo(v: number): string {
+  const 조 = 1_0000_0000_0000;
+  if (v >= 조) return `${(v / 조).toFixed(1)}조`;
+  return `${Math.round(v / 1_0000_0000).toLocaleString("ko-KR")}억`;
+}
+
+export default function SectorPage() {
+  const [data, setData] = useState<SectorResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [picked, setPicked] = useState<string>("");
+
+  // mount 시 전체 개요 로드
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await getSector();
+        if (!res) setError("섹터 데이터를 찾을 수 없어요.");
+        setData(res);
+      } catch {
+        setError("데이터를 가져오지 못했어요.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const loadDetail = async (sector: string) => {
+    setPicked(sector);
+    if (!sector) return;
+    setLoading(true);
+    try {
+      const res = await getSector(sector);
+      if (res) setData(res);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const stats = data?.stats ?? [];
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-3 py-5 sm:px-4">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">🏭 섹터 분석</h1>
+      <p className="mb-4 text-xs text-gray-500">업종별 등락률·시가총액·밸류에이션</p>
+
+      {loading && !data && (
+        <p className="mt-6 text-center text-sm text-gray-400">불러오는 중…</p>
+      )}
+      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="space-y-4">
+          <ChartImage b64={data.overview_chart_b64} alt="섹터 개요" />
+
+          {/* 섹터 선택 → 상세 */}
+          {stats.length > 0 && (
+            <select
+              value={picked}
+              onChange={(e) => loadDetail(e.target.value)}
+              className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="">— 업종 상세 보기 —</option>
+              {stats.map((s) => (
+                <option key={s.sector} value={s.sector}>
+                  {s.sector} ({s.count}종목)
+                </option>
+              ))}
+            </select>
+          )}
+
+          {data.detail_chart_b64 && (
+            <ChartImage b64={data.detail_chart_b64} alt={`${data.sector} 상세`} />
+          )}
+
+          {/* 섹터 요약 표 (상위 20) */}
+          <div className="overflow-x-auto">
+            <table className="comparison-table text-xs">
+              <thead>
+                <tr>
+                  <th className="text-left">업종</th>
+                  <th className="text-right">종목수</th>
+                  <th className="text-right">등락률</th>
+                  <th className="text-right">시가총액</th>
+                  <th className="text-right">PER중간</th>
+                  <th className="text-right">상승/하락</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.slice(0, 20).map((s) => (
+                  <tr key={s.sector}>
+                    <td className="text-left">{s.sector}</td>
+                    <td className="text-right tabular-nums">{s.count}</td>
+                    <td
+                      className={`text-right tabular-nums ${s.change_pct > 0 ? "text-red-600" : s.change_pct < 0 ? "text-blue-600" : ""}`}
+                    >
+                      {s.change_pct > 0 ? "+" : ""}
+                      {s.change_pct.toFixed(2)}%
+                    </td>
+                    <td className="text-right tabular-nums">{jo(s.market_cap)}</td>
+                    <td className="text-right tabular-nums">{s.median_per}</td>
+                    <td className="text-right tabular-nums">
+                      {s.up_count}/{s.down_count}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/ETF_RAG/frontend/src/components/ChartImage.tsx
+++ b/ETF_RAG/frontend/src/components/ChartImage.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable @next/next/no-img-element */
+// base64 data URI는 next/image로 최적화 불가 → 일반 <img>.
+
+export default function ChartImage({
+  b64,
+  alt,
+}: {
+  b64: string | null | undefined;
+  alt: string;
+}) {
+  if (!b64) return null;
+  return (
+    <img
+      src={`data:image/png;base64,${b64}`}
+      alt={alt}
+      className="mt-3 w-full rounded-lg border border-gray-200"
+    />
+  );
+}

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -10,6 +10,10 @@ import type {
   StructuredData,
   TechnicalResponse,
   TickerSearchResponse,
+  FinancialResponse,
+  ComparisonResponse,
+  OutlookResponse,
+  SectorResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
@@ -135,4 +139,59 @@ export async function getTechnical(
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`technical ${res.status}`);
   return (await res.json()) as TechnicalResponse;
+}
+
+/** 재무제표 — 분기 rows + 차트. 404면 null. */
+export async function getFinancial(
+  ticker: string,
+  quarters = 8,
+): Promise<FinancialResponse | null> {
+  const url = new URL(`${API_BASE}/tabs/financial`);
+  url.searchParams.set("ticker", ticker);
+  url.searchParams.set("quarters", String(quarters));
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`financial ${res.status}`);
+  return (await res.json()) as FinancialResponse;
+}
+
+/** 비교 분석 — 2종목. 404면 null. */
+export async function postComparison(
+  tickers: [string, string],
+  days = 120,
+): Promise<ComparisonResponse | null> {
+  const res = await fetch(`${API_BASE}/tabs/comparison`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tickers, days }),
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`comparison ${res.status}`);
+  return (await res.json()) as ComparisonResponse;
+}
+
+/** 가격 전망 — 4축. 404면 null. */
+export async function getOutlook(
+  ticker: string,
+  horizon = "1m",
+): Promise<OutlookResponse | null> {
+  const url = new URL(`${API_BASE}/tabs/outlook`);
+  url.searchParams.set("ticker", ticker);
+  url.searchParams.set("horizon", horizon);
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`outlook ${res.status}`);
+  return (await res.json()) as OutlookResponse;
+}
+
+/** 섹터 분석 — 전체 또는 특정 섹터. 404면 null. */
+export async function getSector(
+  sector?: string,
+): Promise<SectorResponse | null> {
+  const url = new URL(`${API_BASE}/tabs/sector`);
+  if (sector) url.searchParams.set("sector", sector);
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`sector ${res.status}`);
+  return (await res.json()) as SectorResponse;
 }

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -45,6 +45,67 @@ export interface TickerSearchResponse {
   options: string[];
 }
 
+/** /tabs/financial 응답 */
+export interface FinancialRow {
+  fiscal_year: number;
+  fiscal_quarter: number;
+  revenue?: number | null;
+  operating_profit?: number | null;
+  net_income?: number | null;
+  operating_margin?: number | null;
+  net_margin?: number | null;
+  revenue_growth_yoy?: number | null;
+  op_growth_yoy?: number | null;
+}
+export interface FinancialResponse {
+  ticker: string;
+  name: string;
+  rows: FinancialRow[];
+  chart_b64: string | null;
+}
+
+/** /tabs/comparison 응답 (items = 구조화 데이터 dict) */
+export interface ComparisonResponse {
+  items: Record<string, unknown>[];
+  comparison_chart_b64: string | null;
+  valuation_chart_b64: string | null;
+}
+
+/** /tabs/outlook 응답 (복잡 중첩 — 느슨한 타입) */
+export interface OutlookResponse {
+  ticker?: string;
+  name?: string;
+  horizon?: string;
+  current_price?: number;
+  composite_score?: number;
+  confidence_grade?: string;
+  technical?: Record<string, unknown>;
+  fundamental?: Record<string, unknown>;
+  statistical?: Record<string, unknown>;
+  prophet?: Record<string, unknown>;
+  scenarios?: Record<string, { probability?: number; target_return?: number; description?: string }>;
+  risk_factors?: string[];
+  [k: string]: unknown;
+}
+
+/** /tabs/sector 응답 */
+export interface SectorStat {
+  sector: string;
+  count: number;
+  market_cap: number;
+  change_pct: number;
+  median_per: number;
+  up_count: number;
+  down_count: number;
+}
+export interface SectorResponse {
+  stats: SectorStat[];
+  overview_chart_b64: string | null;
+  sector?: string;
+  detail_chart_b64?: string | null;
+  stocks?: Record<string, unknown>[];
+}
+
 // ── SSE structured_data 변형 (data를 JSON.parse한 결과) ──
 export interface ComparisonItem {
   name: string;


### PR DESCRIPTION
## Context

기술분석 탭(PR #27) 패턴을 반복해 나머지 4탭 완성. **F-4 프론트 6탭(채팅+기술/재무/비교/전망/섹터) = Streamlit 기능 패리티 달성.**

## 변경 (frontend/src)

- **lib/api.ts**: getFinancial/postComparison/getOutlook/getSector (404→null). 타입 4종.
- **ChartImage.tsx**: base64 PNG `<img>` 공통 컴포넌트.
- **financial**: 분기 재무 테이블(억원/마진/YoY) + 차트.
- **comparison**: TickerSearch 2개 + ComparisonTable(재사용) + 비교/밸류 차트.
- **outlook**: 종합점수/신뢰등급 + 4축 카드 + 시나리오 3종 + 리스크 + 면책.
- **sector**: 개요 차트 + 업종 selectbox 상세 + 요약표(등락률 색상).

## 검증

- `npm run build` 통과 (6라우트)
- e2e: 4페이지 렌더 + financial(삼성전자 8분기+차트)/sector(29섹터+차트) API 동작

## 다음

F-5 배포(Railway) → 실제 URL. 또는 F-1 잔여(인증/Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)