### PR TITLE
Phase F-5: 도커화 + 배포 설정 (Railway)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -1970,5 +1970,39 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + 탭 REST API + F-4 프론트 6탭 완성(채팅+기술/재무/비교/전망/섹터, Streamlit 패리티). 백엔드 테스트 670개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+## Phase F-5: 도커화 + 배포 설정 (2026-06-08)
+
+실제 URL 배포 준비. **설정/도커화 + 가이드만** (실제 배포는 사용자 직접 — 계정/비용). DB 현행 유지(Release 다운로드). 플랫폼 Railway 권장.
+
+### 신규/변경 파일
+- **api/main.py** (변경): CORS `allow_origins`를 `CORS_ORIGINS` env(쉼표 구분)로. 미설정 시 "*"(dev), "*"아닐 때만 credentials. 유일한 백엔드 코드 변경.
+- **Dockerfile** (백엔드): python:3.11-slim + build-essential/cmake(prophet C++)/fonts-nanum(한글차트)/curl. requirements 캐시 레이어. config/src/api/scripts COPY(frontend/tests/eval 제외). HEALTHCHECK(start-period 360s). CMD 쉘형식 `${PORT}` 확장(앱이 PORT 안 읽음), 단일워커.
+- **.dockerignore**: *.db(1.7GB 베이크 금지), faiss/bm25/collected 캐시, frontend/tests/eval 제외. **deploy/ fallback + src/data/*.py 소스는 유지**.
+- **frontend/next.config.ts** (변경): `output:"standalone"` (Next16 확인: `.next/standalone/server.js` + static/public 수동복사).
+- **frontend/Dockerfile**: 멀티스테이지(deps→build→runner node:20-alpine). NEXT_PUBLIC_API_BASE는 빌드타임 baked → build ARG. CMD `node server.js`.
+- **frontend/.dockerignore**, **docker-compose.yml**(로컬 2서비스), **DEPLOY.md**(Railway 가이드).
+
+### 핵심 설계 결정 / 함정
+- **PORT를 앱이 안 읽음** → Dockerfile CMD 쉘형식 `${PORT:-8000}`.
+- **NEXT_PUBLIC_API_BASE 빌드타임 baked** → 프론트는 백엔드 URL을 빌드 시 주입, URL 바뀌면 재빌드. 배포 순서: 백엔드 먼저→URL 확보→프론트 빌드.
+- **⚠️ src/data 볼륨 마운트 금지** (탐색에서 발견): src/data는 순수 데이터가 아니라 **소스 패키지(database/technical/chart_generator/*.py) + git추적 deploy/ fallback** 포함 → 볼륨이 가려 import 깨짐. **영속은 ETF_DATA_DIR(/data 마운트) 권장 후속으로 DEPLOY.md에 문서화**(이번 미구현 — config/deps/vectorstore/retriever 다중 파일 주입 필요해 범위 제외).
+- **단일 워커 전용** 재확인(set_retriever 전역).
+
+### 검증
+- pytest API(test_api + test_api_tabs) 21개 통과 — CORS 변경 회귀 0.
+- frontend `npm run build`(standalone) 성공 — `.next/standalone/server.js` 생성, 6라우트.
+- COPY 대상 존재 + .dockerignore가 deploy/ 안 막음 + compose 문법 OK 확인.
+- **Docker daemon 미실행으로 이미지 실제 빌드는 미검증** — Dockerfile은 검증된 Next16 standalone 사양 + 정확한 시스템 의존성 기반. 사용자가 `docker build`로 최종 확인(prophet 컴파일 수분).
+
+### 커밋 (브랜치 phase-f5-deploy, main에서 분기, 5개)
+- CORS env / 백엔드 Dockerfile / 프론트 Dockerfile+standalone / compose / DEPLOY.md
+
+### 다음
+- **실제 Railway 배포 실행** (사용자) → 첫 실제 URL. 그 후 ETF_DATA_DIR 영속 편집 권장.
+- **F-1 잔여**: 인증(JWT/소셜) + PostgreSQL + 유저별 저장 + WebSocket.
+- **F-2 KIS**(신분증 보류), **F-3 KoELECTRA 감성**.
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드 + 탭 REST API + F-4 프론트 6탭(Streamlit 패리티) + F-5 도커화/배포설정. 백엔드 테스트 670개, 프론트 standalone 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -256,7 +256,8 @@
   - [x] **F-4d 멀티턴/마감** (2026-06-08): chat_history 멀티턴(대명사 참조) + 후속질문 칩 + localStorage 영속(텍스트만) + 대화 초기화 + 모바일 반응형. **F-4 프론트 채팅 완성.**
   - [x] **탭 REST API** (2026-06-08): `api/tabs.py` — `/tabs/{technical,financial,comparison,outlook,sector,tickers}` 엔드포인트. Streamlit 탭 함수를 Streamlit 없이 래핑(기존 함수 재사용). 테스트 670개.
   - [x] **프론트 탭(공통+기술분석)** (2026-06-08): NavBar(6탭 URL 라우트) + TickerSearch(디바운스 자동완성) + `/technical` 페이지(지표+차트).
-  - [x] **프론트 탭 완성(재무/비교/전망/섹터)** (2026-06-08): 나머지 4탭 같은 패턴. **F-4 프론트 6탭(채팅+5데이터) 완성 — Streamlit 기능 패리티 달성.** 후속: F-1잔여(인증/Postgres/WebSocket), F-2 KIS, F-5 배포(Railway).
+  - [x] **프론트 탭 완성(재무/비교/전망/섹터)** (2026-06-08): 나머지 4탭 같은 패턴. **F-4 프론트 6탭(채팅+5데이터) 완성 — Streamlit 기능 패리티 달성.**
+  - [x] **F-5 도커화/배포 설정** (2026-06-08): 백엔드/프론트 Dockerfile + docker-compose + DEPLOY.md(Railway) + CORS_ORIGINS env화. 실제 배포는 직접(계정/비용). 영속 볼륨(ETF_DATA_DIR)은 권장 후속으로 문서화. 후속: 실제 배포 실행, F-1잔여(인증/Postgres/WebSocket), F-2 KIS.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/.dockerignore
+++ b/ETF_RAG/.dockerignore
@@ -1,0 +1,46 @@
+# 백엔드 이미지 빌드 컨텍스트 제외 (frontend는 자체 이미지)
+frontend/
+
+# 테스트/평가/문서 — 런타임 불필요
+tests/
+eval/
+docs/
+
+# Python 로컬 env / 캐시
+.venv/
+__pycache__/
+**/__pycache__/
+*.pyc
+.pytest_cache/
+.coverage
+coverage.json
+
+# 대용량 DB + WAL/SHM — 런타임 다운로드, 절대 베이크 금지(~1.7GB)
+*.db
+*.db-wal
+*.db-shm
+src/data/etf_rag.db
+
+# 로컬 수집 데이터 + FAISS/BM25 캐시 (런타임 재생성 / 볼륨)
+src/data/collected/
+src/data/faiss_index/
+src/data/bm25_cache/
+
+# 로그
+logs/
+*.log
+
+# Git / 에디터 / OS
+.git/
+.gitignore
+.DS_Store
+.streamlit/
+
+# env 파일 — 시크릿 베이크 금지
+.env
+.env.*
+!.env.example
+
+# 계획/문서 산출물
+DEPLOY.md
+*.md

