### PR TITLE
Phase F-1(C): 프론트 인증 UI — 로그인/회원가입 + 서버 대화 영속

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2056,9 +2056,36 @@ A(인증) 위에 관심종목/대화이력 서버 저장 추가. 단순 형태(�
 모델+Pydantic / user_data 라우터+main / 테스트.
 
 ### 다음
-- **(C)** 프론트: 로그인/회원가입 UI + auth context(토큰 localStorage) + Bearer 스레딩(lib/api 전 함수) + NavBar 로그인/로그아웃 + 로그인 시 서버 대화/관심종목, 비로그인 시 localStorage fallback(get_current_user_optional 활용). 실제 배포. F-2 KIS.
+- (C)로 이어짐.
 
 ---
 
-_Last Updated: 2026-06-08 (Phase F: F-1 백엔드+인증(A)+유저저장(B) + 탭 REST API + F-4 프론트 6탭 + F-5 도커화. 백엔드 테스트 684개, 프론트 standalone 빌드, e2e 확인. Streamlit 병행)_
+## Phase F-1 잔여 (C): 프론트 인증 UI (2026-06-09)
+
+A(인증 백엔드)+B(유저저장)에 프론트 연결. **로그인 선택제** — 비로그인도 전 기능 사용, 로그인 시 서버 동기화.
+
+### 신규/변경 (frontend/src)
+- **lib/auth.ts**(신규): 토큰 localStorage(`etfrag.token`), `authHeader()`, `signup/login/fetchMe`, 서버 대화이력 `getServerHistory/appendServerHistory/clearServerHistory`(/me/history).
+- **lib/AuthContext.tsx**(신규): `useAuth()` — user/loading/login/signup/logout. mount 시 토큰→fetchMe 복원.
+- **lib/api.ts**: chatOnce/streamChat에 `authHeader()` 스레딩(로그인 시 Bearer, 탭 API는 public이라 미적용).
+- **app/login/page.tsx**(신규): 로그인↔회원가입 토글 폼, 에러, 성공 시 router.push("/").
+- **layout.tsx**: AuthProvider로 감쌈.
+- **NavBar**: 우측 인증 영역 — 비로그인 "로그인" 링크 / 로그인 시 이메일+로그아웃.
+- **app/page.tsx**: 로그인 변화 시 서버 이력 로드(localStorage 위 덮어씀), onDone에서 로그인 시 user+assistant append, handleReset이 로그인 시 서버도 clear.
+
+### 검증
+- `npm run build` 통과(/login 라우트 추가, 10라우트). e2e(백엔드+프론트 기동): /login 렌더, signup→token→me(c@test.com), /me/history append(201)→get(2개) 정상. 프론트가 하는 호출 전부 통과.
+
+### 커밋 (브랜치 phase-f1c-frontend-auth, 3개)
+lib(auth/context/api) / 로그인UI+NavBar+layout / 채팅 서버영속.
+
+### Phase F-1 완료
+인증(A) + 유저저장(B) + 프론트(C) 다 됨. SaaS 코어 완성 — 이제 **로그인하면 기기 넘어 대화 유지**.
+
+### 다음
+- **실제 Railway 배포**(사용자 액션 — 계정/비용/Postgres). **PWA**(비용 0, 홈화면 설치 — 사용자 합의됨, manifest+SW). F-2 KIS(신분증). 관심종목 프론트 연결(watchlist UI)은 미구현(백엔드 /me/watchlist는 준비됨).
+
+---
+
+_Last Updated: 2026-06-09 (Phase F-1 완료: 인증(A)+유저저장(B)+프론트인증(C). + 탭 REST API + F-4 프론트 6탭 + F-5 도커화. 백엔드 테스트 684개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -259,7 +259,8 @@
   - [x] **프론트 탭 완성(재무/비교/전망/섹터)** (2026-06-08): 나머지 4탭 같은 패턴. **F-4 프론트 6탭(채팅+5데이터) 완성 — Streamlit 기능 패리티 달성.**
   - [x] **F-5 도커화/배포 설정** (2026-06-08): 백엔드/프론트 Dockerfile + docker-compose + DEPLOY.md(Railway) + CORS_ORIGINS env화. 실제 배포는 직접(계정/비용). 영속 볼륨(ETF_DATA_DIR)은 권장 후속으로 문서화.
   - [x] **F-1잔여 (A) JWT 인증 백엔드** (2026-06-08): 동기 SQLAlchemy 사용자 DB(stock DB와 분리, Postgres prod/sqlite dev) + bcrypt + PyJWT + `/auth/signup,login,me` + get_current_user.
-  - [x] **F-1잔여 (B) 유저별 저장 CRUD** (2026-06-08): Watchlist/ChatHistory 모델 + `/me/watchlist`·`/me/history` CRUD(get_current_user 뒤, 유저 격리). 테스트 684개. 후속: (C) 프론트 로그인 UI+Bearer+서버 대화 전환, 실제 배포, F-2 KIS.
+  - [x] **F-1잔여 (B) 유저별 저장 CRUD** (2026-06-08): Watchlist/ChatHistory 모델 + `/me/watchlist`·`/me/history` CRUD(get_current_user 뒤, 유저 격리). 테스트 684개.
+  - [x] **F-1잔여 (C) 프론트 인증 UI** (2026-06-09): lib/auth(토큰)+AuthContext + `/login`(로그인/회원가입 토글) + NavBar 로그인/로그아웃 + chat/stream Bearer 스레딩 + **로그인 시 서버 대화이력 로드/append**(비로그인은 localStorage). **로그인 선택제 — 비로그인도 전 기능 사용.** **Phase F-1 완료(인증+유저저장+프론트).** 후속: 실제 배포, PWA(저비용), F-2 KIS.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/frontend/src/app/layout.tsx
+++ b/ETF_RAG/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import NavBar from "@/components/NavBar";
+import { AuthProvider } from "@/lib/AuthContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,8 +30,10 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <NavBar />
-        {children}
+        <AuthProvider>
+          <NavBar />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/ETF_RAG/frontend/src/app/login/page.tsx
+++ b/ETF_RAG/frontend/src/app/login/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useAuth } from "@/lib/AuthContext";
+
+export default function LoginPage() {
+  const { login, signup } = useAuth();
+  const router = useRouter();
+  const [mode, setMode] = useState<"login" | "signup">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      if (mode === "login") await login(email, password);
+      else await signup(email, password);
+      router.push("/"); // 채팅으로
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "처리 중 오류가 발생했어요.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-sm px-4 py-10">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">
+        {mode === "login" ? "로그인" : "회원가입"}
+      </h1>
+      <p className="mb-5 text-xs text-gray-500">
+        로그인하면 관심종목·대화 이력이 기기 간에 유지돼요. (선택 사항 — 로그인
+        없이도 모든 기능 사용 가능)
+      </p>
+
+      <form onSubmit={submit} className="flex flex-col gap-3">
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="이메일"
+          className="rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+        />
+        <input
+          type="password"
+          required
+          minLength={mode === "signup" ? 8 : 1}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder={mode === "signup" ? "비밀번호 (8자 이상)" : "비밀번호"}
+          className="rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+        />
+        {error && <p className="text-xs text-red-600">{error}</p>}
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-gray-300"
+        >
+          {busy ? "처리 중…" : mode === "login" ? "로그인" : "가입하기"}
+        </button>
+      </form>
+
+      <button
+        type="button"
+        onClick={() => {
+          setMode(mode === "login" ? "signup" : "login");
+          setError(null);
+        }}
+        className="mt-4 text-xs text-blue-600 hover:underline"
+      >
+        {mode === "login"
+          ? "계정이 없으신가요? 회원가입"
+          : "이미 계정이 있으신가요? 로그인"}
+      </button>
+    </main>
+  );
+}

