### PR TITLE
Phase F-1(B): 유저별 저장 CRUD (관심종목/대화이력)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2036,9 +2036,29 @@ cd ETF_RAG && uvicorn api.main:app --host 0.0.0.0 --port 8000   # 단일 워커
 Railway: `DATABASE_URL=postgresql://...`(Postgres 플러그인) + `JWT_SECRET` 추가. init_models가 부팅 시 테이블 생성. etf_rag_users.db는 *.db로 gitignore/dockerignore 제외.
 
 ### 다음
-- **(B)** Watchlist/ChatHistory 모델 + CRUD(get_current_user 뒤). **(C)** 프론트 로그인/회원가입 UI + auth context + Bearer 스레딩(lib/api) + NavBar + 서버/localStorage 대화 전환. 실제 배포. F-2 KIS.
+- (B)로 이어짐.
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드+인증(A) + 탭 REST API + F-4 프론트 6탭 + F-5 도커화. 백엔드 테스트 678개, 프론트 standalone 빌드, e2e 확인. Streamlit 병행)_
+## Phase F-1 잔여 (B): 유저별 저장 CRUD (2026-06-08)
+
+A(인증) 위에 관심종목/대화이력 서버 저장 추가. 단순 형태(세션 구분 없는 append).
+
+- **models_db.py**: `Watchlist`(user_id+ticker UniqueConstraint), `ChatHistory`(role/content/question_type/model, user+created 복합 인덱스). 둘 다 users FK.
+- **models.py**: WatchlistResponse, ChatHistoryItemDB/Append/Response.
+- **api/user_data.py**(신규): `APIRouter(prefix="/me")`, 전부 `get_current_user` 뒤, 동기 def.
+  - GET/PUT/DELETE `/me/watchlist/{ticker}` — PUT 멱등(중복 무시), 응답은 현재 ticker 리스트.
+  - GET/POST/DELETE `/me/history` — POST append(시간순), DELETE 204.
+- **main.py**: include_router(user_data).
+- 검증: tests/test_user_data.py 6개(add/list/remove/멱등/**유저격리**/인증401, history append/순서/clear/빈payload422). TestClient로 signup→token→CRUD = 실질 e2e. 전체 **684개**(+6).
+
+### 커밋 (브랜치 phase-f1b-userdata, 3개)
+모델+Pydantic / user_data 라우터+main / 테스트.
+
+### 다음
+- **(C)** 프론트: 로그인/회원가입 UI + auth context(토큰 localStorage) + Bearer 스레딩(lib/api 전 함수) + NavBar 로그인/로그아웃 + 로그인 시 서버 대화/관심종목, 비로그인 시 localStorage fallback(get_current_user_optional 활용). 실제 배포. F-2 KIS.
+
+---
+
+_Last Updated: 2026-06-08 (Phase F: F-1 백엔드+인증(A)+유저저장(B) + 탭 REST API + F-4 프론트 6탭 + F-5 도커화. 백엔드 테스트 684개, 프론트 standalone 빌드, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -258,7 +258,8 @@
   - [x] **프론트 탭(공통+기술분석)** (2026-06-08): NavBar(6탭 URL 라우트) + TickerSearch(디바운스 자동완성) + `/technical` 페이지(지표+차트).
   - [x] **프론트 탭 완성(재무/비교/전망/섹터)** (2026-06-08): 나머지 4탭 같은 패턴. **F-4 프론트 6탭(채팅+5데이터) 완성 — Streamlit 기능 패리티 달성.**
   - [x] **F-5 도커화/배포 설정** (2026-06-08): 백엔드/프론트 Dockerfile + docker-compose + DEPLOY.md(Railway) + CORS_ORIGINS env화. 실제 배포는 직접(계정/비용). 영속 볼륨(ETF_DATA_DIR)은 권장 후속으로 문서화.
-  - [x] **F-1잔여 (A) JWT 인증 백엔드** (2026-06-08): 동기 SQLAlchemy 사용자 DB(stock DB와 분리, Postgres prod/sqlite dev) + bcrypt + PyJWT + `/auth/signup,login,me` + get_current_user. 테스트 678개. 후속: (B) Watchlist/ChatHistory CRUD, (C) 프론트 로그인 UI+Bearer, 실제 배포, F-2 KIS.
+  - [x] **F-1잔여 (A) JWT 인증 백엔드** (2026-06-08): 동기 SQLAlchemy 사용자 DB(stock DB와 분리, Postgres prod/sqlite dev) + bcrypt + PyJWT + `/auth/signup,login,me` + get_current_user.
+  - [x] **F-1잔여 (B) 유저별 저장 CRUD** (2026-06-08): Watchlist/ChatHistory 모델 + `/me/watchlist`·`/me/history` CRUD(get_current_user 뒤, 유저 격리). 테스트 684개. 후속: (C) 프론트 로그인 UI+Bearer+서버 대화 전환, 실제 배포, F-2 KIS.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/api/main.py
+++ b/ETF_RAG/api/main.py
@@ -32,6 +32,7 @@ from api.db import init_models
 from api.models import ChatRequest, ChatResponse, HealthResponse
 from api.tabs import router as tabs_router
 from api.auth import router as auth_router
+from api.user_data import router as user_data_router
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,8 @@ app.add_middleware(
 app.include_router(tabs_router)
 # JWT 이메일 인증 (/auth/*)
 app.include_router(auth_router)
+# 유저별 저장 — 관심종목/대화이력 (/me/*)
+app.include_router(user_data_router)
 
 
 def _require_ready() -> None:

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -56,3 +56,23 @@ class TokenResponse(BaseModel):
 class UserResponse(BaseModel):
     id: int
     email: EmailStr
+
+
+# ── 유저별 저장 (관심종목 / 대화이력) ──────────────────────
+class WatchlistResponse(BaseModel):
+    tickers: List[str]
+
+
+class ChatHistoryItemDB(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+    question_type: Optional[str] = None
+    model: Optional[str] = None
+
+
+class ChatHistoryAppend(BaseModel):
+    messages: List[ChatHistoryItemDB] = Field(..., min_length=1)
+
+
+class ChatHistoryResponse(BaseModel):
+    messages: List[ChatHistoryItemDB]

--- a/ETF_RAG/api/models_db.py
+++ b/ETF_RAG/api/models_db.py
@@ -5,8 +5,18 @@ Phase A는 User만. B에서 Watchlist/ChatHistory + relationship 추가 예정.
 """
 
 from datetime import datetime, timezone
+from typing import Optional
 
-from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from api.db import Base
@@ -26,4 +36,39 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, server_default=func.now()
+    )
+
+
+class Watchlist(Base):
+    __tablename__ = "watchlists"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), index=True, nullable=False
+    )
+    ticker: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, server_default=func.now()
+    )
+    __table_args__ = (
+        UniqueConstraint("user_id", "ticker", name="uq_watchlist_user_ticker"),
+    )
+
+
+class ChatHistory(Base):
+    __tablename__ = "chat_histories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), index=True, nullable=False
+    )
+    role: Mapped[str] = mapped_column(String(10), nullable=False)  # user | assistant
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    question_type: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+    model: Mapped[Optional[str]] = mapped_column(String(40), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, server_default=func.now(), index=True
+    )
+    __table_args__ = (
+        Index("ix_chat_user_created", "user_id", "created_at"),
     )

--- a/ETF_RAG/api/user_data.py
+++ b/ETF_RAG/api/user_data.py
@@ -1,0 +1,117 @@
+"""유저별 저장 — 관심종목/대화이력 CRUD (Phase F-1 B).
+
+모든 엔드포인트 get_current_user 뒤. 동기 def 핸들러(threadpool).
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from api.auth import get_current_user
+from api.db import get_db
+from api.models import (
+    ChatHistoryAppend,
+    ChatHistoryItemDB,
+    ChatHistoryResponse,
+    WatchlistResponse,
+)
+from api.models_db import ChatHistory, User, Watchlist
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/me", tags=["user-data"])
+
+
+# ── 관심종목 ────────────────────────────────────────────
+@router.get("/watchlist", response_model=WatchlistResponse)
+def get_watchlist(
+    user: User = Depends(get_current_user), db: Session = Depends(get_db)
+) -> WatchlistResponse:
+    rows = db.scalars(
+        select(Watchlist.ticker)
+        .where(Watchlist.user_id == user.id)
+        .order_by(Watchlist.created_at)
+    ).all()
+    return WatchlistResponse(tickers=list(rows))
+
+
+@router.put("/watchlist/{ticker}", response_model=WatchlistResponse,
+            status_code=status.HTTP_200_OK)
+def add_watchlist(
+    ticker: str,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> WatchlistResponse:
+    exists = db.scalar(
+        select(Watchlist).where(
+            Watchlist.user_id == user.id, Watchlist.ticker == ticker
+        )
+    )
+    if exists is None:
+        db.add(Watchlist(user_id=user.id, ticker=ticker))
+        db.commit()
+    return get_watchlist(user, db)
+
+
+@router.delete("/watchlist/{ticker}", response_model=WatchlistResponse)
+def remove_watchlist(
+    ticker: str,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> WatchlistResponse:
+    db.execute(
+        delete(Watchlist).where(
+            Watchlist.user_id == user.id, Watchlist.ticker == ticker
+        )
+    )
+    db.commit()
+    return get_watchlist(user, db)
+
+
+# ── 대화 이력 (단순 append, 세션 구분 없음) ──────────────
+@router.get("/history", response_model=ChatHistoryResponse)
+def get_history(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    limit: int = 200,
+) -> ChatHistoryResponse:
+    rows = db.scalars(
+        select(ChatHistory)
+        .where(ChatHistory.user_id == user.id)
+        .order_by(ChatHistory.created_at, ChatHistory.id)
+        .limit(limit)
+    ).all()
+    return ChatHistoryResponse(
+        messages=[
+            ChatHistoryItemDB(
+                role=r.role, content=r.content,
+                question_type=r.question_type, model=r.model,
+            )
+            for r in rows
+        ]
+    )
+
+
+@router.post("/history", response_model=ChatHistoryResponse,
+             status_code=status.HTTP_201_CREATED)
+def append_history(
+    payload: ChatHistoryAppend,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ChatHistoryResponse:
+    for m in payload.messages:
+        db.add(ChatHistory(
+            user_id=user.id, role=m.role, content=m.content,
+            question_type=m.question_type, model=m.model,
+        ))
+    db.commit()
+    return get_history(user, db)
+
+
+@router.delete("/history", status_code=status.HTTP_204_NO_CONTENT)
+def clear_history(
+    user: User = Depends(get_current_user), db: Session = Depends(get_db)
+) -> None:
+    db.execute(delete(ChatHistory).where(ChatHistory.user_id == user.id))
+    db.commit()

--- a/ETF_RAG/tests/test_user_data.py
+++ b/ETF_RAG/tests/test_user_data.py
@@ -1,0 +1,132 @@
+"""유저별 저장(관심종목/대화이력) CRUD 테스트 (Phase F-1 B).
+
+test_auth.py와 동일한 StaticPool 인메모리 sqlite 패턴.
+"""
+
+import os
+
+os.environ["API_SKIP_INIT"] = "1"
+os.environ["DATABASE_URL"] = "sqlite://"
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import api.db as db  # noqa: E402
+from api.db import Base, get_db  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_sse_global():
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit_event = None
+    yield
+
+
+@pytest.fixture
+def client():
+    test_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, expire_on_commit=False)
+    db.engine = test_engine
+    db.SessionLocal = TestSession
+    Base.metadata.create_all(test_engine)
+
+    from api.main import app
+
+    def _override_db():
+        s = TestSession()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(test_engine)
+
+
+@pytest.fixture
+def auth(client):
+    """가입 후 Authorization 헤더 반환."""
+    r = client.post("/auth/signup", json={"email": "u@b.com", "password": "pw123456"})
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── 관심종목 ────────────────────────────────────────────
+def test_watchlist_add_list_remove(client, auth):
+    assert client.get("/me/watchlist", headers=auth).json()["tickers"] == []
+
+    r = client.put("/me/watchlist/005930", headers=auth)
+    assert r.status_code == 200
+    assert r.json()["tickers"] == ["005930"]
+
+    client.put("/me/watchlist/000660", headers=auth)
+    assert set(client.get("/me/watchlist", headers=auth).json()["tickers"]) == {
+        "005930", "000660"
+    }
+
+    # 중복 추가 멱등
+    client.put("/me/watchlist/005930", headers=auth)
+    assert len(client.get("/me/watchlist", headers=auth).json()["tickers"]) == 2
+
+    r = client.delete("/me/watchlist/005930", headers=auth)
+    assert r.json()["tickers"] == ["000660"]
+
+
+def test_watchlist_requires_auth(client):
+    assert client.get("/me/watchlist").status_code == 401
+    assert client.put("/me/watchlist/005930").status_code == 401
+
+
+def test_watchlist_isolated_per_user(client):
+    t1 = client.post("/auth/signup", json={"email": "a@b.com", "password": "pw123456"}).json()["access_token"]
+    t2 = client.post("/auth/signup", json={"email": "b@b.com", "password": "pw123456"}).json()["access_token"]
+    client.put("/me/watchlist/005930", headers={"Authorization": f"Bearer {t1}"})
+    # user2는 비어있어야
+    r = client.get("/me/watchlist", headers={"Authorization": f"Bearer {t2}"})
+    assert r.json()["tickers"] == []
+
+
+# ── 대화 이력 ──────────────────────────────────────────
+def test_history_append_list_clear(client, auth):
+    assert client.get("/me/history", headers=auth).json()["messages"] == []
+
+    payload = {"messages": [
+        {"role": "user", "content": "삼성전자 어때?"},
+        {"role": "assistant", "content": "PER 49.81배입니다.", "question_type": "simple", "model": "gpt-4o-mini"},
+    ]}
+    r = client.post("/me/history", headers=auth, json=payload)
+    assert r.status_code == 201
+    msgs = r.json()["messages"]
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[1]["question_type"] == "simple"
+
+    # 순서 보존 + 누적
+    client.post("/me/history", headers=auth, json={"messages": [{"role": "user", "content": "다음은?"}]})
+    got = client.get("/me/history", headers=auth).json()["messages"]
+    assert len(got) == 3
+    assert got[-1]["content"] == "다음은?"
+
+    assert client.delete("/me/history", headers=auth).status_code == 204
+    assert client.get("/me/history", headers=auth).json()["messages"] == []
+
+
+def test_history_requires_auth(client):
+    assert client.get("/me/history").status_code == 401
+
+
+def test_history_empty_payload_422(client, auth):
+    r = client.post("/me/history", headers=auth, json={"messages": []})
+    assert r.status_code == 422  # min_length=1


### PR DESCRIPTION
## Context

A(JWT 인증) 위에 유저별 관심종목/대화이력 서버 저장. 모든 엔드포인트 get_current_user 뒤, 유저 격리.

## 변경

- **models_db.py**: Watchlist(user_id+ticker unique), ChatHistory(role/content/qtype/model + 복합 인덱스).
- **api/user_data.py**(신규, prefix `/me`): GET/PUT/DELETE `/me/watchlist/{ticker}`(멱등), GET/POST/DELETE `/me/history`(append/clear).
- models.py Pydantic, main include_router.

## 검증

- tests/test_user_data.py 6개 (관심종목 add/list/remove/멱등/유저격리/인증, 대화 append/순서/clear/빈payload422). TestClient signup→token→CRUD = 실질 e2e.
- 전체 **684개** 통과(+6, 회귀 0).

## 다음

(C) 프론트 로그인 UI + Bearer 스레딩 + 서버/localStorage 대화 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)