--- a/ETF_RAG/DEPLOY.md
+++ b/ETF_RAG/DEPLOY.md
@@ -1,0 +1,95 @@
+# 배포 가이드 (Phase F-5)
+
+ETF RAG를 **Railway**에 배포하는 단계별 안내. 백엔드(FastAPI)와 프론트(Next.js)는
+HTTP로만 결합된 **독립 2서비스**다. 기존 Streamlit 앱은 그대로 병행.
+
+> 이 문서는 설정/도커화까지 준비된 상태 기준. 실제 계정 생성·배포 클릭은 직접 수행.
+> **시크릿은 절대 커밋하지 않는다** (전부 Railway 대시보드 env로).
+
+## 구성 요약
+
+| 서비스 | Root Dir | 빌더 | 노출 |
+|--------|----------|------|------|
+| `etf-backend` | `ETF_RAG/` | Dockerfile | `/health`,`/chat`,`/stream`,`/tabs/*` |
+| `etf-frontend` | `ETF_RAG/frontend/` | Dockerfile | Next.js UI |
+
+(GitHub repo가 `m2222n/AI_agent`이고 ETF_RAG가 하위 디렉토리이므로 Root Dir은 위와 같이 지정.)
+
+추가된 파일: `Dockerfile`, `.dockerignore`, `frontend/Dockerfile`, `frontend/.dockerignore`,
+`frontend/next.config.ts`(standalone), `docker-compose.yml`, `api/main.py`(CORS env화).
+
+## 사전 준비
+
+- Railway 계정 + GitHub repo 연결
+- `OPENAI_API_KEY` (필수). 선택: `COHERE_API_KEY`(rerank), `DART_API_KEY`(재무).
+- DB는 현행 유지 — 백엔드 첫 부팅 시 GitHub Release `db-latest/etf_rag.db.zst`(~450MB→1.75GB) 자동 다운로드.
+
+## 1단계: 백엔드 배포 (먼저)
+
+1. Railway 프로젝트 생성 → 서비스 `etf-backend`, **Root Directory = `ETF_RAG`**. (Dockerfile 자동 감지)
+2. **환경변수** (대시보드):
+   - `OPENAI_API_KEY` (필수)
+   - `CORS_ORIGINS` = 프론트 URL (2단계 후 설정 — 처음엔 비워두면 `*`)
+   - 선택: `COHERE_API_KEY`, `DART_API_KEY`, `LANGCHAIN_*`, `VECTOR_DB_BACKEND`, `PINECONE_*`
+   - `PORT` — Railway가 자동 주입 (Dockerfile CMD가 `${PORT}` 확장).
+3. 배포 → **첫 부팅 동작**: lifespan `run_init()`이 DB 다운로드(3~5분) + FAISS 인덱스 빌드(~90s).
+   그동안 `/health`는 `{ready:false}`, 완료되면 `{ready:true}`. 이후 부팅은 (볼륨 있으면) 빠름.
+4. 백엔드 **public URL** 확보 (예: `https://etf-backend-production.up.railway.app`).
+
+## 2단계: 프론트 배포 (백엔드 URL 확보 후)
+
+1. 같은 프로젝트에 서비스 `etf-frontend`, **Root Directory = `ETF_RAG/frontend`**.
+2. **빌드 변수** `NEXT_PUBLIC_API_BASE` = 백엔드 URL.
+   - ⚠️ **빌드타임 baked** — 번들에 굳어진다. 백엔드 URL이 바뀌면 **프론트 재빌드** 필요.
+3. 배포 후, 백엔드 `CORS_ORIGINS`를 프론트 URL로 설정하고 백엔드 재배포.
+
+## 3단계: 검증
+
+프론트 URL 열기 → health 게이트 통과 확인 → 채팅 한 번 → 데이터 탭(기술/재무/섹터) 확인.
+
+## 영속(권장 후속) — DB/FAISS 콜드스타트 제거
+
+현재 영속 볼륨 **미구현**. 그대로 두면 컨테이너 재생성(콜드스타트)마다 DB 재다운로드(3~5분) +
+FAISS 재임베딩(~90s, ~$0.005). 한 번 띄우면 유지되지만, 재배포 때마다 반복.
+
+**권장 후속 편집** (별도 작업):
+1. `config.py`: `DATA_DIR`를 `ETF_DATA_DIR` 환경변수로 오버라이드 가능하게.
+   (DB_PATH, FAISS/BM25 캐시 경로가 DATA_DIR 기준이 되도록 — vectorstore/retriever도 확인.)
+2. `api/deps.py`: 하드코딩된 `_DB_PATH`도 `ETF_DATA_DIR` 반영.
+3. Railway: 볼륨을 **`/data`에 마운트**(❌ `src/data` 금지 — 소스 패키지/`deploy/` fallback을 가림),
+   `ETF_DATA_DIR=/data` 설정.
+→ DB와 FAISS가 `/data`에 영속되어 콜드스타트 1회로 끝남.
+
+## Render 대안 (비권장)
+
+같은 Dockerfile 사용 가능. **단, 무료 티어는 디스크가 ephemeral** → 재시작마다 1.7GB 재다운로드 +
+무료 인스턴스 유휴 슬립 → 반복 3~5분 콜드부팅. 영속 디스크는 유료 플랜 필요. 유료+영속 디스크면 가능.
+
+## 로컬 테스트 (docker-compose)
+
+```bash
+# 이미지 빌드만 확인 (백엔드는 prophet 컴파일로 수분 소요)
+docker build -t etf-backend .
+docker build -t etf-frontend --build-arg NEXT_PUBLIC_API_BASE=http://localhost:8000 frontend/
+
+# DB 다운로드 없이 백엔드 스모크:
+docker run --rm -p 8000:8000 -e API_SKIP_INIT=1 etf-backend
+#   → curl http://localhost:8000/health  (ready:true, 단 실제 retriever 없음 — 라우팅/CORS 확인용)
+
+# 2서비스 함께 (실제 DB 다운로드 발생):
+OPENAI_API_KEY=sk-... docker compose up --build
+#   → 프론트 http://localhost:3000, 백엔드 http://localhost:8000
+```
+
+## 트러블슈팅
+
+- `/health`가 계속 `ready:false` → `OPENAI_API_KEY` 확인, 로그에서 DB 다운로드 진행 확인(3~5분).
+- CORS 에러 → 백엔드 `CORS_ORIGINS`를 프론트 URL로 설정했는지.
+- 프론트가 `localhost:8000` 호출 → `NEXT_PUBLIC_API_BASE`를 올바른 백엔드 URL로 **재빌드**.
+
+## 하지 말 것
+
+- 시크릿 커밋 금지 (`.dockerignore`가 `.env*` 제외, 키는 대시보드로).
+- 1.7GB DB 이미지 베이크 금지 (Release 다운로드 유지).
+- **멀티 워커 금지** — `set_retriever`가 프로세스 전역 상태 (`api/main.py`). uvicorn 단일 워커.
+- 볼륨을 `src/data`에 마운트 금지 (소스 패키지 shadow). `/data` + `ETF_DATA_DIR` 사용.

