### PR TITLE
KIS 실시간 시세 프론트 노출 (기술 탭 시세 카드)

### DIFF
--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -97,6 +97,21 @@ class MoversResponse(BaseModel):
     most_traded: List[MoverItem]
 
 
+# ── 실시간 시세 (KIS 우선 → yfinance, 장 외엔 종가) ──────
+class PriceResponse(BaseModel):
+    name: str
+    ticker: str
+    price: float                      # 현재가(장중) 또는 종가(장 외)
+    prev_close: Optional[float] = None
+    change: Optional[float] = None
+    change_pct: Optional[float] = None
+    volume: Optional[int] = None
+    source: str                       # "kis" | "yfinance" | "close"(수집 종가)
+    is_live: bool                     # 장중 실시간 여부
+    timestamp: Optional[str] = None    # 조회 시각(실시간) 또는 기준일(종가)
+    market_open: bool                 # 현재 장 운영 여부
+
+
 class FeedbackRequest(BaseModel):
     question: str
     answer: str

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -20,6 +20,7 @@ from api.models import (
     MoverItem,
     MoversResponse,
     OverviewResponse,
+    PriceResponse,
     TickerSearchResponse,
 )
 from src.data.technical import get_technical_summary
@@ -264,6 +265,53 @@ async def resolve(q: str = Query(..., min_length=1)):
     if not data:
         raise HTTPException(404, f"'{q}'을(를) 찾을 수 없습니다.")
     return data
