### PR TITLE
방문자 카운터 (Supabase) — 백엔드 엔드포인트 + 사이드바

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2164,6 +2164,8 @@ DEPLOY.md 기반으로 사용자가 직접 Railway에 배포(클로드는 단계
 
 **[완료] 기간 선택 보강 (2026-06-10):** 기술 탭 10년(2500일) 옵션 추가 + 비교 탭 기간 선택(6개월~10년) 신설(`days` state→`postComparison(tickers, days)`, 종목 둘 다 선택 시 기간 변경 재조회). 백엔드 technical/comparison 모두 `days` le=2500 이미 허용.
 
+**[완료] 방문자 카운터 (2026-06-10):** 기존 `src/data/visitor.py`(Supabase REST, Streamlit과 공유)를 백엔드에서 재사용 → `POST/GET /stats/visit`(VisitorResponse{daily,total}, record_visit/get_visitor_counts를 threadpool 실행). 프론트 `getVisitor(record)` + Sidebar 표시(👤 오늘/누적, total>0일 때만). **세션당 1회만 POST**(sessionStorage `etfrag.visited`), 이후 GET. Supabase 미설정 시 (0,0)→숨김. SUPABASE_URL/KEY를 .env.example + DEPLOY.md에 추가(Railway 백엔드 env 등록 필요). 테스트 +2(test_api.py).
+
 **참고**: Streamlit 전수 인벤토리는 이 세션 탐색 결과(167개).
 
 ### 다음

--- a/ETF_RAG/.env.example
+++ b/ETF_RAG/.env.example
@@ -27,3 +27,9 @@ JWT_EXPIRE_MINUTES=10080
 # --- CORS (프로덕션) ---
 # 프론트 배포 origin. 미설정 시 "*"(dev). 예: https://your-frontend.up.railway.app
 # CORS_ORIGINS=https://your-frontend.example.com
+
+# --- 방문자 카운터 (Supabase, 선택) ---
+# 미설정 시 카운터는 (0,0) 반환하고 사이드바에 숨겨짐(graceful degradation).
+# Streamlit과 동일한 visitor_stats 테이블 공유. 백엔드(FastAPI)가 REST로 직접 호출.
+# SUPABASE_URL=https://xxxx.supabase.co
+# SUPABASE_KEY=your-anon-key

--- a/ETF_RAG/DEPLOY.md
+++ b/ETF_RAG/DEPLOY.md
@@ -32,6 +32,7 @@ HTTP로만 결합된 **독립 2서비스**다. 기존 Streamlit 앱은 그대로
    - `CORS_ORIGINS` = 프론트 URL (2단계 후 설정 — 처음엔 비워두면 `*`)
    - **`DATABASE_URL`** = `postgresql://user:pass@host:5432/db` (인증/유저 DB — Railway Postgres 플러그인 추가 후 제공되는 URL). 미설정 시 로컬 sqlite(컨테이너 휘발 → 재시작 시 유저 데이터 소실, 프로덕션 비권장).
    - **`JWT_SECRET`** (필수) = 랜덤 긴 문자열. 미설정 시 dev 기본값 + 경고. `JWT_EXPIRE_MINUTES`(선택, 기본 7일).
+   - 선택: `SUPABASE_URL` + `SUPABASE_KEY` (방문자 카운터 — 미설정 시 카운터 숨김). Streamlit과 같은 `visitor_stats` 테이블 공유.
    - 선택: `COHERE_API_KEY`, `DART_API_KEY`, `LANGCHAIN_*`, `VECTOR_DB_BACKEND`, `PINECONE_*`
    - `PORT` — Railway가 자동 주입 (Dockerfile CMD가 `${PORT}` 확장).
    - 인증 테이블은 부팅 시 `init_models()`가 자동 생성(create_all). 마이그레이션 도구(Alembic)는 후속.

--- a/ETF_RAG/api/main.py
+++ b/ETF_RAG/api/main.py
@@ -26,6 +26,7 @@ from sse_starlette.sse import EventSourceResponse
 from starlette.concurrency import iterate_in_threadpool
 
 from src.llm.agent import run_agent, stream_agent
+from src.data.visitor import record_visit, get_visitor_counts
 
 from typing import Optional
 
@@ -33,7 +34,13 @@ from fastapi import Depends
 
 from api.deps import AppState, run_init
 from api.db import init_models
-from api.models import ChatRequest, ChatResponse, FeedbackRequest, HealthResponse
+from api.models import (
+    ChatRequest,
+    ChatResponse,
+    FeedbackRequest,
+    HealthResponse,
+    VisitorResponse,
+)
 from api.tabs import router as tabs_router
 from api.auth import router as auth_router, get_current_user_optional
 from api.user_data import router as user_data_router
@@ -97,6 +104,23 @@ def _require_ready() -> None:
 async def health() -> HealthResponse:
     state: AppState = app.state.app_state
     return HealthResponse(ready=state.ready, error=state.error)
+
+
+@app.post("/stats/visit", response_model=VisitorResponse)
+async def visit() -> VisitorResponse:
+    """방문 1회 기록 + (당일, 누적) 반환. Supabase 미설정/오류 시 (0,0).
+
+    프론트가 앱 마운트 시 1회 호출. record_visit이 requests 동기 I/O라 threadpool 실행.
+    """
+    daily, total = await run_in_threadpool(record_visit)
+    return VisitorResponse(daily=daily, total=total)
+
+
+@app.get("/stats/visit", response_model=VisitorResponse)
+async def visit_read() -> VisitorResponse:
+    """방문자 수 조회만 (기록 없이)."""
+    daily, total = await run_in_threadpool(get_visitor_counts)
+    return VisitorResponse(daily=daily, total=total)
 
 
 @app.post("/chat", response_model=ChatResponse)

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -32,6 +32,12 @@ class TickerSearchResponse(BaseModel):
     options: List[str]
 
 
+class VisitorResponse(BaseModel):
+    """방문자 카운터 (당일/누적). Supabase 미설정 시 둘 다 0."""
+    daily: int
+    total: int
+
+
 class ComparisonRequest(BaseModel):
     tickers: List[str] = Field(..., min_length=2, max_length=2)
     days: int = Field(120, ge=20, le=2500)

--- a/ETF_RAG/frontend/src/components/Sidebar.tsx
+++ b/ETF_RAG/frontend/src/components/Sidebar.tsx
@@ -2,8 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getOverview } from "@/lib/api";
-import type { InstrumentItem, OverviewResponse } from "@/lib/types";
+import { getOverview, getVisitor } from "@/lib/api";
+import type {
+  InstrumentItem,
+  OverviewResponse,
+  VisitorResponse,
+} from "@/lib/types";
 
 function fmtDate(s: string | null): string {
   if (!s) return "-";
@@ -51,11 +55,18 @@ function ItemRow({
 export default function Sidebar() {
   const router = useRouter();
   const [data, setData] = useState<OverviewResponse | null>(null);
+  const [visitor, setVisitor] = useState<VisitorResponse | null>(null);
   const [tab, setTab] = useState<"etf" | "stock">("etf");
   const [q, setQ] = useState("");
 
   useEffect(() => {
     getOverview(20).then(setData);
+    // 방문은 브라우저 세션당 1회만 기록(POST), 이후 마운트는 조회(GET)
+    const recorded = sessionStorage.getItem("etfrag.visited") === "1";
+    getVisitor(!recorded).then((v) => {
+      if (v) setVisitor(v);
+      if (!recorded) sessionStorage.setItem("etfrag.visited", "1");
+    });
   }, []);
 
   const list = data ? (tab === "etf" ? data.top_etfs : data.top_stocks) : [];
@@ -87,6 +98,12 @@ export default function Sidebar() {
           </>
         ) : (
           <div className="mt-1 text-xs text-gray-400">불러오는 중…</div>
+        )}
+        {visitor && visitor.total > 0 && (
+          <div className="mt-1 text-xs text-gray-400">
+            👤 오늘 <b>{visitor.daily.toLocaleString("ko-KR")}</b> · 누적{" "}
+            <b>{visitor.total.toLocaleString("ko-KR")}</b>
+          </div>
         )}
       </div>
 

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   SectorResponse,
   MoversResponse,
   OverviewResponse,
+  VisitorResponse,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
@@ -232,6 +233,20 @@ export async function getMovers(n = 3): Promise<MoversResponse | null> {
     const res = await fetch(url, { cache: "no-store" });
     if (!res.ok) return null;
     return (await res.json()) as MoversResponse;
+  } catch {
+    return null;
+  }
+}
+
+/** 방문 기록(POST, 세션당 1회) 또는 조회(GET). 실패 시 null. */
+export async function getVisitor(record: boolean): Promise<VisitorResponse | null> {
+  try {
+    const res = await fetch(`${API_BASE}/stats/visit`, {
+      method: record ? "POST" : "GET",
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as VisitorResponse;
   } catch {
     return null;
   }

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -63,6 +63,11 @@ export interface OverviewResponse {
   sectors: string[];
 }
 
+export interface VisitorResponse {
+  daily: number;
+  total: number;
+}
+
 // ── 탭 API ──────────────────────────────────────────────
 /** /tabs/technical 응답 (summary는 복잡 중첩 dict — 느슨한 타입) */
 export interface TechnicalResponse {

--- a/ETF_RAG/tests/test_api.py
+++ b/ETF_RAG/tests/test_api.py
@@ -134,3 +134,23 @@ def test_feedback_negative_with_reason(client):
     # log_feedback(question, answer, tag) — tag에 rating+reason 포함
     tag = m.call_args.args[2]
     assert "negative" in tag and "부정확" in tag
+
+
+def test_visit_records_and_returns_counts(client):
+    """POST /stats/visit이 record_visit 결과를 VisitorResponse로 반환."""
+    with patch("api.main.record_visit", return_value=(3, 42)) as m:
+        r = client.post("/stats/visit")
+    assert r.status_code == 200
+    assert r.json() == {"daily": 3, "total": 42}
+    m.assert_called_once()
+
+
+def test_visit_read_only(client):
+    """GET /stats/visit은 get_visitor_counts만 호출(기록 없이)."""
+    with patch("api.main.get_visitor_counts", return_value=(5, 100)) as m, \
+            patch("api.main.record_visit") as rec:
+        r = client.get("/stats/visit")
+    assert r.status_code == 200
+    assert r.json() == {"daily": 5, "total": 100}
+    m.assert_called_once()
+    rec.assert_not_called()


### PR DESCRIPTION
## 요약
Streamlit ↔ SaaS 2차 대조에서 발견한 갭 — 방문자 카운터.

Streamlit 사이드바엔 "👤 오늘 N · 누적 M"이 있었지만 SaaS엔 없었음. 기존 `src/data/visitor.py`(Supabase REST, Streamlit과 같은 `visitor_stats` 테이블)를 백엔드에서 그대로 재사용.

### 백엔드
- `POST /stats/visit` — 방문 1회 기록 + `{daily, total}` 반환
- `GET /stats/visit` — 조회만 (기록 없이)
- `record_visit`/`get_visitor_counts`를 `run_in_threadpool`로 실행 (requests 동기 I/O)
- Supabase 미설정 시 `(0,0)` graceful degradation
- `VisitorResponse` 모델 + 테스트 2개

### 프론트
- `getVisitor(record)` API 클라이언트
- Sidebar에 "👤 오늘 N · 누적 M" 표시 (`total>0`일 때만 → 미설정 시 자동 숨김)
- **세션당 1회만 POST**(sessionStorage `etfrag.visited`), 이후 마운트는 GET

### 배포
- `SUPABASE_URL`/`SUPABASE_KEY`를 `.env.example` + `DEPLOY.md`에 추가. Railway 백엔드 env에 등록 필요(미등록 시 카운터만 숨겨지고 나머지는 정상).

### 검증
- 백엔드: `pytest tests/test_api.py tests/test_api_tabs.py` 29 passed
- 프론트: `tsc` ✅ / `next build` ✅ / eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)