--- a/ETF_RAG/Dockerfile
+++ b/ETF_RAG/Dockerfile
@@ -1,0 +1,44 @@
+# ETF RAG FastAPI 백엔드 (Phase F-5 배포)
+# 빌드 컨텍스트: repo 루트(ETF_RAG/). DB는 베이크하지 않고 런타임에 ensure_db()가 다운로드.
+FROM python:3.11-slim
+
+# 시스템 의존성:
+#  - build-essential + cmake: prophet(C++ 컴파일), kiwipiepy(소스 빌드 가능성)
+#  - fonts-nanum: matplotlib 한글 차트 글리프 (chart_generator)
+#  - curl: HEALTHCHECK용
+# pip install 전에 설치해야 prophet/kiwipiepy 컴파일이 컴파일러/cmake를 찾는다.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        fonts-nanum \
+        curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && fc-cache -f
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8000
+
+WORKDIR /app
+
+# 의존성 레이어 먼저 (requirements.txt 변경 시에만 재실행 → 캐시 재사용)
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# 애플리케이션 코드만 (frontend/, tests/, eval/ 제외 — .dockerignore).
+# src/data/*.py 소스 + src/data/deploy/ fallback JSON은 포함, etf_rag.db(1.7GB)는 제외.
+COPY config.py .
+COPY src/ ./src/
+COPY api/ ./api/
+COPY scripts/ ./scripts/
+
+EXPOSE 8000
+
+# 첫 부팅 시 DB 다운로드(3~5분) 대기 위해 start-period 넉넉히.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=360s --retries=3 \
+    CMD curl -fsS "http://localhost:${PORT:-8000}/health" || exit 1
+
+# 쉘 형식 — 앱이 PORT를 직접 안 읽으므로 ${PORT}를 쉘이 확장.
+# 단일 워커 전용: set_retriever가 프로세스 전역 상태 (api/main.py 참조).
+CMD uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/ETF_RAG/api/main.py
+++ b/ETF_RAG/api/main.py
@@ -55,11 +55,15 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="ETF RAG API", version="0.1.0", lifespan=lifespan)
 app.state.app_state = AppState()
 
