### PR TITLE
모바일 사이드바 드로워 + 데이터 탭 반응형 보강

### DIFF
--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -63,7 +63,7 @@ export default function FinancialPage() {
       <TickerSearch onSelect={onSelect} placeholder="종목명 또는 티커 (주식만)" />
 
       {/* 조회 기간 선택 */}
-      <div className="mt-3 flex gap-1.5">
+      <div className="mt-3 flex flex-wrap gap-1.5">
         {RANGES.map((r) => (
           <button
             key={r.quarters}

--- a/ETF_RAG/frontend/src/app/layout.tsx
+++ b/ETF_RAG/frontend/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import NavBar from "@/components/NavBar";
-import Sidebar from "@/components/Sidebar";
+import ChromeShell from "@/components/ChromeShell";
 import { AuthProvider } from "@/lib/AuthContext";
 import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 
@@ -47,11 +46,7 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col">
         <AuthProvider>
-          <NavBar />
-          <div className="flex flex-1 overflow-hidden">
-            <Sidebar />
-            <div className="flex flex-1 flex-col overflow-y-auto">{children}</div>
-          </div>
+          <ChromeShell>{children}</ChromeShell>
         </AuthProvider>
         <ServiceWorkerRegister />
       </body>

--- a/ETF_RAG/frontend/src/app/outlook/page.tsx
+++ b/ETF_RAG/frontend/src/app/outlook/page.tsx
@@ -83,7 +83,7 @@ export default function OutlookPage() {
       <TickerSearch onSelect={onSelect} />
 
       {selected && (
-        <div className="mt-3 flex gap-2">
+        <div className="mt-3 flex flex-wrap gap-2">
           {HORIZONS.map((h) => (
             <button
               key={h}
@@ -122,7 +122,7 @@ export default function OutlookPage() {
           </div>
 
           {/* 시나리오 */}
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
             {(["bullish", "neutral", "bearish"] as const).map((k) => {
               const sc = scenarios[k];
               const label = { bullish: "🔼 상승", neutral: "➖ 중립", bearish: "🔽 하락" }[k];

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -153,7 +153,7 @@ export default function TechnicalPage() {
           </div>
 
           {/* 핵심 지표 */}
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 max-[380px]:grid-cols-1">
             <Metric label="종가" value={`${n(s.close)}원`} />
             <Metric label="추세" value={String(s.trend ?? "-")} />
             <Metric label="MA5" value={n(ma.ma5)} />

--- a/ETF_RAG/frontend/src/components/ChromeShell.tsx
+++ b/ETF_RAG/frontend/src/components/ChromeShell.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import NavBar from "@/components/NavBar";
+import Sidebar from "@/components/Sidebar";
+
+/**
+ * NavBar + Sidebar + 본문을 감싸는 클라이언트 셸.
+ * 모바일 드로워(사이드바) open 상태를 보유 — NavBar의 ☰ 버튼과 Sidebar 오버레이를 연결한다.
+ * 데스크톱(lg+)에서는 Sidebar가 고정 표시되고 open 상태는 무시된다.
+ */
+export default function ChromeShell({ children }: { children: React.ReactNode }) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <NavBar onMenuClick={() => setDrawerOpen(true)} />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+        <div className="flex flex-1 flex-col overflow-y-auto">{children}</div>
+      </div>
+    </>
+  );
+}

--- a/ETF_RAG/frontend/src/components/NavBar.tsx
+++ b/ETF_RAG/frontend/src/components/NavBar.tsx
@@ -13,13 +13,24 @@ const TABS = [
   { href: "/sector", label: "🏭 섹터" },
 ];
 
-export default function NavBar() {
+export default function NavBar({ onMenuClick }: { onMenuClick?: () => void } = {}) {
   const pathname = usePathname();
   const { user, loading, logout } = useAuth();
 
   return (
     <nav className="border-b border-gray-200">
       <div className="mx-auto flex max-w-3xl items-center gap-1 overflow-x-auto px-3 py-2 sm:px-4">
+        {/* 모바일 햄버거 — 사이드바 드로워 열기 (lg 미만에서만) */}
+        {onMenuClick && (
+          <button
+            type="button"
+            aria-label="메뉴 열기"
+            onClick={onMenuClick}
+            className="shrink-0 rounded-lg px-2 py-1.5 text-base text-gray-600 hover:bg-gray-100 lg:hidden"
+          >
+            ☰
+          </button>
+        )}
         {TABS.map((t) => {
           const active = t.href === pathname;
           return (

--- a/ETF_RAG/frontend/src/components/Sidebar.tsx
+++ b/ETF_RAG/frontend/src/components/Sidebar.tsx
@@ -52,7 +52,13 @@ function ItemRow({
   );
 }
 
-export default function Sidebar() {
+export default function Sidebar({
+  open = false,
+  onClose,
+}: {
+  open?: boolean;
+  onClose?: () => void;
+} = {}) {
   const router = useRouter();
   const [data, setData] = useState<OverviewResponse | null>(null);
   const [visitor, setVisitor] = useState<VisitorResponse | null>(null);
@@ -98,11 +104,13 @@ export default function Sidebar() {
     );
   }, [list, q]);
 
-  const go = (it: InstrumentItem) =>
+  const go = (it: InstrumentItem) => {
     router.push(`/technical?ticker=${encodeURIComponent(it.ticker)}`);
+    onClose?.(); // 모바일 드로워에서 종목 선택 시 닫기
+  };
 
-  return (
-    <aside className="hidden w-72 shrink-0 overflow-y-auto border-r border-gray-200 p-3 text-sm lg:block">
+  const content = (
+    <>
       {/* 데이터 현황 */}
       <div className="mb-3">
         <div className="text-xs font-semibold text-gray-700">📊 데이터 현황</div>
@@ -186,6 +194,41 @@ export default function Sidebar() {
         ⚠️ 본 정보는 투자 참고용입니다. 투자 판단과 책임은 본인에게 있으며, 실제
         투자 시 추가 조사와 전문가 상담을 권장합니다.
       </p>
-    </aside>
+    </>
+  );
+
+  return (
+    <>
+      {/* 데스크톱: 고정 사이드바 (lg 이상) */}
+      <aside className="hidden w-72 shrink-0 overflow-y-auto border-r border-gray-200 p-3 text-sm lg:block">
+        {content}
+      </aside>
+
+      {/* 모바일/태블릿: 드로워 오버레이 (lg 미만, open일 때만) */}
+      {open && (
+        <div className="fixed inset-0 z-40 lg:hidden">
+          {/* 배경 딤 — 클릭 시 닫기 */}
+          <button
+            type="button"
+            aria-label="사이드바 닫기"
+            onClick={onClose}
+            className="absolute inset-0 bg-black/40"
+          />
+          {/* 드로워 패널 (좌측 슬라이드) */}
+          <aside className="absolute left-0 top-0 h-full w-72 max-w-[85%] overflow-y-auto border-r border-gray-200 bg-white p-3 text-sm shadow-xl">
+            <div className="mb-2 flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg px-2 py-1 text-xs text-gray-500 hover:bg-gray-100"
+              >
+                ✕ 닫기
+              </button>
+            </div>
+            {content}
+          </aside>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## 배경
사용자 지적 — "모바일에서 PC와 다른 점 해결됐나?" 점검 중 발견: SaaS 프론트 사이드바가 **lg(1024px) 미만에서 통째로 숨겨져**, 모바일/태블릿 사용자는 사이드바 전용 기능(데이터현황·ETF/주식 거래대금 TOP·업종 필터·종목 검색→기술분석 점프·방문자 카운터)을 **전혀 사용할 수 없었음.** (Streamlit은 모바일 사이드바 동작.)

## 변경
**1) 모바일 사이드바 드로워 (햄버거)**
- `Sidebar`: `open`/`onClose` prop 추가. 데스크톱(lg+)은 기존 고정 aside 유지, 모바일은 ☰ 클릭 시 좌측 슬라이드 드로워 오버레이 — 배경 딤 클릭 / ✕ 버튼으로 닫기, 종목 선택 시 자동 닫기. 내부 컨텐츠는 동일(재사용).
- `NavBar`: 모바일 ☰ 햄버거 버튼(`lg:hidden`) + `onMenuClick`.
- `ChromeShell`(신규): NavBar+Sidebar+본문을 감싸는 클라이언트 셸, 드로워 open 상태 보유.
- `layout.tsx`: 서버 컴포넌트 → ChromeShell로 클라이언트 상태 분리.

**2) 데이터 탭 모바일 레이아웃**
- 전망 탭 시나리오 카드: `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` (모바일 스택).
- 전망/재무 탭 기간 선택 버튼: `flex flex-wrap` (좁은 화면 줄바꿈).
- 기술 탭 지표 카드: 초소형 폰(<380px) 1컬럼.

(표·차트는 이미 `overflow-x-auto`/`w-full`로 양호 — Explore 전수 점검으로 확인.)

## 검증
- `npm run build` 통과(9라우트, 타입 0).
- prod 서버 스모크: `/` HTML에 ☰(메뉴 열기, lg:hidden) + 데스크톱 aside(lg:block) 동시 존재, 탭 페이지 200. 드로워 오버레이는 클라이언트 open 상태라 SSR엔 미출현(정상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)