### PR TITLE
사이드바 업종 필터 (주식 탭)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2166,10 +2166,12 @@ DEPLOY.md 기반으로 사용자가 직접 Railway에 배포(클로드는 단계
 
 **[완료] 방문자 카운터 (2026-06-10):** 기존 `src/data/visitor.py`(Supabase REST, Streamlit과 공유)를 백엔드에서 재사용 → `POST/GET /stats/visit`(VisitorResponse{daily,total}, record_visit/get_visitor_counts를 threadpool 실행). 프론트 `getVisitor(record)` + Sidebar 표시(👤 오늘/누적, total>0일 때만). **세션당 1회만 POST**(sessionStorage `etfrag.visited`), 이후 GET. Supabase 미설정 시 (0,0)→숨김. SUPABASE_URL/KEY를 .env.example + DEPLOY.md에 추가(Railway 백엔드 env 등록 필요). 테스트 +2(test_api.py).
 
+**[완료] 사이드바 업종 필터 (2026-06-10):** 주식 탭에 업종 드롭다운(`data.sectors`) — 선택 시 `/tabs/overview?sector=` 재조회. 백엔드 `_overview_blocking(top, sector)` — sector 지정 시 **전체 종목 목록**에서 해당 업종 거래대금 TOP(top-20 내 필터 아님). ETF/주식 탭 분리는 이미 존재. lint(setState-in-effect) 회피: 동기 reset을 onChange 핸들러로 이동. 테스트 +1(test_api_tabs). → **2차 대조 4건 전부 해소, Streamlit 패리티 완료.**
+
 **참고**: Streamlit 전수 인벤토리는 이 세션 탐색 결과(167개).
 
 ### 다음
-- Streamlit 패리티 마무리. **F-2 KIS**(신분증), **푸시**(VAPID), 유료 전환($5/월~), 블로그 9편.
+- Streamlit 패리티 완료(2026-06-10). **F-2 KIS**(신분증), **푸시**(VAPID), 유료 전환($5/월~), 블로그 9편.
 
 ---
 

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -330,7 +330,7 @@ def _to_instrument(d: dict) -> InstrumentItem:
     )
 
 
-def _overview_blocking(top: int) -> dict:
+def _overview_blocking(top: int, sector: Optional[str] = None) -> dict:
     etf_idx, stock_idx = get_data_indices()
     etfs = _dedup_items(etf_idx)
     stocks = _dedup_items(stock_idx)
@@ -342,8 +342,13 @@ def _overview_blocking(top: int) -> dict:
             as_of = d["date"]
             break
 
+    # 업종 필터 — 지정 시 해당 업종 종목만(전체 목록 기준), 미지정 시 전체에서 거래대금 TOP
+    filtered_stocks = stocks
+    if sector:
+        filtered_stocks = [d for d in stocks if d.get("sector") == sector]
+
     top_etfs = sorted(etfs, key=lambda x: x.get("trade_value", 0) or 0, reverse=True)[:top]