-# 프론트엔드는 추후 별도 origin → dev용 permissive CORS (F-2에서 조임)
+# CORS: CORS_ORIGINS 환경변수(쉼표 구분)로 제어, 미설정 시 "*"(로컬/dev).
+# 프로덕션은 프론트 배포 origin을 지정. "*"일 때만 credentials 비활성(브라우저 제약).
+_cors_env = os.getenv("CORS_ORIGINS", "*")
+_cors_origins = [o.strip() for o in _cors_env.split(",") if o.strip()] or ["*"]
+_allow_credentials = _cors_origins != ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,  # allow_origins=["*"]와 함께 쓰려면 False여야 함
+    allow_origins=_cors_origins,
+    allow_credentials=_allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/ETF_RAG/docker-compose.yml
+++ b/ETF_RAG/docker-compose.yml
@@ -1,0 +1,40 @@
+# 로컬 2서비스 테스트용 (백엔드 + 프론트). 프로덕션 아님.
+# 사용: OPENAI_API_KEY=sk-... docker compose up --build
+#
+# 주의:
+#  - 백엔드 첫 부팅 시 ensure_db()가 1.7GB DB를 다운로드(3~5분). 이번 범위에선
+#    영속 볼륨 미구현(src/data 마운트는 소스 shadow → 불가). DEPLOY.md의 ETF_DATA_DIR
+#    후속 편집을 적용하면 /data 볼륨으로 영속 가능. 그전엔 컨테이너 새로 만들 때마다 재다운로드.
+#  - NEXT_PUBLIC_API_BASE는 브라우저에서 실행되는 번들에 baked → http://localhost:8000
+#    (compose 네트워크 별칭 backend:8000 아님 — 브라우저가 localhost를 해석).
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      PORT: "8000"
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      COHERE_API_KEY: ${COHERE_API_KEY:-}
+      DART_API_KEY: ${DART_API_KEY:-}
+      CORS_ORIGINS: "http://localhost:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 360s
+      retries: 5
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_BASE: "http://localhost:8000"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/ETF_RAG/frontend/.dockerignore
+++ b/ETF_RAG/frontend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+out
+build
+npm-debug.log*
+.env
+.env.*
+!.env.example
+.DS_Store
+.git
+*.tsbuildinfo
+README.md

