### PR TITLE
Phase F: 관심종목(watchlist) 프론트 UI

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2083,9 +2083,23 @@ lib(auth/context/api) / 로그인UI+NavBar+layout / 채팅 서버영속.
 인증(A) + 유저저장(B) + 프론트(C) 다 됨. SaaS 코어 완성 — 이제 **로그인하면 기기 넘어 대화 유지**.
 
 ### 다음
-- **실제 Railway 배포**(사용자 액션 — 계정/비용/Postgres). **PWA**(비용 0, 홈화면 설치 — 사용자 합의됨, manifest+SW). F-2 KIS(신분증). 관심종목 프론트 연결(watchlist UI)은 미구현(백엔드 /me/watchlist는 준비됨).
+- 관심종목 UI로 이어짐.
+
+## 관심종목(watchlist) 프론트 UI (2026-06-09)
+
+백엔드 `/me/watchlist`(B에서 준비됨)를 프론트 연결. 로그인 시에만 동작.
+- **lib/auth.ts**: getWatchlist/addWatchlist/removeWatchlist.
+- **lib/useWatchlist.ts**: 로그인 변화 시 서버 로드 + **낙관적 토글**(즉시 UI 반영 → 서버 응답 보정).
+- **WatchlistStar**: 종목 ⭐ 토글 — 기술적 분석 탭 종목명 옆. **WatchlistBar**: 채팅 홈 상단 칩 → 클릭 시 `/technical?ticker=`.
+- **technical/page**: `?ticker=` 쿼리 진입 시 자동 조회(mount, `window.location.search` — useSearchParams Suspense 회피).
+- 검증: build(10라우트), e2e PUT/GET/DELETE 005930·000660 정상.
+- 미구현: 다른 탭(재무/전망 등) ⭐ 미배치(기술탭만). 필요 시 후속.
+
+### 다음 (남은 것)
+- **실제 Railway 배포**(사용자 — 계정/비용/Postgres). **PWA**(비용 0, manifest+SW, 합의됨). **F-2 KIS**(신분증).
+- 코드로 더 만들 SaaS 코어는 사실상 완료. 다음 우선순위는 배포 또는 PWA.
 
 ---
 
-_Last Updated: 2026-06-09 (Phase F-1 완료: 인증(A)+유저저장(B)+프론트인증(C). + 탭 REST API + F-4 프론트 6탭 + F-5 도커화. 백엔드 테스트 684개, 프론트 빌드 통과, e2e 확인. Streamlit 병행)_
+_Last Updated: 2026-06-09 (Phase F-1 완료 + 관심종목 UI. SaaS 코어 완성. 백엔드 테스트 684개, 프론트 빌드 통과(10라우트), e2e 확인. Streamlit 병행)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -261,6 +261,7 @@
   - [x] **F-1잔여 (A) JWT 인증 백엔드** (2026-06-08): 동기 SQLAlchemy 사용자 DB(stock DB와 분리, Postgres prod/sqlite dev) + bcrypt + PyJWT + `/auth/signup,login,me` + get_current_user.
   - [x] **F-1잔여 (B) 유저별 저장 CRUD** (2026-06-08): Watchlist/ChatHistory 모델 + `/me/watchlist`·`/me/history` CRUD(get_current_user 뒤, 유저 격리). 테스트 684개.
   - [x] **F-1잔여 (C) 프론트 인증 UI** (2026-06-09): lib/auth(토큰)+AuthContext + `/login`(로그인/회원가입 토글) + NavBar 로그인/로그아웃 + chat/stream Bearer 스레딩 + **로그인 시 서버 대화이력 로드/append**(비로그인은 localStorage). **로그인 선택제 — 비로그인도 전 기능 사용.** **Phase F-1 완료(인증+유저저장+프론트).** 후속: 실제 배포, PWA(저비용), F-2 KIS.
