### PR TITLE
F-2: KIS Open API 실시간 현재가 연동 (REST)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2179,5 +2179,46 @@ DEPLOY.md 기반으로 사용자가 직접 Railway에 배포(클로드는 단계
 
 ---
 
-_Last Updated: 2026-06-10 (Streamlit↔SaaS 패리티 완료 PR #42~48: 비교/재무/전망/데이터범위안내/기술10년/방문자카운터(라이브검증 누적148)/업종필터. KIS 계좌 개설 완료→F-2 착수 가능. 라이브 운영 중, Streamlit 병행. 다음: KIS API키 발급→실시간시세, 푸시, 유료전환)_
+## Phase F-2: KIS Open API 실시간 현재가 연동 (REST) (2026-06-12, PR #50)
+
+계좌 개설(6-10)에 이어 사용자가 **KIS Developers 앱 등록 + API 키 발급 완료**(`.env`에 KIS_APP_KEY/SECRET/ACCOUNT_NO/ENV 설정됨). 이번엔 **REST 현재가 + 코드/테스트만** (WebSocket·호가·체결은 후속, 프론트 노출/Railway env 등록도 후속).
+
+### 설계: KIS 우선 → yfinance fallback
+- 기존 `realtime.py`는 yfinance(15분 지연)뿐 → KIS(실시간)를 우선 시도, 비활성/실패 시 yfinance로 자동 fallback. **realtime 표준 스키마**(price/prev_close/change/change_pct/volume/timestamp/source) 그대로 반환해 상위 코드(도구·UI) 변경 최소화.
+- 활성 조건: `KIS_APP_KEY` + `KIS_APP_SECRET` 둘 다 존재(`config.KIS["enabled"]`). 미설정 시 아무 동작 변화 없음(yfinance 그대로).
+
+### 신규/변경
+- **config.py**: `KIS` dict — enabled(키 2종 존재), app_key/secret, env(real|vps), **base_url 자동 선택**(real=openapi:9443 / vps=openapivts:29443), timeout 5s, token_margin 600s. `.env.example`에 KIS 4종 안내.
+- **src/data/kis_client.py**(신규):
+  - `_get_access_token(force)`: OAuth2 `/oauth2/tokenP`(grant_type=client_credentials). **인메모리+디스크 캐시**(`~/.cache/etf_rag/kis_token.json`) + margin 안이면 선제 갱신. **KIS 토큰 재발급 분당 1회 제한**을 디스크 캐시로 회피(프로세스 재시작·멀티프로세스 생존). threading.Lock.
+  - `get_current_price(ticker, cache_ttl)`: `GET /uapi/domestic-stock/v1/quotations/inquire-price`, **tr_id=FHKST01010100**, headers(authorization Bearer/appkey/appsecret/tr_id), params(fid_cond_mrkt_div_code=**J**, fid_input_iscd=티커). rt_cd!="0"이거나 HTTP 오류면 None. 5분 인메모리 캐시.
+  - `_parse_price_output()`: stck_prpr(현재가)/stck_sdpr(전일종가)/prdy_vrss(전일대비)/prdy_ctrt(등락률)/acml_vol(거래량). **prdy_vrss_sign 4(하한)·5(하락)이면 change/change_pct 음수 보정**.
+  - `is_enabled()`, `clear_cache()`.
+- **src/data/realtime.py**: `get_realtime_price`에 KIS 우선 분기 추가(`kis_client.is_enabled()` → `get_current_price()` 성공 시 반환, 실패 시 아래 yfinance로).
+- **src/llm/tools/analysis.py**: 출처 표기 source 분기 — "한국투자증권 실시간 시세" / "yfinance 15분 지연 데이터".
+
+### ⚠️ 함정 (이번에 실제로 부딪힘)
+- **기존 test_realtime.py가 라이브 KIS 호출**: yfinance만 mock하고 KIS는 안 막아서, 실 `.env`에 KIS 키가 있으니 `is_enabled()`=True → 테스트가 진짜 KIS API를 때림(price 134595 같은 실값 반환 → mock 기대값과 불일치로 4개 실패). **수정**: yfinance 전용 테스트 4개에 `patch("src.data.kis_client.is_enabled", return_value=False)` 추가 → 라이브 호출 차단 + 의도(yfinance 경로) 명확화.
+- KIS는 **6자리 종목코드만**(시장구분 J로 ETF/주식/ETN 공통) — yfinance의 .KS/.KQ 변환 불필요.
+
+### 테스트 (tests/test_kis_client.py, 22개)
+- 활성화 2 / 토큰(발급·인메모리캐시·만료재발급·디스크생존·post오류·필드누락) 7 / 파싱(상승·하락부호·0가·누락) 4 / 현재가(비활성·성공+tr_id검증·캐시히트·rt_cd오류·HTTP오류·토큰실패) 7 / realtime 통합(KIS우선·yfinance fallback·KIS비활성) 3.
+- autouse fixture로 디스크 토큰 캐시를 tmp_path로 격리(테스트 간 누수 방지).
+- 전체 **671 pass**(로컬 fastapi 미설치로 test_api/api_tabs/auth/user_data 4파일 제외 — CI는 전체 실행).
+
+### 라이브 검증 (2026-06-12 장중, 실 .env 키)
+- `_get_access_token()` 토큰 발급 OK(디스크 캐시 파일 생성 확인).
+- 삼성전자(005930)·KODEX 200(069500) `get_current_price()` 실시간 현재가 정상(source=kis).
+- LangGraph `get_realtime_price` 도구 end-to-end → "한국투자증권 실시간 시세" 출력.
+
+### 커밋 (브랜치 phase-f2-kis-realtime, main에서 분기, 2개)
+- `feat(kis)`: KIS 현재가 REST 클라이언트 + config / `feat(kis)`: realtime KIS 우선→yfinance fallback + 테스트 22개.
+
+### 다음
+- **배포 시**: Railway 백엔드 env에 KIS_APP_KEY/SECRET/ENV 등록(선택 — 미등록 시 yfinance fallback, 디스크 토큰 캐시는 컨테이너 재시작 시 사라지나 24h 유효라 재발급 부담 적음).
+- **후속 코드**: WebSocket 실시간 스트리밍(체결 구독·토큰 자동 갱신), 호가 10단계, 프론트/사이드바 KIS 시세 노출. **F-3 KoELECTRA 감성**, 푸시(VAPID), 유료 전환.
+
+---
+
+_Last Updated: 2026-06-12 (Phase F-2 KIS 실시간 현재가 REST 연동 PR #50: kis_client.py OAuth 토큰 캐시+FHKST01010100 현재가, realtime KIS 우선→yfinance fallback, 테스트 22개(전체 671), 장중 라이브 검증. 다음: WebSocket·호가, Railway KIS env, 푸시, 유료전환)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,10 +77,10 @@
 - [x] 데이터 정합성 검증 로직 — validate_result() 구현 완료
 
 **1-3. 한국투자증권 OpenAPI 연동**
-- [x] 한국투자증권 계좌 개설 (2026-06-10) — KIS Developers API 키 발급은 다음 단계
-- [ ] KIS Developers 앱 등록 + API 키(appkey/appsecret) 발급
-- [ ] 실시간 시세 조회 연동 (REST, 추후 WebSocket)
-- [ ] 에러 핸들링 패턴 적용 (timeout, retry, rate limit)
+- [x] 한국투자증권 계좌 개설 (2026-06-10)
+- [x] KIS Developers 앱 등록 + API 키(appkey/appsecret) 발급
+- [x] 실시간 시세 조회 연동 (REST, PR #50) — `src/data/kis_client.py` 현재가(FHKST01010100), realtime.py가 KIS 우선→yfinance fallback. 추후 WebSocket
+- [x] 에러 핸들링 패턴 적용 (timeout, OAuth 토큰 디스크 캐시/재발급 분당 1회 제한 회피, rt_cd/HTTP 오류 시 None→fallback)
 
 **1-4. 수집 자동화** ✅ 완료
 - [x] 일배치 셸 스크립트 (`scripts/daily_collect.sh`) — 수집 + 로깅 + 정리
@@ -528,7 +528,7 @@ ETF_RAG/
 
 ---
 
-_Last Updated: 2026-06-08 (dead code 정리: 깨진 아카이브 스크립트 docs/test_scenarios.py 제거 + calc_ichimoku 중복 라인 정리. bare pytest 수집 복구. 도구 14개, 테스트 649개, eval 172개, Hit Rate 100%, F=0.688, AR=0.709, CR=0.854)_
+_Last Updated: 2026-06-12 (Phase F-2 착수 — KIS Open API 실시간 현재가 REST 연동 PR #50: src/data/kis_client.py(OAuth 토큰 디스크 캐시 + FHKST01010100 현재가), realtime.py KIS 우선→yfinance fallback, 테스트 22개(전체 671), 장중 라이브 검증. 도구 14개, eval 172개, Hit Rate 100%, F=0.688, AR=0.709, CR=0.854. 상세: CLAUDE.local.md "Phase F-2")_
 
 > ✅ **CI 액션 Node 24 대응 완료** (2026-06-08): `checkout@v4→v6`, `setup-python@v5→v6` (ci.yml + daily-collect.yml 4곳). CI green 확인. 2026-06-16 Node 24 강제 전환 대비.
 

--- a/ETF_RAG/.env.example
+++ b/ETF_RAG/.env.example
@@ -33,3 +33,11 @@ JWT_EXPIRE_MINUTES=10080
 # Streamlit과 동일한 visitor_stats 테이블 공유. 백엔드(FastAPI)가 REST로 직접 호출.
 # SUPABASE_URL=https://xxxx.supabase.co
 # SUPABASE_KEY=your-anon-key
+
+# --- 한국투자증권 KIS Open API (F-2 실시간 시세, 선택) ---
+# apiportal.koreainvestment.com → API신청 → 발급. 미설정 시 KIS 연동 비활성(yfinance fallback).
+# KIS_ENV: real(실전) | vps(모의투자). 시세 조회만 하면 real로 충분(주문 권한과 무관).
+# KIS_APP_KEY=your-app-key
+# KIS_APP_SECRET=your-app-secret
+# KIS_ACCOUNT_NO=00000000          # 종합계좌 8자리 (주문 시 필요, 시세 조회엔 불필요)
+# KIS_ENV=real

--- a/ETF_RAG/config.py
+++ b/ETF_RAG/config.py
@@ -121,6 +121,26 @@ REALTIME_PRICE = {
     "enabled": True,            # 기능 활성화 플래그
 }
 
+# 한국투자증권 KIS Open API (F-2 실시간 시세)
+# 키 3종이 모두 설정돼야 활성화. 미설정 시 realtime.py가 yfinance로 fallback.
+# KIS_ENV: real(실전, openapi.koreainvestment.com:9443) | vps(모의, openapivts:29443)
+# 시세 조회만 하므로 real로 충분 (주문 권한과 무관).
+KIS_APP_KEY = os.getenv("KIS_APP_KEY", "")
+KIS_APP_SECRET = os.getenv("KIS_APP_SECRET", "")
+KIS = {
+    "enabled": bool(os.getenv("KIS_APP_KEY") and os.getenv("KIS_APP_SECRET")),
+    "app_key": KIS_APP_KEY,
+    "app_secret": KIS_APP_SECRET,
+    "env": os.getenv("KIS_ENV", "real"),    # real | vps
+    "base_url": (
+        "https://openapivts.koreainvestment.com:29443"
+        if os.getenv("KIS_ENV", "real") == "vps"
+        else "https://openapi.koreainvestment.com:9443"
+    ),
+    "timeout": 5,               # REST 호출 타임아웃 (초)
+    "token_margin": 600,        # 토큰 만료 N초 전 선제 갱신 (10분)
+}
+
 # Vector DB backend: "faiss" (default) or "pinecone"
 VECTOR_DB_BACKEND = os.getenv("VECTOR_DB_BACKEND", "faiss")
 PINECONE_API_KEY = os.getenv("PINECONE_API_KEY", "")

--- a/ETF_RAG/src/data/kis_client.py
+++ b/ETF_RAG/src/data/kis_client.py
@@ -1,0 +1,240 @@
+"""
+한국투자증권(KIS) Open API REST 클라이언트 — 국내 주식/ETF 현재가 조회 (F-2)
+
+- OAuth2 접근토큰 발급/캐싱/자동 갱신 (KIS는 토큰 재발급을 분당 1회로 제한하고
+  유효기간 내 동일 토큰을 재사용하라고 안내 → 디스크 캐시로 프로세스 재시작에도 생존)
+- 국내주식 현재가 시세 (FHKST01010100)
+- 키 미설정 시 비활성 → 호출자(realtime.py)가 yfinance로 fallback
+
+설계: realtime.py와 동일한 dict 스키마({"price","prev_close","change","change_pct",
+"volume","timestamp","source"})를 반환해 상위 코드 변경을 최소화한다.
+"""
+
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+# 토큰 디스크 캐시 (프로세스 재시작/멀티프로세스 간 공유, 재발급 rate-limit 회피)
+_TOKEN_CACHE_PATH = Path.home() / ".cache" / "etf_rag" / "kis_token.json"
+
+# 인메모리 토큰 상태: {"access_token": str, "expires_at": float}
+_token_state: dict = {}
+_token_lock = threading.Lock()
+
+# 현재가 캐시: {ticker: {"data": dict, "fetched_at": float}}
+_price_cache: dict = {}
+
+
+def _kis_config() -> dict:
+    """config.KIS 를 매 호출 시 읽어 테스트에서 patch 가능하게 한다."""
+    from config import KIS
+    return KIS
+
+
+def is_enabled() -> bool:
+    """KIS 연동 활성화 여부 (app_key/secret 모두 존재)."""
+    return bool(_kis_config().get("enabled"))
+
+
+# ── 토큰 발급/캐싱 ────────────────────────────────────────
+
+def _load_cached_token() -> Optional[dict]:
+    """디스크 캐시에서 유효한 토큰 로드 (없거나 만료 시 None)."""
+    try:
+        if not _TOKEN_CACHE_PATH.exists():
+            return None
+        with open(_TOKEN_CACHE_PATH, "r") as f:
+            data = json.load(f)
+        margin = _kis_config().get("token_margin", 600)
+        if data.get("expires_at", 0) - margin > time.time():
+            return data
+    except Exception as e:
+        logger.debug(f"KIS 토큰 캐시 로드 실패: {e}")
+    return None
+
+
+def _save_cached_token(state: dict) -> None:
+    """토큰을 디스크 캐시에 저장 (best-effort)."""
+    try:
+        _TOKEN_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(_TOKEN_CACHE_PATH, "w") as f:
+            json.dump(state, f)
+    except Exception as e:
+        logger.debug(f"KIS 토큰 캐시 저장 실패: {e}")
+
+
+def _get_access_token(force: bool = False) -> Optional[str]:
+    """유효한 접근토큰 반환. 캐시 우선 → 만료/없음이면 신규 발급.
+
+    KIS 토큰은 발급 후 24시간 유효, 재발급은 분당 1회 제한.
+    margin(기본 10분) 안에 들면 선제 갱신한다.
+    """
+    cfg = _kis_config()
+    if not cfg.get("enabled"):
+        return None
+
+    margin = cfg.get("token_margin", 600)
+    now = time.time()
+
+    with _token_lock:
+        # 1) 인메모리 캐시
+        if not force and _token_state.get("access_token") and \
+                _token_state.get("expires_at", 0) - margin > now:
+            return _token_state["access_token"]
+
+        # 2) 디스크 캐시
+        if not force:
+            cached = _load_cached_token()
+            if cached:
+                _token_state.update(cached)
+                return cached["access_token"]
+
+        # 3) 신규 발급
+        import requests
+        url = f"{cfg['base_url']}/oauth2/tokenP"
+        body = {
+            "grant_type": "client_credentials",
+            "appkey": cfg["app_key"],
+            "appsecret": cfg["app_secret"],
+        }
+        try:
+            resp = requests.post(url, json=body, timeout=cfg.get("timeout", 5))
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning(f"KIS 토큰 발급 실패: {e}")
+            return None
+
+        token = data.get("access_token")
+        if not token:
+            logger.warning(f"KIS 토큰 응답에 access_token 없음: {data}")
+            return None
+
+        # expires_in(초) 우선, 없으면 24시간으로 가정
+        expires_in = data.get("expires_in", 86400)
+        try:
+            expires_in = int(expires_in)
+        except (TypeError, ValueError):
+            expires_in = 86400
+
+        state = {"access_token": token, "expires_at": now + expires_in}
+        _token_state.update(state)
+        _save_cached_token(state)
+        return token
+
+
+# ── 현재가 조회 ───────────────────────────────────────────
+
+def _parse_price_output(output: dict) -> Optional[dict]:
+    """KIS inquire-price output → realtime 표준 스키마 변환."""
+    try:
+        price = float(output.get("stck_prpr", 0))  # 주식 현재가
+    except (TypeError, ValueError):
+        return None
+    if price <= 0:
+        return None
+
+    def _to_float(v):
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    def _to_int(v):
+        try:
+            return int(float(v))
+        except (TypeError, ValueError):
+            return None
+
+    prev_close = _to_float(output.get("stck_sdpr"))     # 전일 종가
+    change = _to_float(output.get("prdy_vrss"))         # 전일 대비
+    change_pct = _to_float(output.get("prdy_ctrt"))     # 전일 대비율(%)
+    sign = output.get("prdy_vrss_sign", "")             # 1상한 2상승 3보합 4하한 5하락
+    if change is not None and sign in ("4", "5"):
+        change = -abs(change)
+    if change_pct is not None and sign in ("4", "5"):
+        change_pct = -abs(change_pct)
+
+    return {
+        "price": round(price),
+        "prev_close": round(prev_close) if prev_close else None,
+        "change": round(change) if change is not None else None,
+        "change_pct": round(change_pct, 2) if change_pct is not None else None,
+        "volume": _to_int(output.get("acml_vol")),      # 누적 거래량
+        "timestamp": datetime.now(KST).strftime("%Y-%m-%d %H:%M"),
+        "source": "kis",
+    }
+
+
+def get_current_price(ticker: str, cache_ttl: int = 300) -> Optional[dict]:
+    """국내 주식/ETF 현재가 조회 (FHKST01010100).
+
+    Args:
+        ticker: KRX 6자리 종목코드 (ETF/주식 공통, 시장구분 'J' 사용)
+        cache_ttl: 결과 캐시 TTL(초)
+
+    Returns:
+        성공 시 realtime 표준 dict (source="kis"), 실패/비활성 시 None.
+    """
+    if not is_enabled():
+        return None
+
+    now = time.time()
+    cached = _price_cache.get(ticker)
+    if cached and (now - cached["fetched_at"]) < cache_ttl:
+        return cached["data"]
+
+    token = _get_access_token()
+    if not token:
+        return None
+
+    cfg = _kis_config()
+    import requests
+    url = f"{cfg['base_url']}/uapi/domestic-stock/v1/quotations/inquire-price"
+    headers = {
+        "content-type": "application/json; charset=utf-8",
+        "authorization": f"Bearer {token}",
+        "appkey": cfg["app_key"],
+        "appsecret": cfg["app_secret"],
+        "tr_id": "FHKST01010100",
+    }
+    params = {
+        "fid_cond_mrkt_div_code": "J",   # J: 주식/ETF/ETN
+        "fid_input_iscd": ticker,
+    }
+
+    try:
+        resp = requests.get(url, headers=headers, params=params,
+                            timeout=cfg.get("timeout", 5))
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.warning(f"KIS 현재가 조회 실패 ({ticker}): {e}")
+        return None
+
+    # rt_cd "0" = 정상
+    if data.get("rt_cd") != "0":
+        logger.warning(f"KIS 현재가 응답 오류 ({ticker}): "
+                       f"{data.get('msg_cd')} {data.get('msg1')}")
+        return None
+
+    parsed = _parse_price_output(data.get("output", {}))
+    if parsed is None:
+        return None
+
+    _price_cache[ticker] = {"data": parsed, "fetched_at": now}
+    return parsed
+
+
+def clear_cache() -> None:
+    """현재가/토큰 인메모리 캐시 초기화 (디스크 캐시는 유지)."""
+    _price_cache.clear()
+    _token_state.clear()

--- a/ETF_RAG/src/data/realtime.py
+++ b/ETF_RAG/src/data/realtime.py
@@ -67,7 +67,10 @@ def krx_to_yfinance(ticker: str, asset_type: str = "etf") -> str:
 
 def get_realtime_price(ticker: str, asset_type: str = "etf",
                        cache_ttl: int = 300) -> Optional[dict]:
-    """yfinance에서 현재 가격 조회 (장중만, 5분 캐시)
+    """현재 가격 조회 (장중만, 5분 캐시).
+
+    KIS Open API(실시간)를 우선 사용하고, 비활성/실패 시 yfinance(15분 지연)로
+    fallback 한다. 둘 다 실패하면 None.
 
     Returns:
         성공 시 {"price", "prev_close", "change", "change_pct",
@@ -83,7 +86,19 @@ def get_realtime_price(ticker: str, asset_type: str = "etf",
     if cached and (now - cached["fetched_at"]) < cache_ttl:
         return cached["data"]
 
-    # yfinance 조회
+    # 1) KIS 실시간 시세 우선 (활성화된 경우)
+    try:
+        from src.data import kis_client
+        if kis_client.is_enabled():
+            kis_data = kis_client.get_current_price(ticker, cache_ttl=cache_ttl)
+            if kis_data:
+                _cache[ticker] = {"data": kis_data, "fetched_at": now}
+                return kis_data
+            # KIS 실패 시 yfinance로 fallback (아래로 진행)
+    except Exception as e:
+        logger.warning(f"KIS 조회 실패, yfinance fallback ({ticker}): {e}")
+
+    # 2) yfinance fallback (15분 지연)
     try:
         import yfinance as yf
         yf_ticker = krx_to_yfinance(ticker, asset_type)

--- a/ETF_RAG/src/llm/tools/analysis.py
+++ b/ETF_RAG/src/llm/tools/analysis.py
@@ -165,7 +165,10 @@ def get_realtime_price(name_or_ticker: str) -> str:
                     line += f", 전일대비: {rt['change']:+,}원 ({rt['change_pct']:+.2f}%)"
                 if rt.get("volume"):
                     line += f", 거래량: {rt['volume']:,}주"
-                line += f"\n(yfinance 15분 지연 데이터, 조회시각: {rt['timestamp']})"
+                if rt.get("source") == "kis":
+                    line += f"\n(한국투자증권 실시간 시세, 조회시각: {rt['timestamp']})"
+                else:
+                    line += f"\n(yfinance 15분 지연 데이터, 조회시각: {rt['timestamp']})"
                 return line
         except Exception as e:
             logger.warning(f"실시간 가격 조회 실패: {e}")

--- a/ETF_RAG/tests/test_kis_client.py
+++ b/ETF_RAG/tests/test_kis_client.py
@@ -1,0 +1,287 @@
+"""한국투자증권(KIS) REST 클라이언트 테스트 — 토큰 캐싱 / 현재가 파싱 / fallback"""
+
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.data import kis_client
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kis(tmp_path):
+    """매 테스트마다 인메모리 캐시 초기화 + 토큰 디스크 캐시를 임시 경로로 격리."""
+    kis_client.clear_cache()
+    kis_client._price_cache.clear()
+    kis_client._token_state.clear()
+    with patch.object(kis_client, "_TOKEN_CACHE_PATH",
+                      tmp_path / "kis_token.json"):
+        yield
+    kis_client.clear_cache()
+
+
+ENABLED_CFG = {
+    "enabled": True,
+    "app_key": "appkey-x",
+    "app_secret": "appsecret-y",
+    "env": "real",
+    "base_url": "https://openapi.koreainvestment.com:9443",
+    "timeout": 5,
+    "token_margin": 600,
+}
+DISABLED_CFG = {**ENABLED_CFG, "enabled": False, "app_key": "", "app_secret": ""}
+
+
+def _mock_resp(json_data, status=200):
+    m = MagicMock()
+    m.json.return_value = json_data
+    m.raise_for_status.return_value = None
+    if status >= 400:
+        m.raise_for_status.side_effect = Exception(f"HTTP {status}")
+    return m
+
+
+# ── 활성화 여부 ───────────────────────────────────────────
+
+def test_is_enabled_true():
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG):
+        assert kis_client.is_enabled() is True
+
+
+def test_is_enabled_false_no_keys():
+    with patch.object(kis_client, "_kis_config", return_value=DISABLED_CFG):
+        assert kis_client.is_enabled() is False
+
+
+# ── 토큰 발급/캐싱 ────────────────────────────────────────
+
+def test_get_token_disabled_returns_none():
+    with patch.object(kis_client, "_kis_config", return_value=DISABLED_CFG):
+        assert kis_client._get_access_token() is None
+
+
+def test_get_token_issues_new():
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=_mock_resp(
+             {"access_token": "tok-123", "expires_in": 86400})) as post:
+        token = kis_client._get_access_token()
+    assert token == "tok-123"
+    post.assert_called_once()
+    # tokenP 엔드포인트 호출 확인
+    assert "/oauth2/tokenP" in post.call_args[0][0]
+
+
+def test_get_token_inmemory_cache_hit():
+    """두 번째 호출은 requests.post 미호출 (인메모리 캐시)."""
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=_mock_resp(
+             {"access_token": "tok-abc", "expires_in": 86400})) as post:
+        t1 = kis_client._get_access_token()
+        t2 = kis_client._get_access_token()
+    assert t1 == t2 == "tok-abc"
+    assert post.call_count == 1
+
+
+def test_get_token_expired_reissues():
+    """만료 임박(margin 안) 토큰은 재발급."""
+    kis_client._token_state.update({
+        "access_token": "old", "expires_at": time.time() + 100,  # margin 600 안
+    })
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=_mock_resp(
+             {"access_token": "new", "expires_in": 86400})):
+        token = kis_client._get_access_token()
+    assert token == "new"
+
+
+def test_get_token_disk_cache_survives_memory_clear():
+    """디스크 캐시에서 복구 — 인메모리 비어도 post 미호출."""
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG):
+        with patch("requests.post", return_value=_mock_resp(
+                {"access_token": "disk-tok", "expires_in": 86400})) as post:
+            kis_client._get_access_token()
+        assert post.call_count == 1
+        # 인메모리만 비우기 (디스크 캐시는 유지)
+        kis_client._token_state.clear()
+        with patch("requests.post") as post2:
+            token = kis_client._get_access_token()
+    assert token == "disk-tok"
+    post2.assert_not_called()
+
+
+def test_get_token_post_error_returns_none():
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", side_effect=Exception("network down")):
+        assert kis_client._get_access_token() is None
+
+
+def test_get_token_missing_field_returns_none():
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=_mock_resp({"msg": "no token"})):
+        assert kis_client._get_access_token() is None
+
+
+# ── 현재가 파싱 ───────────────────────────────────────────
+
+def test_parse_price_output_rising():
+    out = {
+        "stck_prpr": "81200", "stck_sdpr": "80800",
+        "prdy_vrss": "400", "prdy_ctrt": "0.50",
+        "prdy_vrss_sign": "2", "acml_vol": "5000000",
+    }
+    p = kis_client._parse_price_output(out)
+    assert p["price"] == 81200
+    assert p["prev_close"] == 80800
+    assert p["change"] == 400
+    assert p["change_pct"] == 0.50
+    assert p["volume"] == 5000000
+    assert p["source"] == "kis"
+
+
+def test_parse_price_output_falling_sign():
+    """하락(sign=5)이면 change/change_pct 음수로 보정."""
+    out = {
+        "stck_prpr": "79000", "stck_sdpr": "80000",
+        "prdy_vrss": "1000", "prdy_ctrt": "1.25",
+        "prdy_vrss_sign": "5", "acml_vol": "3000000",
+    }
+    p = kis_client._parse_price_output(out)
+    assert p["price"] == 79000
+    assert p["change"] == -1000
+    assert p["change_pct"] == -1.25
+
+
+def test_parse_price_output_zero_price_none():
+    assert kis_client._parse_price_output({"stck_prpr": "0"}) is None
+
+
+def test_parse_price_output_missing_price_none():
+    assert kis_client._parse_price_output({}) is None
+
+
+# ── 현재가 조회 (통합) ────────────────────────────────────
+
+def test_get_current_price_disabled_none():
+    with patch.object(kis_client, "_kis_config", return_value=DISABLED_CFG):
+        assert kis_client.get_current_price("005930") is None
+
+
+def test_get_current_price_success():
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    price_resp = _mock_resp({
+        "rt_cd": "0",
+        "output": {
+            "stck_prpr": "70000", "stck_sdpr": "69000",
+            "prdy_vrss": "1000", "prdy_ctrt": "1.45",
+            "prdy_vrss_sign": "2", "acml_vol": "12000000",
+        },
+    })
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", return_value=price_resp) as get:
+        p = kis_client.get_current_price("005930")
+    assert p["price"] == 70000
+    assert p["change_pct"] == 1.45
+    assert p["source"] == "kis"
+    # 올바른 tr_id / 파라미터 확인
+    _, kw = get.call_args
+    assert kw["headers"]["tr_id"] == "FHKST01010100"
+    assert kw["params"]["fid_input_iscd"] == "005930"
+    assert kw["params"]["fid_cond_mrkt_div_code"] == "J"
+
+
+def test_get_current_price_cache_hit():
+    """두 번째 호출은 requests.get 미호출."""
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    price_resp = _mock_resp({
+        "rt_cd": "0",
+        "output": {"stck_prpr": "70000", "stck_sdpr": "69000",
+                   "prdy_vrss": "1000", "prdy_ctrt": "1.45",
+                   "prdy_vrss_sign": "2", "acml_vol": "100"},
+    })
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", return_value=price_resp) as get:
+        kis_client.get_current_price("005930", cache_ttl=300)
+        kis_client.get_current_price("005930", cache_ttl=300)
+    assert get.call_count == 1
+
+
+def test_get_current_price_error_rt_cd_none():
+    """rt_cd != '0' → None."""
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    err_resp = _mock_resp({"rt_cd": "1", "msg_cd": "EGW", "msg1": "오류"})
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", return_value=err_resp):
+        assert kis_client.get_current_price("005930") is None
+
+
+def test_get_current_price_http_error_none():
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", side_effect=Exception("timeout")):
+        assert kis_client.get_current_price("005930") is None
+
+
+def test_get_current_price_no_token_none():
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", side_effect=Exception("token fail")):
+        assert kis_client.get_current_price("005930") is None
+
+
+# ── realtime.py 통합: KIS 우선 → yfinance fallback ────────
+
+def test_realtime_prefers_kis():
+    """KIS 활성 + 성공 시 source=kis 반환, yfinance 미호출."""
+    from src.data import realtime
+    realtime.clear_cache()
+    kis_data = {"price": 70000, "prev_close": 69000, "change": 1000,
+                "change_pct": 1.45, "volume": 100,
+                "timestamp": "2026-06-12 10:00", "source": "kis"}
+    with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=True), \
+         patch("src.data.kis_client.get_current_price", return_value=kis_data), \
+         patch("yfinance.Ticker") as yf:
+        result = realtime.get_realtime_price("005930", "stock")
+    assert result["source"] == "kis"
+    assert result["price"] == 70000
+    yf.assert_not_called()
+
+
+def test_realtime_fallback_to_yfinance_when_kis_fails():
+    """KIS 활성이나 조회 실패 → yfinance로 fallback."""
+    from src.data import realtime
+    realtime.clear_cache()
+    mock_info = MagicMock()
+    mock_info.last_price = 70500.0
+    mock_info.previous_close = 70000.0
+    mock_info.last_volume = 999
+    mock_ticker = MagicMock()
+    mock_ticker.fast_info = mock_info
+    with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=True), \
+         patch("src.data.kis_client.get_current_price", return_value=None), \
+         patch("yfinance.Ticker", return_value=mock_ticker):
+        result = realtime.get_realtime_price("069500", "etf")
+    assert result["source"] == "yfinance"
+    assert result["price"] == 70500
+
+
+def test_realtime_uses_yfinance_when_kis_disabled():
+    """KIS 비활성 → yfinance 경로."""
+    from src.data import realtime
+    realtime.clear_cache()
+    mock_info = MagicMock()
+    mock_info.last_price = 80500.0
+    mock_info.previous_close = 80000.0
+    mock_info.last_volume = 1500000
+    mock_ticker = MagicMock()
+    mock_ticker.fast_info = mock_info
+    with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=False), \
+         patch("yfinance.Ticker", return_value=mock_ticker):
+        result = realtime.get_realtime_price("069500", "etf")
+    assert result["source"] == "yfinance"
+    assert result["price"] == 80500