--- a/ETF_RAG/frontend/Dockerfile
+++ b/ETF_RAG/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# ETF RAG 프론트엔드 (Next.js 16, App Router, standalone) — Phase F-5 배포
+# 멀티스테이지: deps → build → runner.
+# NEXT_PUBLIC_API_BASE는 빌드타임 baked → build ARG로 주입 (백엔드 URL).
+
+# 1) deps
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# 2) build — NEXT_PUBLIC_API_BASE가 번들에 baked됨
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ARG NEXT_PUBLIC_API_BASE
+ENV NEXT_PUBLIC_API_BASE=${NEXT_PUBLIC_API_BASE}
+RUN npm run build
+
+# 3) runner — standalone 최소 이미지
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    PORT=3000
+# standalone은 필요한 node_modules + server.js만 포함.
+# public, .next/static은 수동 복사 필요 (Next 16 standalone 사양).
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+EXPOSE 3000
+# server.js는 PORT env를 네이티브로 읽음.
+CMD ["node", "server.js"]

--- a/ETF_RAG/frontend/next.config.ts
+++ b/ETF_RAG/frontend/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Docker 배포용 — .next/standalone/server.js 생성 (린 runner 이미지)
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Context

Phase F-4(프론트 6탭 Streamlit 패리티) 완료 후, 실제 URL 배포 준비. **설정/도커화 + 가이드만** (실제 계정/배포는 직접). DB 현행 유지(GitHub Release 다운로드). Railway 권장(영구 볼륨).

## 변경

- **api/main.py**: CORS `allow_origins`를 `CORS_ORIGINS` env로 (미설정 시 "*"). 유일한 백엔드 코드 변경.
- **Dockerfile**(백엔드): python:3.11-slim + build-essential/cmake(prophet)/fonts-nanum. CMD 쉘형식 `${PORT}`(앱이 PORT 안 읽음), 단일워커. DB 베이크 안 함.
- **.dockerignore**: *.db/캐시/frontend/tests 제외, deploy/ fallback+소스 유지.
- **frontend/next.config.ts**: `output:"standalone"`. **frontend/Dockerfile**: 멀티스테이지, NEXT_PUBLIC_API_BASE build ARG.
- **docker-compose.yml**, **DEPLOY.md**(Railway 가이드).

## 핵심/함정

- NEXT_PUBLIC_API_BASE 빌드타임 baked → 배포 순서 백엔드먼저→프론트.
- **⚠️ src/data 볼륨 마운트 금지** — 소스 패키지+deploy fallback 포함이라 shadow됨. 영속은 ETF_DATA_DIR(/data) 권장 후속으로 DEPLOY.md 문서화(이번 미구현).
- 단일 워커 전용.

## 검증

- pytest API 21개 통과(CORS 회귀 0). frontend standalone 빌드 성공(server.js 생성, 6라우트).
- Docker daemon 미실행으로 이미지 빌드는 미검증 — 검증된 Next16 standalone 사양 기반, 사용자가 `docker build`로 최종 확인.

## 다음

실제 Railway 배포(사용자) → 첫 URL. 그 후 ETF_DATA_DIR 영속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)