+  - [x] **관심종목(watchlist) 프론트 UI** (2026-06-09): `/me/watchlist` 연결 — useWatchlist hook(낙관적 토글) + ⭐ 토글(기술탭) + 홈 관심종목 칩(→/technical?ticker=). 로그인 시에만. 후속: 실제 배포, PWA, F-2 KIS.
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)

--- a/ETF_RAG/frontend/src/app/page.tsx
+++ b/ETF_RAG/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/auth";
 import MessageList from "@/components/MessageList";
 import ChatInput from "@/components/ChatInput";
+import WatchlistBar from "@/components/WatchlistBar";
 
 const STORAGE_KEY = "etfrag.messages.v1";
 
@@ -258,6 +259,10 @@ export default function Home() {
           </button>
         )}
       </header>
+
+      <div className="pt-3">
+        <WatchlistBar />
+      </div>
 
       <div ref={scrollRef} className="flex-1 overflow-y-auto py-4">
         {messages.length === 0 ? (

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { getTechnical } from "@/lib/api";
 import type { TechnicalResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
+import WatchlistStar from "@/components/WatchlistStar";
 
 const PERIODS: { label: string; days: number }[] = [
   { label: "6개월", days: 120 },
@@ -46,6 +47,16 @@ export default function TechnicalPage() {
     setSelected(sel);
     run(sel.ticker, days);
   };
+
+  // 관심종목 칩 등에서 /technical?ticker=005930 로 진입 시 자동 조회 (mount 1회)
+  useEffect(() => {
+    const t = new URLSearchParams(window.location.search).get("ticker");
+    if (t) {
+      setSelected({ name: t, ticker: t });
+      run(t, 120);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onPeriod = (d: number) => {
     setDays(d);
@@ -93,9 +104,10 @@ export default function TechnicalPage() {
 
       {data && !loading && (
         <div className="mt-5">
-          <div className="mb-3 flex items-baseline gap-2">
+          <div className="mb-3 flex items-center gap-2">
             <h2 className="text-base font-semibold">{data.name}</h2>
             <span className="text-xs text-gray-400">{data.ticker}</span>
+            <WatchlistStar ticker={data.ticker} />
           </div>
 
           {/* 핵심 지표 */}

--- a/ETF_RAG/frontend/src/components/WatchlistBar.tsx
+++ b/ETF_RAG/frontend/src/components/WatchlistBar.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Link from "next/link";
+import { useWatchlist } from "@/lib/useWatchlist";
+
+/** 로그인 사용자의 관심종목 칩 목록. 클릭 시 기술적 분석 탭으로. 비어있거나 비로그인이면 숨김. */
+export default function WatchlistBar() {
+  const { enabled, tickers } = useWatchlist();
+  if (!enabled || tickers.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-gray-100 pb-3">
+      <span className="text-xs text-gray-500">⭐ 관심종목</span>
+      {tickers.map((t) => (
+        <Link
+          key={t}
+          href={`/technical?ticker=${encodeURIComponent(t)}`}
+          className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-700 hover:bg-gray-100"
+        >
+          {t}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/components/WatchlistStar.tsx
+++ b/ETF_RAG/frontend/src/components/WatchlistStar.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useWatchlist } from "@/lib/useWatchlist";
+
+/** 종목 관심 토글 버튼(⭐). 로그인 시에만 표시. */
+export default function WatchlistStar({
+  ticker,
+  name,
+}: {
+  ticker: string;
+  name?: string;
+}) {
+  const { enabled, has, toggle } = useWatchlist();
+  if (!enabled) return null;
+
+  const active = has(ticker);
+  return (
+    <button
+      type="button"
+      onClick={() => toggle(ticker)}
+      title={active ? "관심종목에서 제거" : "관심종목에 추가"}
+      aria-label={active ? "관심종목 제거" : "관심종목 추가"}
+      className="shrink-0 rounded-lg px-2 py-1 text-base hover:bg-gray-100"
+    >
+      <span className={active ? "" : "opacity-30"}>
+        {active ? "⭐" : "☆"}
+      </span>
+      {name ? <span className="ml-1 text-xs text-gray-400">{name}</span> : null}
+    </button>
+  );
+}

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -105,3 +105,34 @@ export async function clearServerHistory(): Promise<void> {
 export function toServerMessages(items: ChatHistoryItem[]): ServerChatMessage[] {
   return items.map((m) => ({ role: m.role, content: m.content }));
 }
+
+// ── 관심종목 (로그인 시) ─────────────────────────────────
+export async function getWatchlist(): Promise<string[]> {
+  const res = await fetch(`${API_BASE}/me/watchlist`, {
+    headers: authHeader(),
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.tickers ?? []) as string[];
+}
+
+export async function addWatchlist(ticker: string): Promise<string[]> {
+  const res = await fetch(`${API_BASE}/me/watchlist/${ticker}`, {
+    method: "PUT",
+    headers: authHeader(),
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.tickers ?? []) as string[];
+}
+
+export async function removeWatchlist(ticker: string): Promise<string[]> {
+  const res = await fetch(`${API_BASE}/me/watchlist/${ticker}`, {
+    method: "DELETE",
+    headers: authHeader(),
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.tickers ?? []) as string[];
+}

--- a/ETF_RAG/frontend/src/lib/useWatchlist.ts
+++ b/ETF_RAG/frontend/src/lib/useWatchlist.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "./AuthContext";
+import { addWatchlist, getWatchlist, removeWatchlist } from "./auth";
+
+/** 관심종목 상태 + 토글. 로그인 시에만 동작(비로그인은 빈 set + enabled=false). */
+export function useWatchlist() {
+  const { user } = useAuth();
+  const [tickers, setTickers] = useState<Set<string>>(new Set());
+
+  // 로그인 변화 시 서버에서 로드
+  useEffect(() => {
+    if (!user) {
+      setTickers(new Set());
+      return;
+    }
+    let cancelled = false;
+    getWatchlist().then((list) => {
+      if (!cancelled) setTickers(new Set(list));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const has = useCallback((t: string) => tickers.has(t), [tickers]);
+
+  const toggle = useCallback(
+    async (ticker: string) => {
+      if (!user) return;
+      const adding = !tickers.has(ticker);
+      // 낙관적 업데이트
+      setTickers((prev) => {
+        const next = new Set(prev);
+        if (adding) next.add(ticker);
+        else next.delete(ticker);
+        return next;
+      });
+      // 서버 반영 → 정본으로 동기화 (실패 시 서버 응답으로 보정)
+      const server = adding ? await addWatchlist(ticker) : await removeWatchlist(ticker);
+      setTickers(new Set(server));
+    },
+    [user, tickers],
+  );
+
+  return {
+    enabled: !!user,
+    tickers: Array.from(tickers),
+    has,
+    toggle,
+  };
+}


### PR DESCRIPTION
## Context

백엔드 `/me/watchlist`(PUT/GET/DELETE, F-1 B에서 준비)를 프론트에 연결. 로그인 시에만 동작.

## 변경 (frontend/src)

- **lib/auth.ts**: getWatchlist/addWatchlist/removeWatchlist.
- **lib/useWatchlist.ts**: 로그인 시 서버 로드 + 낙관적 토글(서버 응답으로 보정).
- **WatchlistStar**: ⭐ 토글 — 기술적 분석 탭 종목명 옆.
- **WatchlistBar**: 채팅 홈 상단 관심종목 칩 → 클릭 시 `/technical?ticker=`.
- **technical/page**: `?ticker=` 쿼리 진입 시 자동 조회.

## 검증

- `npm run build` 통과(10라우트)
- e2e: PUT 005930 → PUT 000660 → DELETE 005930 → `['000660']` 정상.

## 다음

실제 배포, PWA, F-2 KIS. (다른 탭 ⭐는 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)