--- a/ETF_RAG/tests/test_realtime.py
+++ b/ETF_RAG/tests/test_realtime.py
@@ -169,6 +169,7 @@ def test_get_realtime_price_success():
     mock_ticker.fast_info = mock_info
 
     with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=False), \
          patch("yfinance.Ticker", return_value=mock_ticker):
         result = get_realtime_price("069500", "etf")
 
@@ -210,6 +211,7 @@ def test_get_realtime_price_cache_expired():
     mock_ticker.fast_info = mock_info
 
     with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=False), \
          patch("yfinance.Ticker", return_value=mock_ticker):
         result = get_realtime_price("069500", "etf", cache_ttl=300)
 
@@ -220,6 +222,7 @@ def test_get_realtime_price_yfinance_error():
     """yfinance 예외 → None"""
     clear_cache()
     with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=False), \
          patch("yfinance.Ticker", side_effect=Exception("API error")):
         result = get_realtime_price("069500", "etf")
     assert result is None
@@ -234,6 +237,7 @@ def test_get_realtime_price_no_last_price():
     mock_ticker.fast_info = mock_info
 
     with patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.kis_client.is_enabled", return_value=False), \
          patch("yfinance.Ticker", return_value=mock_ticker):
         result = get_realtime_price("069500", "etf")
     assert result is None