--- a/ETF_RAG/frontend/src/app/page.tsx
+++ b/ETF_RAG/frontend/src/app/page.tsx
@@ -5,19 +5,26 @@ import { getHealth, streamChat } from "@/lib/api";
 import type { ChatHistoryItem, Health, UiMessage } from "@/lib/types";
 import { toolLabel } from "@/lib/labels";
 import { getFollowupSuggestions } from "@/lib/followup";
+import { useAuth } from "@/lib/AuthContext";
+import {
+  appendServerHistory,
+  clearServerHistory,
+  getServerHistory,
+} from "@/lib/auth";
 import MessageList from "@/components/MessageList";
 import ChatInput from "@/components/ChatInput";
 
 const STORAGE_KEY = "etfrag.messages.v1";
 
 export default function Home() {
+  const { user } = useAuth();
   const [health, setHealth] = useState<Health | null>(null);
   const [messages, setMessages] = useState<UiMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hydrated, setHydrated] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // mount 시 localStorage 복원 (1회)
+  // mount 시 localStorage 복원 (1회). 로그인 사용자는 아래 effect가 서버 이력으로 덮어씀.
   useEffect(() => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
@@ -28,8 +35,29 @@ export default function Home() {
     setHydrated(true);
   }, []);
 
+  // 로그인 상태 변화 시 서버 대화 이력 로드(로그인) — localStorage 위에 덮어씀.
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    getServerHistory().then((rows) => {
+      if (cancelled || rows.length === 0) return;
+      setMessages(
+        rows.map((r) => ({
+          role: r.role,
+          content: r.content,
+          questionType: (r.question_type as UiMessage["questionType"]) ?? undefined,
+          model: r.model ?? undefined,
+        })),
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
   // 대화 변경 시 영속. base64 차트(structured)·전이 상태(status)는 제외 —
   // 이미지가 200KB+라 localStorage(~5MB) 초과 위험. 텍스트 대화만 보존.
+  // (로그인 사용자도 localStorage는 오프라인 캐시로 병행 — 서버가 정본.)
   useEffect(() => {
     if (!hydrated) return;
     try {
@@ -144,18 +172,30 @@ export default function Home() {
           status: undefined,
           followups,
         });
+        let finalAnswer = "";
         setMessages((prev) => {
           const next = [...prev];
           const last = next[next.length - 1];
-          if (
-            last &&
-            last.role === "assistant" &&
-            d.answer.length > last.content.length
-          ) {
-            next[next.length - 1] = { ...last, content: d.answer };
+          if (last && last.role === "assistant") {
+            if (d.answer.length > last.content.length) {
+              next[next.length - 1] = { ...last, content: d.answer };
+            }
+            finalAnswer = next[next.length - 1].content;
           }
           return next;
         });
+        // 로그인 시 user+assistant 쌍을 서버에 append (실패해도 UI 영향 없음)
+        if (user && finalAnswer) {
+          appendServerHistory([
+            { role: "user", content: question },
+            {
+              role: "assistant",
+              content: finalAnswer,
+              question_type: d.question_type,
+              model: d.model,
+            },
+          ]).catch(() => {});
+        }
         setIsLoading(false);
       },
       onError: (msg) => {
@@ -173,6 +213,7 @@ export default function Home() {
     } catch {
       /* 무시 */
     }
+    if (user) clearServerHistory().catch(() => {});
   };
 
   const statusText = !health

--- a/ETF_RAG/frontend/src/components/NavBar.tsx
+++ b/ETF_RAG/frontend/src/components/NavBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useAuth } from "@/lib/AuthContext";
 
 const TABS = [
   { href: "/", label: "💬 채팅" },
@@ -14,6 +15,7 @@ const TABS = [
 
 export default function NavBar() {
   const pathname = usePathname();
+  const { user, loading, logout } = useAuth();
 
   return (
     <nav className="border-b border-gray-200">
@@ -35,6 +37,36 @@ export default function NavBar() {
             </Link>
           );
         })}
+
+        {/* 인증 영역 (오른쪽) */}
+        <div className="ml-auto flex shrink-0 items-center gap-2 pl-2">
+          {loading ? null : user ? (
+            <>
+              <span className="hidden text-xs text-gray-500 sm:inline">
+                {user.email}
+              </span>
+              <button
+                type="button"
+                onClick={logout}
+                className="shrink-0 rounded-lg px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-100"
+              >
+                로그아웃
+              </button>
+            </>
+          ) : (
+            <Link
+              href="/login"
+              className={[
+                "shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium",
+                pathname === "/login"
+                  ? "bg-blue-600 text-white"
+                  : "text-blue-600 hover:bg-blue-50",
+              ].join(" ")}
+            >
+              로그인
+            </Link>
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/ETF_RAG/frontend/src/lib/AuthContext.tsx
+++ b/ETF_RAG/frontend/src/lib/AuthContext.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  clearToken,
+  fetchMe,
+  login as apiLogin,
+  setToken,
+  signup as apiSignup,
+  type AuthUser,
+} from "./auth";
+
+interface AuthState {
+  user: AuthUser | null;
+  loading: boolean; // 초기 토큰 검증 중
+  login: (email: string, password: string) => Promise<void>;
+  signup: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthCtx = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // mount 시 저장된 토큰으로 사용자 복원
+  useEffect(() => {
+    let cancelled = false;
+    fetchMe()
+      .then((u) => {
+        if (!cancelled) setUser(u);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const token = await apiLogin(email, password);
+    setToken(token);
+    setUser(await fetchMe());
+  };
+
+  const signup = async (email: string, password: string) => {
+    const token = await apiSignup(email, password);
+    setToken(token);
+    setUser(await fetchMe());
+  };
+
+  const logout = () => {
+    clearToken();
+    setUser(null);
+  };
+
+  return (
+    <AuthCtx.Provider value={{ user, loading, login, signup, logout }}>
+      {children}
+    </AuthCtx.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthCtx);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 // 백엔드 API 클라이언트.
 import { fetchEventSource } from "@microsoft/fetch-event-source";
+import { authHeader } from "./auth";
 import type {
   ChatHistoryItem,
   ChatResponse,
@@ -30,7 +31,7 @@ export async function chatOnce(
 ): Promise<ChatResponse> {
   const res = await fetch(`${API_BASE}/chat`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeader() },
     body: JSON.stringify({
       question,
       chat_history: history.length ? history : null,
@@ -55,7 +56,7 @@ export function streamChat(
 
   fetchEventSource(`${API_BASE}/stream`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeader() },
     body: JSON.stringify({
       question,
       chat_history: history.length ? history : null,

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -1,0 +1,107 @@
+// 인증 토큰 저장 + 인증/유저데이터 API. 토큰은 localStorage.
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
+const TOKEN_KEY = "etfrag.token";
+
+export function getToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+/** 토큰이 있으면 Authorization 헤더 객체 반환 (없으면 빈 객체) */
+export function authHeader(): Record<string, string> {
+  const t = getToken();
+  return t ? { Authorization: `Bearer ${t}` } : {};
+}
+
+export interface AuthUser {
+  id: number;
+  email: string;
+}
+
+async function postAuth(
+  path: string,
+  body: { email: string; password: string },
+): Promise<string> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail || `${path} ${res.status}`);
+  }
+  const data = await res.json();
+  return data.access_token as string;
+}
+
+export async function signup(email: string, password: string): Promise<string> {
+  return postAuth("/auth/signup", { email, password });
+}
+
+export async function login(email: string, password: string): Promise<string> {
+  return postAuth("/auth/login", { email, password });
+}
+
+/** 현재 토큰으로 사용자 조회. 실패(401 등) 시 null. */
+export async function fetchMe(): Promise<AuthUser | null> {
+  const t = getToken();
+  if (!t) return null;
+  const res = await fetch(`${API_BASE}/auth/me`, {
+    headers: { Authorization: `Bearer ${t}` },
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as AuthUser;
+}
+
+// ── 유저별 저장 (로그인 시) ──────────────────────────────
+import type { ChatHistoryItem } from "./types";
+
+export interface ServerChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  question_type?: string | null;
+  model?: string | null;
+}
+
+export async function getServerHistory(): Promise<ServerChatMessage[]> {
+  const res = await fetch(`${API_BASE}/me/history`, {
+    headers: authHeader(),
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.messages ?? []) as ServerChatMessage[];
+}
+
+export async function appendServerHistory(
+  messages: ServerChatMessage[],
+): Promise<void> {
+  if (!messages.length) return;
+  await fetch(`${API_BASE}/me/history`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ messages }),
+  });
+}
+
+export async function clearServerHistory(): Promise<void> {
+  await fetch(`${API_BASE}/me/history`, {
+    method: "DELETE",
+    headers: authHeader(),
+  });
+}
+
+// ChatHistoryItem(UI) → 서버 전송용 평탄화
+export function toServerMessages(items: ChatHistoryItem[]): ServerChatMessage[] {
+  return items.map((m) => ({ role: m.role, content: m.content }));
+}


### PR DESCRIPTION
## Context

A(인증 백엔드)+B(유저저장) 위에 프론트 연결로 **Phase F-1 완료**. 로그인 선택제 — 비로그인도 전 기능 사용, 로그인 시 서버 동기화.

## 변경 (frontend/src)

- **lib/auth.ts**(신규): 토큰 localStorage, authHeader(), signup/login/fetchMe, 서버 대화이력 get/append/clear.
- **lib/AuthContext.tsx**(신규): useAuth() — user/login/signup/logout, mount 시 토큰 복원.
- **lib/api.ts**: chatOnce/streamChat에 Bearer 스레딩.
- **app/login/page.tsx**(신규): 로그인↔회원가입 토글.
- **layout.tsx**: AuthProvider. **NavBar**: 로그인 링크 / 이메일+로그아웃.
- **app/page.tsx**: 로그인 시 서버 이력 로드 + onDone append + reset 시 서버 clear. 비로그인은 localStorage.

## 검증

- `npm run build` 통과(10라우트, /login 추가)
- e2e: /login 렌더, signup→token→me, /me/history append(201)→get(2개) 정상

## 다음

실제 Railway 배포, PWA(비용 0), F-2 KIS. watchlist 프론트 UI(백엔드 /me/watchlist는 준비됨)는 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)