+
+
+# ── 실시간 시세 (KIS 우선 → yfinance, 장 외엔 수집 종가) ──────
+def _price_blocking(q: str) -> Optional[dict]:
+    """종목 해석 → 장중이면 실시간(KIS 우선) 조회, 실패/장외면 수집 종가 fallback."""
+    data = _find_structured_data(q)
+    if not data:
+        return None
+    ticker = data.get("ticker", "")
+    name = data.get("name", "")
+    asset_type = "etf" if "nav" in data else "stock"
+
+    from src.data.realtime import get_realtime_price, is_market_open
+    market_open = is_market_open()
+
+    rt = get_realtime_price(ticker, asset_type) if market_open else None
+    if rt:
+        return {
+            "name": name, "ticker": ticker,
+            "price": rt["price"], "prev_close": rt.get("prev_close"),
+            "change": rt.get("change"), "change_pct": rt.get("change_pct"),
+            "volume": rt.get("volume"), "source": rt.get("source", "yfinance"),
+            "is_live": True, "timestamp": rt.get("timestamp"),
+            "market_open": True,
+        }
+
+    # Fallback: 수집 종가
+    date = data.get("date", "")
+    if len(date) == 8:
+        date = f"{date[:4]}-{date[4:6]}-{date[6:]}"
+    return {
+        "name": name, "ticker": ticker,
+        "price": data.get("close", 0) or 0, "prev_close": None,
+        "change": None, "change_pct": data.get("change_pct"),
+        "volume": data.get("volume"), "source": "close",
+        "is_live": False, "timestamp": date or None,
+        "market_open": market_open,
+    }
+
+
+@router.get("/price", response_model=PriceResponse)
+async def price(ticker: str = Query(..., min_length=1)):
+    """종목 현재가 — 장중엔 실시간(KIS 우선→yfinance), 장 외엔 수집 종가(source=close)."""
+    result = await run_in_threadpool(_price_blocking, ticker)
+    if not result:
+        raise HTTPException(404, f"'{ticker}'을(를) 찾을 수 없습니다.")
+    return PriceResponse(**result)
 
 
 # ── 동적 추천질문용 movers (오늘의 급등/급락/거래대금 TOP) ──────────

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -6,6 +6,7 @@ import type { TechnicalResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import WatchlistStar from "@/components/WatchlistStar";
 import DataRangeNote from "@/components/DataRangeNote";
+import PriceCard from "@/components/PriceCard";
 
 const PERIODS: { label: string; days: number }[] = [
   { label: "6개월", days: 120 },
@@ -151,6 +152,9 @@ export default function TechnicalPage() {
             <span className="text-xs text-gray-400">{data.ticker}</span>
             <WatchlistStar ticker={data.ticker} />
           </div>
+
+          {/* 실시간 시세 (KIS 우선 → yfinance, 장 외엔 종가) */}
+          <PriceCard ticker={data.ticker} />
 
           {/* 핵심 지표 */}
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 max-[380px]:grid-cols-1">

--- a/ETF_RAG/frontend/src/components/PriceCard.tsx
+++ b/ETF_RAG/frontend/src/components/PriceCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { getPrice } from "@/lib/api";
+import type { PriceData } from "@/lib/types";
+
+/**
+ * 종목 실시간 시세 카드.
+ * - 장중: KIS 실시간(또는 yfinance 지연)을 30초마다 자동 갱신
+ * - 장 외: 수집 종가 1회 표시(자동 갱신 없음)
+ * source 배지로 출처 구분(🔴 실시간 / 🟡 지연 / 종가).
+ */
+export default function PriceCard({ ticker }: { ticker: string }) {
+  const [data, setData] = useState<PriceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setData(null);
+
+    const load = async () => {
+      try {
+        const p = await getPrice(ticker);
+        if (alive) setData(p);
+      } catch {
+        if (alive) setData(null);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    };
+
+    load().then(() => {
+      // 장중일 때만 30초 폴링 (load 결과는 다음 tick에서 확인 — is_live 기준)
+      if (timer.current) clearInterval(timer.current);
+      timer.current = setInterval(async () => {
+        try {
+          const p = await getPrice(ticker);
+          if (alive && p && p.is_live) setData(p);
+          else if (alive && p && !p.market_open && timer.current) {
+            clearInterval(timer.current); // 장 마감 감지 시 폴링 중단
+          }
+        } catch {
+          /* 일시 오류 무시 */
+        }
+      }, 30_000);
+    });
+
+    return () => {
+      alive = false;
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, [ticker]);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-400">
+        시세 불러오는 중…
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const up = (data.change_pct ?? 0) > 0;
+  const down = (data.change_pct ?? 0) < 0;
+  const color = up ? "text-red-600" : down ? "text-blue-600" : "text-gray-500";
+
+  const badge =
+    data.source === "kis"
+      ? { label: "🔴 실시간 (KIS)", cls: "bg-red-50 text-red-600" }
+      : data.source === "yfinance"
+        ? { label: "🟡 15분 지연 (yfinance)", cls: "bg-yellow-50 text-yellow-700" }
+        : { label: "종가", cls: "bg-gray-100 text-gray-500" };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xl font-bold tabular-nums text-gray-900">
+            {data.price.toLocaleString("ko-KR")}원
+          </span>
+          {data.change_pct != null && (
+            <span className={`text-sm font-medium tabular-nums ${color}`}>
+              {data.change != null
+                ? `${up ? "+" : ""}${data.change.toLocaleString("ko-KR")}원 `
+                : ""}
+              ({up ? "+" : ""}
+              {data.change_pct}%)
+            </span>
+          )}
+        </div>
+        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] ${badge.cls}`}>
+          {badge.label}
+        </span>
+      </div>
+      <div className="mt-1 flex items-center gap-3 text-[11px] text-gray-400">
+        {data.volume != null && (
+          <span>거래량 {data.volume.toLocaleString("ko-KR")}주</span>
+        )}
+        {data.timestamp && <span>{data.timestamp}</span>}
+        {data.source === "close" && !data.market_open && <span>장 마감</span>}
+      </div>
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   MoversResponse,
   OverviewResponse,
   VisitorResponse,
+  PriceData,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
@@ -143,6 +144,16 @@ export async function getTechnical(
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`technical ${res.status}`);
   return (await res.json()) as TechnicalResponse;
+}
+
+/** 실시간 시세 — 장중엔 KIS 우선(yfinance fallback), 장 외엔 수집 종가. 404면 null. */
+export async function getPrice(ticker: string): Promise<PriceData | null> {
+  const url = new URL(`${API_BASE}/tabs/price`);
+  url.searchParams.set("ticker", ticker);
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`price ${res.status}`);
+  return (await res.json()) as PriceData;
 }
 
 /** 장중 시세 차트 (yfinance 15분봉). 장 외/데이터 없으면 null. */

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -82,6 +82,21 @@ export interface TickerSearchResponse {
   options: string[];
 }
 
+/** 실시간 시세 (/tabs/price). source: kis(실시간) | yfinance(지연) | close(종가) */
+export interface PriceData {
+  name: string;
+  ticker: string;
+  price: number;
+  prev_close: number | null;
+  change: number | null;
+  change_pct: number | null;
+  volume: number | null;
+  source: "kis" | "yfinance" | "close";
+  is_live: boolean;
+  timestamp: string | null;
+  market_open: boolean;
+}
+
 /** /tabs/financial 응답 */
 export interface FinancialRow {
   fiscal_year: number;

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -268,6 +268,65 @@ def test_overview_sector_filter(client):
     assert set(b["sectors"]) == {"전기·전자", "서비스업"}
 
 
+# ── 실시간 시세 /tabs/price ────────────────────────────────────────
+def test_price_live_kis(client):
+    """장중 + KIS 실시간 → is_live=True, source=kis."""
+    structured = {"ticker": "005930", "name": "삼성전자", "close": 69000,
+                  "date": "20260611"}
+    rt = {"price": 70000, "prev_close": 69000, "change": 1000,
+          "change_pct": 1.45, "volume": 12000000,
+          "timestamp": "2026-06-12 10:00", "source": "kis"}
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.realtime.get_realtime_price", return_value=rt):
+        r = client.get("/tabs/price", params={"ticker": "삼성전자"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["price"] == 70000
+    assert b["source"] == "kis"
+    assert b["is_live"] is True
+    assert b["market_open"] is True
+    assert b["change_pct"] == 1.45
+
+
+def test_price_fallback_close_when_market_closed(client):
+    """장 외 → 실시간 미조회, 수집 종가(source=close, is_live=False)."""
+    structured = {"ticker": "069500", "name": "KODEX 200", "close": 80800,
+                  "change_pct": 2.91, "volume": 14000000, "nav": 80647,
+                  "date": "20260611"}
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.realtime.is_market_open", return_value=False):
+        r = client.get("/tabs/price", params={"ticker": "KODEX 200"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["price"] == 80800
+    assert b["source"] == "close"
+    assert b["is_live"] is False
+    assert b["market_open"] is False
+    assert b["timestamp"] == "2026-06-11"  # YYYYMMDD → YYYY-MM-DD
+
+
+def test_price_fallback_close_when_realtime_fails(client):
+    """장중이나 실시간 실패(None) → 종가 fallback."""
+    structured = {"ticker": "005930", "name": "삼성전자", "close": 69000,
+                  "change_pct": 0.5, "date": "20260611"}
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.realtime.is_market_open", return_value=True), \
+         patch("src.data.realtime.get_realtime_price", return_value=None):
+        r = client.get("/tabs/price", params={"ticker": "삼성전자"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["source"] == "close"
+    assert b["is_live"] is False
+    assert b["market_open"] is True  # 장중이지만 실시간 실패
+
+
+def test_price_404_when_unresolved(client):
+    with patch("api.tabs._find_structured_data", return_value=None):
+        r = client.get("/tabs/price", params={"ticker": "ZZZ없는종목"})
+    assert r.status_code == 404
+
+
 # ── 가드 ───────────────────────────────────────────────────────────
 def test_tabs_require_ready_503(client):
     # ready=False면 503 (require_ready 의존성)


### PR DESCRIPTION
## 배경
F-2에서 만든 KIS REST 실시간 현재가(PR #50)를 SaaS 프론트에서 **실제로 보이게** 함. 사용자 큐 "하나씩"의 첫 작업.

## 변경
**백엔드** — `GET /tabs/price?ticker=`
- 장중: `realtime.get_realtime_price`(KIS 우선 → yfinance 15분 지연) 반환.
- 장 외 / 실시간 실패: 수집 종가로 fallback(`source=close`) → 항상 시세 반환.
- `PriceResponse`(price/prev_close/change/change_pct/volume/**source**/**is_live**/**market_open**/timestamp).
- 테스트 4개(KIS 실시간 / 장외 종가 / 실시간 실패 fallback / 404).

**프론트** — 기술 분석 탭 시세 카드
- `getPrice()` + `PriceData` 타입.
- `PriceCard`: 현재가·등락(상승 빨강/하락 파랑) + **source 배지**(🔴 실시간 KIS / 🟡 15분 지연 yfinance / 종가), 거래량·시각. **장중 30초 자동 갱신**, 장 마감 감지 시 폴링 중단.
- 종목 헤더 아래 배치.

## 검증
- 백엔드 `pytest tests/test_api_tabs.py` **24 pass**(신규 4 포함, ETF_RAG/.venv).
- 프론트 `npm run build` 통과(9라우트).
- **라이브 end-to-end**: `_price_blocking` 실 KIS 키로 — 장중(12:38 KST 당시) source=kis 실시간 / 장 마감(19:34 KST) source=close·is_live=false·날짜 포맷 정상. 양쪽 경로 확인.

## 후속
배포 시 Railway 백엔드 env에 KIS 키 등록하면 라이브에서도 실시간(미등록 시 yfinance/종가로 동작). 사이드바 종목 목록 실시간화는 N콜 부담이라 보류(단일 종목 상세 = 기술 탭만 실시간).

🤖 Generated with [Claude Code](https://claude.com/claude-code)