### PR DESCRIPTION
## 개요
Phase F-2 착수 — 한국투자증권(KIS) Open API로 **실시간 현재가**를 연동. 기존 yfinance(15분 지연)는 fallback으로 유지.

계좌 개설(2026-06-10)·앱 등록·API 키 발급까지 완료되어, 이번 PR은 **코드 연동 + 테스트**가 범위. WebSocket/호가/체결은 후속.

## 변경
- **`src/data/kis_client.py` (신설)** — KIS REST 클라이언트
  - OAuth2 접근토큰 발급 + 인메모리·디스크 캐싱(`~/.cache/etf_rag/kis_token.json`) + 만료 선제 갱신. KIS의 토큰 재발급 분당 1회 제한을 디스크 캐시로 회피, 프로세스 재시작에도 토큰 생존.
  - 국내 주식/ETF 현재가 시세 (`FHKST01010100`, 시장구분 `J`). `realtime` 표준 스키마(`price/prev_close/change/change_pct/volume/timestamp/source`) 반환.
  - `app_key`/`app_secret` 미설정 시 자동 비활성 → 아무 동작 변화 없음.
- **`config.py`** — `KIS` dict (real/vps 환경별 base_url 자동 선택) + `.env.example` 항목.
- **`src/data/realtime.py`** — `get_realtime_price`: KIS 활성 시 실시간 우선, 실패/비활성 시 yfinance fallback.
- **`src/llm/tools/analysis.py`** — 출처 표기 source 분기("한국투자증권 실시간 시세" / "yfinance 15분 지연").

## 테스트
- `tests/test_kis_client.py` **22개** — 토큰 캐싱/디스크 생존/현재가 파싱/하락 부호 보정/`rt_cd` 오류/HTTP 오류/realtime 통합(KIS 우선·yfinance fallback·KIS 비활성).
- `tests/test_realtime.py` — yfinance 전용 테스트에 KIS 비활성 patch 추가(실 `.env` KIS 키로 인한 라이브 호출 방지).
- 전체 **671 pass** (로컬 fastapi 미설치 4개 제외, CI는 전체 실행).

## 라이브 검증 (2026-06-12 장중)
실 `.env` 키로 KIS 호출 성공:
- 삼성전자(005930), KODEX 200(069500) 현재가 정상 조회 (`source=kis`)
- LangGraph `get_realtime_price` 도구 end-to-end → "한국투자증권 실시간 시세" 출력 확인

## 후속
- 배포 시 Railway 백엔드 env에 `KIS_APP_KEY/SECRET/ENV` 등록 (선택 — 미등록 시 yfinance fallback)
- WebSocket 실시간 스트리밍, 호가(10단계)/체결

🤖 Generated with [Claude Code](https://claude.com/claude-code)