### PR TITLE
docs: Streamlit 패리티 완료 + 방문자 카운터 라이브 + KIS 계좌 기록

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2168,12 +2168,16 @@ DEPLOY.md 기반으로 사용자가 직접 Railway에 배포(클로드는 단계
 
 **[완료] 사이드바 업종 필터 (2026-06-10):** 주식 탭에 업종 드롭다운(`data.sectors`) — 선택 시 `/tabs/overview?sector=` 재조회. 백엔드 `_overview_blocking(top, sector)` — sector 지정 시 **전체 종목 목록**에서 해당 업종 거래대금 TOP(top-20 내 필터 아님). ETF/주식 탭 분리는 이미 존재. lint(setState-in-effect) 회피: 동기 reset을 onChange 핸들러로 이동. 테스트 +1(test_api_tabs). → **2차 대조 4건 전부 해소, Streamlit 패리티 완료.**
 
+**[완료] 방문자 카운터 라이브 검증 (2026-06-10):** Railway 백엔드(AI_agent 서비스, `aiagent-production-75ca`) Variables에 SUPABASE_URL/KEY 등록 → Deploy → `GET /stats/visit` = `{"daily":16,"total":148}` 확인(Supabase 연결 성공). **함정**: ①변수 추가만으론 미적용 — "Apply changes → Deploy" 눌러야 재배포됨(누르기 전엔 구버전이라 0,0). ②Railway Raw Editor의 ENV 형식은 값의 `"..."`를 자동 strip하므로 따옴표 둬도 무방(기존 OPENAI_API_KEY도 동일). Supabase 키는 `sb_publishable_...`(anon/공개키).
+
+**[KIS 계좌 개설] (2026-06-10):** 한국투자증권 **계좌 개설 완료**. 다음 단계 = KIS Developers 앱 등록 → appkey/appsecret 발급 → F-2 실시간 시세 연동. (메모리: project_ai_agent_saas_roadmap.md의 KIS 항목 참조)
+
 **참고**: Streamlit 전수 인벤토리는 이 세션 탐색 결과(167개).
 
 ### 다음
-- Streamlit 패리티 완료(2026-06-10). **F-2 KIS**(신분증), **푸시**(VAPID), 유료 전환($5/월~), 블로그 9편.
+- **F-2 KIS 실시간** 착수 가능(계좌 개설 완료 2026-06-10) → KIS Developers 앱 등록·API 키 발급부터. **푸시**(VAPID), 유료 전환($5/월~), 블로그 9편.
 
 ---
 
-_Last Updated: 2026-06-10 (Streamlit 패리티 보강 완료: 채팅 + 사이드바 + 기술탭(11지표/크로스/장중차트) + 비교탭(returns 버그수정/5기간 수익률/분기실적) + 재무탭(1~5년 기간) + 전망탭(Prophet/통계 축 렌더 버그수정) + 5탭 데이터범위 안내문. 라이브 운영 중. Streamlit 병행. 다음: F-2 KIS/푸시/유료전환)_
+_Last Updated: 2026-06-10 (Streamlit↔SaaS 패리티 완료 PR #42~48: 비교/재무/전망/데이터범위안내/기술10년/방문자카운터(라이브검증 누적148)/업종필터. KIS 계좌 개설 완료→F-2 착수 가능. 라이브 운영 중, Streamlit 병행. 다음: KIS API키 발급→실시간시세, 푸시, 유료전환)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,7 +77,8 @@
 - [x] 데이터 정합성 검증 로직 — validate_result() 구현 완료
 
 **1-3. 한국투자증권 OpenAPI 연동**
-- [ ] KIS Developers 계좌 개설 + API 키 발급
+- [x] 한국투자증권 계좌 개설 (2026-06-10) — KIS Developers API 키 발급은 다음 단계
+- [ ] KIS Developers 앱 등록 + API 키(appkey/appsecret) 발급
 - [ ] 실시간 시세 조회 연동 (REST, 추후 WebSocket)
 - [ ] 에러 핸들링 패턴 적용 (timeout, retry, rate limit)
 
@@ -269,7 +270,8 @@
   - [x] **🚀 실제 Railway 배포 성공** (2026-06-09): 2서비스(백엔드 ETF_RAG/ + 프론트 ETF_RAG/frontend/) Dockerfile 배포. env: 백엔드 OPENAI_API_KEY/JWT_SECRET/CORS_ORIGINS, 프론트 NEXT_PUBLIC_API_BASE(빌드ARG). **실제 동작 확인(채팅·탭).** 배포 함정: ①fc-cache not found→fontconfig 추가(#37) ②프론트 Railway가 $PORT=8080 주입→Next standalone이 8080 listen→도메인 포트도 8080으로 맞춤(3000 아님). 무료 trial $5/30일(이후 Hobby $5/월~). 후속: F-2 KIS(신분증), 푸시, 도메인.
   - [x] **채팅 패리티 보강** (2026-06-10): Streamlit 대비 누락분 일부 — 동적 추천질문(`/tabs/movers` 급등/급락/거래대금) + 피드백(`/feedback` 익명/로그인) + 에러 재시도 버튼.
   - [x] **사이드바 신설** (2026-06-10): `/tabs/overview`(데이터현황+ETF/주식 거래대금TOP+섹터) + Sidebar(데스크톱 좌측, 종목검색, 클릭→기술분석).
-  - [x] **기술 분석 탭 보강** (2026-06-10): `/tabs/intraday`(장중 15분봉) + 11개 지표 전부(스토캐스틱/일목/CCI/ADX/OBV/ATR) + 골든/데드크로스. **남은 격차(비교/재무 탭)는 CLAUDE.local.md "기능 격차 체크리스트" 참조.**
+  - [x] **기술 분석 탭 보강** (2026-06-10): `/tabs/intraday`(장중 15분봉) + 11개 지표 전부(스토캐스틱/일목/CCI/ADX/OBV/ATR) + 골든/데드크로스.
+  - [x] **🎯 Streamlit ↔ SaaS 기능 패리티 완료** (2026-06-10): PR #42~#48 (7개). 비교탭(returns 버그수정/5기간 수익률/분기실적/기간선택) + 재무탭(1~5년 기간) + 전망탭(Prophet·통계 축 렌더 버그수정) + 5탭 데이터범위 안내문 + 기술탭 10년 + **방문자 카운터**(`/stats/visit` Supabase, Railway 백엔드 env 등록·라이브 검증 완료 누적 148) + 사이드바 업종 필터. 2회 Explore 대조로 누락분 색출. **상세는 CLAUDE.local.md "SaaS ↔ Streamlit 격차 체크리스트".**
 - [ ] **Phase G: 모바일 앱** — React Native (웹 70% 재사용), 푸시 알림, 오프라인 캐시
 - [ ] 한국어 임베딩 모델 비교 (BGE-M3 vs text-embedding-3-small, 검색 품질 불만 시)
 - [ ] KRX 시세정보 재배포 라이선스 검토 (상용화 시 필수)


### PR DESCRIPTION
문서만 변경 (CLAUDE.md / CLAUDE.local.md).

- Streamlit ↔ SaaS 패리티 완료(PR #42~#48) 기록
- 방문자 카운터 Railway 라이브 검증(누적 148) + 등록 함정 2건
- 한국투자증권 계좌 개설(2026-06-10) → F-2 착수 가능, 다음 단계 메모

🤖 Generated with [Claude Code](https://claude.com/claude-code)