-    top_stocks = sorted(stocks, key=lambda x: x.get("trade_value", 0) or 0, reverse=True)[:top]
+    top_stocks = sorted(filtered_stocks, key=lambda x: x.get("trade_value", 0) or 0, reverse=True)[:top]
     sectors = sorted({d.get("sector") for d in stocks if d.get("sector")})
 
     return {
@@ -357,6 +362,9 @@ def _overview_blocking(top: int) -> dict:
 
 
 @router.get("/overview", response_model=OverviewResponse)
-async def overview(top: int = Query(20, ge=1, le=50)):
-    result = await run_in_threadpool(_overview_blocking, top)
+async def overview(
+    top: int = Query(20, ge=1, le=50),
+    sector: Optional[str] = Query(None),
+):
+    result = await run_in_threadpool(_overview_blocking, top, sector)
     return OverviewResponse(**result)

--- a/ETF_RAG/frontend/src/components/Sidebar.tsx
+++ b/ETF_RAG/frontend/src/components/Sidebar.tsx
@@ -58,6 +58,8 @@ export default function Sidebar() {
   const [visitor, setVisitor] = useState<VisitorResponse | null>(null);
   const [tab, setTab] = useState<"etf" | "stock">("etf");
   const [q, setQ] = useState("");
+  const [sector, setSector] = useState(""); // "" = 전체
+  const [sectorStocks, setSectorStocks] = useState<InstrumentItem[] | null>(null);
 
   useEffect(() => {
     getOverview(20).then(setData);
@@ -69,7 +71,25 @@ export default function Sidebar() {
     });
   }, []);
 
-  const list = data ? (tab === "etf" ? data.top_etfs : data.top_stocks) : [];
+  // 업종 선택 시 해당 업종 종목 재조회(전체 목록 기준 거래대금 TOP). 전체면 기본 목록 사용.
+  useEffect(() => {
+    if (!sector) return;
+    let alive = true;
+    getOverview(20, sector).then((r) => {
+      if (alive) setSectorStocks(r ? r.top_stocks : []);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [sector]);
+
+  const onSectorChange = (s: string) => {
+    setSector(s);
+    setSectorStocks(null); // 새 선택 로딩 표시(전체면 그대로 null → 기본 목록 사용)
+  };
+
+  const stockList = sector ? sectorStocks ?? [] : data?.top_stocks ?? [];
+  const list = data ? (tab === "etf" ? data.top_etfs : stockList) : [];
   const filtered = useMemo(() => {
     const ql = q.trim().toLowerCase();
     if (!ql) return list;
@@ -124,6 +144,22 @@ export default function Sidebar() {
         ))}
       </div>
 
+      {/* 업종 필터 (주식 탭에서만) */}
+      {tab === "stock" && data && data.sectors.length > 0 && (
+        <select
+          value={sector}
+          onChange={(e) => onSectorChange(e.target.value)}
+          className="mb-2 w-full rounded-lg border border-gray-300 px-2 py-1.5 text-xs focus:border-blue-500 focus:outline-none"
+        >
+          <option value="">전체 업종</option>
+          {data.sectors.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      )}
+
       {/* 검색 */}
       <input
         value={q}
@@ -136,7 +172,9 @@ export default function Sidebar() {
       <div className="space-y-0.5">
         {filtered.length === 0 ? (
           <div className="px-2 py-3 text-center text-xs text-gray-400">
-            {data ? "결과 없음" : "…"}
+            {!data || (tab === "stock" && sector && sectorStocks === null)
+              ? "…"
+              : "결과 없음"}
           </div>
         ) : (
           filtered.map((it) => <ItemRow key={it.ticker} it={it} onClick={() => go(it)} />)

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -212,10 +212,14 @@ export async function getSector(
   return (await res.json()) as SectorResponse;
 }
 
-/** 사이드바 개요 — 데이터 현황 + ETF/주식 TOP. 실패 시 null. */
-export async function getOverview(top = 20): Promise<OverviewResponse | null> {
+/** 사이드바 개요 — 데이터 현황 + ETF/주식 TOP. sector 지정 시 해당 업종 종목만. 실패 시 null. */
+export async function getOverview(
+  top = 20,
+  sector?: string,
+): Promise<OverviewResponse | null> {
   const url = new URL(`${API_BASE}/tabs/overview`);
   url.searchParams.set("top", String(top));
+  if (sector) url.searchParams.set("sector", sector);
   try {
     const res = await fetch(url, { cache: "no-store" });
     if (!res.ok) return null;

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -251,6 +251,23 @@ def test_overview(client):
     assert "전기·전자" in b["sectors"]
 
 
+def test_overview_sector_filter(client):
+    """sector 지정 시 해당 업종 종목만 top_stocks에 포함."""
+    etf_idx = {}
+    stock_idx = {
+        "005930": {"name": "삼성전자", "ticker": "005930", "close": 70000, "change_pct": -0.5, "trade_value": 5e11, "sector": "전기·전자", "date": "20260609"},
+        "035720": {"name": "카카오", "ticker": "035720", "close": 50000, "change_pct": 1.0, "trade_value": 3e11, "sector": "서비스업", "date": "20260609"},
+    }
+    with patch("api.tabs.get_data_indices", return_value=(etf_idx, stock_idx)):
+        r = client.get("/tabs/overview", params={"top": 20, "sector": "서비스업"})
+    assert r.status_code == 200
+    b = r.json()
+    # 서비스업만 — 카카오 1종목
+    assert [s["ticker"] for s in b["top_stocks"]] == ["035720"]
+    # sectors는 항상 전체 업종(필터와 무관)
+    assert set(b["sectors"]) == {"전기·전자", "서비스업"}
+
+
 # ── 가드 ───────────────────────────────────────────────────────────
 def test_tabs_require_ready_503(client):
     # ready=False면 503 (require_ready 의존성)


### PR DESCRIPTION
## 요약
Streamlit ↔ SaaS 2차 대조 마지막 갭 — 사이드바 주식 탭의 업종(sector) 필터.

ETF/주식 탭 분리는 이미 있었지만, Streamlit에 있던 **업종 필터 드롭다운**이 SaaS엔 없었음.

### 백엔드
- `/tabs/overview`에 `sector` 쿼리 파라미터 추가
- sector 지정 시 **전체 종목 목록**에서 해당 업종 거래대금 TOP을 반환 (top-20 안에서만 거르는 게 아니라 전체 기준 → 업종별 실제 상위 종목이 나옴)
- 미지정 시 기존 동작 그대로. 테스트 +1

### 프론트
- 주식 탭에 업종 `<select>` (옵션 = `data.sectors`)
- 선택 시 `getOverview(20, sector)` 재조회 + 로딩("…") 표시
- `setState-in-effect` eslint 규칙 회피: 동기 reset을 onChange 핸들러로 이동

→ 2차 대조 4건(방문자 카운터/비교 기간/기술 10년/업종 필터) 전부 해소. **Streamlit 패리티 완료.**

### 검증
- 백엔드: `pytest tests/test_api_tabs.py` 20 passed
- 프론트: `tsc` ✅ / `next build` ✅ / eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)