### PR TITLE
KIS 호가 10단계 (기술 탭 호가창)

### DIFF
--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -112,6 +112,23 @@ class PriceResponse(BaseModel):
     market_open: bool                 # 현재 장 운영 여부
 
 
+# ── 호가 10단계 (KIS, 장중 전용) ────────────────────────
+class OrderbookLevel(BaseModel):
+    price: int
+    qty: int
+
+
+class OrderbookResponse(BaseModel):
+    name: str
+    ticker: str
+    asks: List[OrderbookLevel]      # 매도호가 1~10단계
+    bids: List[OrderbookLevel]      # 매수호가 1~10단계
+    total_ask_qty: int
+    total_bid_qty: int
+    timestamp: Optional[str] = None
+    source: str                     # "kis"
+
+
 class FeedbackRequest(BaseModel):
     question: str
     answer: str

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -19,6 +19,7 @@ from api.models import (
     InstrumentItem,
     MoverItem,
     MoversResponse,
+    OrderbookResponse,
     OverviewResponse,
     PriceResponse,
     TickerSearchResponse,
@@ -312,6 +313,42 @@ async def price(ticker: str = Query(..., min_length=1)):
     if not result:
         raise HTTPException(404, f"'{ticker}'을(를) 찾을 수 없습니다.")
     return PriceResponse(**result)
+
+
+# ── 호가 10단계 (KIS 전용, 장중) ───────────────────────────
+def _orderbook_blocking(q: str) -> Optional[dict]:
+    """종목 해석 → KIS 호가 조회. KIS 비활성/장외/조회 실패 시 None.
+
+    호가는 KIS만 제공(yfinance 미지원) → fallback 없음.
+    """
+    data = _find_structured_data(q)
+    if not data:
+        return None
+    ticker = data.get("ticker", "")
+    name = data.get("name", "")
+
+    from src.data import kis_client
+    if not kis_client.is_enabled():
+        return None
+    ob = kis_client.get_orderbook(ticker)
+    if not ob:
+        return None
+    return {
+        "name": name, "ticker": ticker,
+        "asks": ob["asks"], "bids": ob["bids"],
+        "total_ask_qty": ob["total_ask_qty"],
+        "total_bid_qty": ob["total_bid_qty"],
+        "timestamp": ob.get("timestamp"), "source": ob.get("source", "kis"),
+    }
+
+
+@router.get("/orderbook", response_model=OrderbookResponse)
+async def orderbook(ticker: str = Query(..., min_length=1)):
+    """종목 호가 10단계 (KIS 전용). KIS 미설정/장 외/조회 실패 시 404."""
+    result = await run_in_threadpool(_orderbook_blocking, ticker)
+    if not result:
+        raise HTTPException(404, "호가를 가져올 수 없습니다. (KIS 미연동이거나 장 외 시간)")
+    return OrderbookResponse(**result)
 
 
 # ── 동적 추천질문용 movers (오늘의 급등/급락/거래대금 TOP) ──────────

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -7,6 +7,7 @@ import TickerSearch from "@/components/TickerSearch";
 import WatchlistStar from "@/components/WatchlistStar";
 import DataRangeNote from "@/components/DataRangeNote";
 import PriceCard from "@/components/PriceCard";
+import OrderbookCard from "@/components/OrderbookCard";
 
 const PERIODS: { label: string; days: number }[] = [
   { label: "6개월", days: 120 },
@@ -155,6 +156,11 @@ export default function TechnicalPage() {
 
           {/* 실시간 시세 (KIS 우선 → yfinance, 장 외엔 종가) */}
           <PriceCard ticker={data.ticker} />
+
+          {/* 호가 10단계 (KIS 전용, 장중에만 표시) */}
+          <div className="mt-3">
+            <OrderbookCard ticker={data.ticker} />
+          </div>
 
           {/* 핵심 지표 */}
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 max-[380px]:grid-cols-1">

--- a/ETF_RAG/frontend/src/components/OrderbookCard.tsx
+++ b/ETF_RAG/frontend/src/components/OrderbookCard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { getOrderbook } from "@/lib/api";
+import type { OrderbookData } from "@/lib/types";
+
+/**
+ * 호가 10단계 (KIS 전용). 장중에만 데이터가 있고, 5초마다 갱신.
+ * KIS 미연동/장 외/조회 실패(null) 시 카드 자체를 숨김.
+ * KRX 관례: 매도호가(위) 파랑, 매수호가(아래) 빨강. 잔량은 막대로 비례 표시.
+ */
+export default function OrderbookCard({ ticker }: { ticker: string }) {
+  const [data, setData] = useState<OrderbookData | null>(null);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setData(null);
+
+    const load = async () => {
+      try {
+        const ob = await getOrderbook(ticker);
+        if (alive) setData(ob);
+        return ob;
+      } catch {
+        if (alive) setData(null);
+        return null;
+      }
+    };
+
+    load().then((ob) => {
+      if (timer.current) clearInterval(timer.current);
+      // 데이터가 있을 때(장중)만 폴링
+      if (ob) {
+        timer.current = setInterval(async () => {
+          try {
+            const next = await getOrderbook(ticker);
+            if (alive) {
+              setData(next);
+              if (!next && timer.current) clearInterval(timer.current); // 장 마감
+            }
+          } catch {
+            /* 일시 오류 무시 */
+          }
+        }, 5_000);
+      }
+    });
+
+    return () => {
+      alive = false;
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, [ticker]);
+
+  if (!data) return null; // KIS 미연동/장 외 → 숨김
+
+  const maxQty = Math.max(
+    1,
+    ...data.asks.map((a) => a.qty),
+    ...data.bids.map((b) => b.qty),
+  );
+  const fmt = (n: number) => n.toLocaleString("ko-KR");
+
+  // 매도호가: 고가 → 저가 순으로 위에서 아래 (API는 1단계=최저 매도가라 역순)
+  const asksTopDown = [...data.asks].reverse();
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-semibold text-gray-700">📋 호가 10단계</span>
+        <span className="rounded-full bg-red-50 px-2 py-0.5 text-[11px] text-red-600">
+          🔴 실시간 (KIS){data.timestamp ? ` · ${data.timestamp}` : ""}
+        </span>
+      </div>
+
+      {/* 매도호가 (파랑, 위) */}
+      <div className="space-y-0.5">
+        {asksTopDown.map((a, i) => (
+          <Row key={`a${i}`} price={a.price} qty={a.qty} maxQty={maxQty} side="ask" fmt={fmt} />
+        ))}
+      </div>
+      <div className="my-1 border-t border-dashed border-gray-200" />
+      {/* 매수호가 (빨강, 아래) */}
+      <div className="space-y-0.5">
+        {data.bids.map((b, i) => (
+          <Row key={`b${i}`} price={b.price} qty={b.qty} maxQty={maxQty} side="bid" fmt={fmt} />
+        ))}
+      </div>
+
+      <div className="mt-2 flex justify-between text-[11px] text-gray-400">
+        <span>총 매도잔량 {fmt(data.total_ask_qty)}</span>
+        <span>총 매수잔량 {fmt(data.total_bid_qty)}</span>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  price,
+  qty,
+  maxQty,
+  side,
+  fmt,
+}: {
+  price: number;
+  qty: number;
+  maxQty: number;
+  side: "ask" | "bid";
+  fmt: (n: number) => string;
+}) {
+  const pct = Math.round((qty / maxQty) * 100);
+  const barColor = side === "ask" ? "bg-blue-100" : "bg-red-100";
+  const priceColor = side === "ask" ? "text-blue-600" : "text-red-600";
+  return (
+    <div className="grid grid-cols-2 items-center gap-1 text-xs tabular-nums">
+      <span className={`text-right ${priceColor}`}>{price ? fmt(price) : "-"}</span>
+      <div className="relative h-5 overflow-hidden rounded">
+        <div
+          className={`absolute inset-y-0 left-0 ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+        <span className="relative z-10 ml-1 leading-5 text-gray-600">
+          {qty ? fmt(qty) : ""}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   OverviewResponse,
   VisitorResponse,
   PriceData,
+  OrderbookData,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
@@ -154,6 +155,16 @@ export async function getPrice(ticker: string): Promise<PriceData | null> {
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`price ${res.status}`);
   return (await res.json()) as PriceData;
+}
+
+/** 호가 10단계 (KIS 전용). KIS 미연동/장 외/실패 시 null. */
+export async function getOrderbook(ticker: string): Promise<OrderbookData | null> {
+  const url = new URL(`${API_BASE}/tabs/orderbook`);
+  url.searchParams.set("ticker", ticker);
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`orderbook ${res.status}`);
+  return (await res.json()) as OrderbookData;
 }
 
 /** 장중 시세 차트 (yfinance 15분봉). 장 외/데이터 없으면 null. */

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -97,6 +97,22 @@ export interface PriceData {
   market_open: boolean;
 }
 
+/** 호가 10단계 (/tabs/orderbook, KIS 전용) */
+export interface OrderbookLevel {
+  price: number;
+  qty: number;
+}
+export interface OrderbookData {
+  name: string;
+  ticker: string;
+  asks: OrderbookLevel[]; // 매도호가 1~10
+  bids: OrderbookLevel[]; // 매수호가 1~10
+  total_ask_qty: number;
+  total_bid_qty: number;
+  timestamp: string | null;
+  source: string;
+}
+
 /** /tabs/financial 응답 */
 export interface FinancialRow {
   fiscal_year: number;

--- a/ETF_RAG/src/data/kis_client.py
+++ b/ETF_RAG/src/data/kis_client.py
@@ -32,6 +32,9 @@ _token_lock = threading.Lock()
 # 현재가 캐시: {ticker: {"data": dict, "fetched_at": float}}
 _price_cache: dict = {}
 
+# 호가 캐시: {ticker: {"data": dict, "fetched_at": float}}
+_orderbook_cache: dict = {}
+
 
 def _kis_config() -> dict:
     """config.KIS 를 매 호출 시 읽어 테스트에서 patch 가능하게 한다."""
@@ -234,7 +237,106 @@ def get_current_price(ticker: str, cache_ttl: int = 300) -> Optional[dict]:
     return parsed
 
 
+# ── 호가 10단계 조회 ──────────────────────────────────────
+
+def _parse_orderbook_output(output: dict) -> Optional[dict]:
+    """KIS inquire-asking-price-exp-ccn output1 → 호가 10단계 표준 구조.
+
+    askp{1..10}/bidp{1..10} 호가, askp_rsqn{1..10}/bidp_rsqn{1..10} 잔량,
+    total_askp_rsqn/total_bidp_rsqn 총잔량.
+    Returns {"asks": [{"price","qty"}×10(고가→저가)], "bids": [...(고가→저가)],
+             "total_ask_qty", "total_bid_qty", "timestamp", "source"} 또는 None.
+    """
+    def _to_int(v):
+        try:
+            return int(float(v))
+        except (TypeError, ValueError):
+            return 0
+
+    asks, bids = [], []
+    for i in range(1, 11):
+        ap = _to_int(output.get(f"askp{i}"))
+        aq = _to_int(output.get(f"askp_rsqn{i}"))
+        bp = _to_int(output.get(f"bidp{i}"))
+        bq = _to_int(output.get(f"bidp_rsqn{i}"))
+        asks.append({"price": ap, "qty": aq})
+        bids.append({"price": bp, "qty": bq})
+
+    # 매도호가 전부 0이면 무효(장 외/조회 실패)
+    if not any(a["price"] for a in asks) and not any(b["price"] for b in bids):
+        return None
+
+    return {
+        "asks": asks,   # 1단계(최우선 매도, 최저가) → 10단계 순
+        "bids": bids,   # 1단계(최우선 매수, 최고가) → 10단계 순
+        "total_ask_qty": _to_int(output.get("total_askp_rsqn")),
+        "total_bid_qty": _to_int(output.get("total_bidp_rsqn")),
+        "timestamp": datetime.now(KST).strftime("%Y-%m-%d %H:%M"),
+        "source": "kis",
+    }
+
+
+def get_orderbook(ticker: str, cache_ttl: int = 5) -> Optional[dict]:
+    """국내 주식/ETF 호가 10단계 조회 (FHKST01010200).
+
+    호가는 빠르게 변하므로 기본 TTL 5초.
+
+    Returns:
+        성공 시 _parse_orderbook_output 구조, 실패/비활성 시 None.
+    """
+    if not is_enabled():
+        return None
+
+    now = time.time()
+    cached = _orderbook_cache.get(ticker)
+    if cached and (now - cached["fetched_at"]) < cache_ttl:
+        return cached["data"]
+
+    token = _get_access_token()
+    if not token:
+        return None
+
+    cfg = _kis_config()
+    import requests
+    url = (f"{cfg['base_url']}"
+           "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn")
+    headers = {
+        "content-type": "application/json; charset=utf-8",
+        "authorization": f"Bearer {token}",
+        "appkey": cfg["app_key"],
+        "appsecret": cfg["app_secret"],
+        "tr_id": "FHKST01010200",
+    }
+    params = {
+        "fid_cond_mrkt_div_code": "J",   # J: 주식/ETF/ETN
+        "fid_input_iscd": ticker,
+    }
+
+    try:
+        resp = requests.get(url, headers=headers, params=params,
+                            timeout=cfg.get("timeout", 5))
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        logger.warning(f"KIS 호가 조회 실패 ({ticker}): {e}")
+        return None
+
+    if data.get("rt_cd") != "0":
+        logger.warning(f"KIS 호가 응답 오류 ({ticker}): "
+                       f"{data.get('msg_cd')} {data.get('msg1')}")
+        return None
+
+    # 호가정보는 output1 (output2는 예상체결정보)
+    parsed = _parse_orderbook_output(data.get("output1", {}))
+    if parsed is None:
+        return None
+
+    _orderbook_cache[ticker] = {"data": parsed, "fetched_at": now}
+    return parsed
+
+
 def clear_cache() -> None:
-    """현재가/토큰 인메모리 캐시 초기화 (디스크 캐시는 유지)."""
+    """현재가/호가/토큰 인메모리 캐시 초기화 (디스크 캐시는 유지)."""
     _price_cache.clear()
+    _orderbook_cache.clear()
     _token_state.clear()

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -327,6 +327,55 @@ def test_price_404_when_unresolved(client):
     assert r.status_code == 404
 
 
+# ── 호가 /tabs/orderbook ───────────────────────────────────────────
+def _ob():
+    return {
+        "asks": [{"price": 70000 + i * 100, "qty": i * 10} for i in range(1, 11)],
+        "bids": [{"price": 69900 - i * 100, "qty": i * 20} for i in range(1, 11)],
+        "total_ask_qty": 5500, "total_bid_qty": 11000,
+        "timestamp": "2026-06-12 10:00", "source": "kis",
+    }
+
+
+def test_orderbook_success(client):
+    structured = {"ticker": "005930", "name": "삼성전자"}
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.kis_client.is_enabled", return_value=True), \
+         patch("src.data.kis_client.get_orderbook", return_value=_ob()):
+        r = client.get("/tabs/orderbook", params={"ticker": "삼성전자"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["ticker"] == "005930"
+    assert len(b["asks"]) == 10 and len(b["bids"]) == 10
+    assert b["asks"][0] == {"price": 70100, "qty": 10}
+    assert b["total_bid_qty"] == 11000
+    assert b["source"] == "kis"
+
+
+def test_orderbook_404_when_kis_disabled(client):
+    structured = {"ticker": "005930", "name": "삼성전자"}
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.kis_client.is_enabled", return_value=False):
+        r = client.get("/tabs/orderbook", params={"ticker": "삼성전자"})
+    assert r.status_code == 404
+
+
+def test_orderbook_404_when_no_data(client):
+    """KIS 활성이나 장 외/조회 실패(None) → 404."""
+    structured = {"ticker": "005930", "name": "삼성전자"}
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.kis_client.is_enabled", return_value=True), \
+         patch("src.data.kis_client.get_orderbook", return_value=None):
+        r = client.get("/tabs/orderbook", params={"ticker": "삼성전자"})
+    assert r.status_code == 404
+
+
+def test_orderbook_404_when_unresolved(client):
+    with patch("api.tabs._find_structured_data", return_value=None):
+        r = client.get("/tabs/orderbook", params={"ticker": "ZZZ"})
+    assert r.status_code == 404
+
+
 # ── 가드 ───────────────────────────────────────────────────────────
 def test_tabs_require_ready_503(client):
     # ready=False면 503 (require_ready 의존성)

--- a/ETF_RAG/tests/test_kis_client.py
+++ b/ETF_RAG/tests/test_kis_client.py
@@ -13,6 +13,7 @@ def _isolate_kis(tmp_path):
     """매 테스트마다 인메모리 캐시 초기화 + 토큰 디스크 캐시를 임시 경로로 격리."""
     kis_client.clear_cache()
     kis_client._price_cache.clear()
+    kis_client._orderbook_cache.clear()
     kis_client._token_state.clear()
     with patch.object(kis_client, "_TOKEN_CACHE_PATH",
                       tmp_path / "kis_token.json"):
@@ -229,6 +230,100 @@ def test_get_current_price_no_token_none():
     with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
          patch("requests.post", side_effect=Exception("token fail")):
         assert kis_client.get_current_price("005930") is None
+
+
+# ── 호가 10단계 파싱 ──────────────────────────────────────
+
+def _make_orderbook_output():
+    """askp1~10/bidp1~10 + 잔량 + 총잔량 샘플."""
+    out = {}
+    for i in range(1, 11):
+        out[f"askp{i}"] = str(70000 + i * 100)        # 매도호가 (i↑ = 고가)
+        out[f"askp_rsqn{i}"] = str(100 * i)           # 매도 잔량
+        out[f"bidp{i}"] = str(69900 - i * 100)        # 매수호가 (i↑ = 저가)
+        out[f"bidp_rsqn{i}"] = str(200 * i)           # 매수 잔량
+    out["total_askp_rsqn"] = "5500"
+    out["total_bidp_rsqn"] = "11000"
+    return out
+
+
+def test_parse_orderbook_output_full():
+    p = kis_client._parse_orderbook_output(_make_orderbook_output())
+    assert len(p["asks"]) == 10
+    assert len(p["bids"]) == 10
+    assert p["asks"][0] == {"price": 70100, "qty": 100}
+    assert p["asks"][9] == {"price": 71000, "qty": 1000}
+    assert p["bids"][0] == {"price": 69800, "qty": 200}
+    assert p["total_ask_qty"] == 5500
+    assert p["total_bid_qty"] == 11000
+    assert p["source"] == "kis"
+
+
+def test_parse_orderbook_output_all_zero_none():
+    out = {f"askp{i}": "0" for i in range(1, 11)}
+    out.update({f"bidp{i}": "0" for i in range(1, 11)})
+    assert kis_client._parse_orderbook_output(out) is None
+
+
+def test_parse_orderbook_output_malformed_qty_zero():
+    """잔량 필드가 비거나 비정상이면 0으로."""
+    out = _make_orderbook_output()
+    out["askp_rsqn1"] = ""
+    out["bidp_rsqn1"] = None
+    p = kis_client._parse_orderbook_output(out)
+    assert p["asks"][0]["qty"] == 0
+    assert p["bids"][0]["qty"] == 0
+    assert p["asks"][0]["price"] == 70100  # 가격은 유효
+
+
+# ── 호가 조회 (통합) ──────────────────────────────────────
+
+def test_get_orderbook_disabled_none():
+    with patch.object(kis_client, "_kis_config", return_value=DISABLED_CFG):
+        assert kis_client.get_orderbook("005930") is None
+
+
+def test_get_orderbook_success():
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    ob_resp = _mock_resp({"rt_cd": "0", "output1": _make_orderbook_output()})
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", return_value=ob_resp) as get:
+        p = kis_client.get_orderbook("005930")
+    assert p["asks"][0]["price"] == 70100
+    assert p["total_bid_qty"] == 11000
+    _, kw = get.call_args
+    assert kw["headers"]["tr_id"] == "FHKST01010200"
+    assert kw["params"]["fid_input_iscd"] == "005930"
+    assert "inquire-asking-price-exp-ccn" in get.call_args[0][0]
+
+
+def test_get_orderbook_cache_hit():
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    ob_resp = _mock_resp({"rt_cd": "0", "output1": _make_orderbook_output()})
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", return_value=ob_resp) as get:
+        kis_client.get_orderbook("005930", cache_ttl=5)
+        kis_client.get_orderbook("005930", cache_ttl=5)
+    assert get.call_count == 1
+
+
+def test_get_orderbook_rt_cd_error_none():
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    err = _mock_resp({"rt_cd": "1", "msg_cd": "X", "msg1": "오류"})
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", return_value=err):
+        assert kis_client.get_orderbook("005930") is None
+
+
+def test_get_orderbook_http_error_none():
+    token_resp = _mock_resp({"access_token": "tok", "expires_in": 86400})
+    with patch.object(kis_client, "_kis_config", return_value=ENABLED_CFG), \
+         patch("requests.post", return_value=token_resp), \
+         patch("requests.get", side_effect=Exception("timeout")):
+        assert kis_client.get_orderbook("005930") is None
 
 
 # ── realtime.py 통합: KIS 우선 → yfinance fallback ────────


### PR DESCRIPTION
## 배경
사용자 "하나씩" 큐의 2번째 — KIS 호가 10단계 REST 연동. 현재가(PR #50/#52)와 동일 패턴.

## 변경
**kis_client** — `get_orderbook(ticker)`
- `FHKST01010200`, `/uapi/.../inquire-asking-price-exp-ccn`, 시장구분 `J`. **output1**에서 askp/bidp 1~10 가격+잔량 + total_askp_rsqn/total_bidp_rsqn 파싱. 5초 캐시. 전부 0이면 None. 토큰/캐시 인프라 재사용.

**백엔드** — `GET /tabs/orderbook?ticker=`
- `_orderbook_blocking`: 종목 해석 → KIS 조회. 호가는 KIS만 제공(yfinance 미지원) → **fallback 없음**, 미연동/장외/실패 시 404.
- `OrderbookResponse`/`OrderbookLevel`.

**프론트** — 기술 탭 호가창
- `getOrderbook()` + `OrderbookData`.
- `OrderbookCard`: 매도호가(파랑, 위)/매수호가(빨강, 아래) 10단계 + 잔량 비례 막대 + 총잔량. **5초 자동 갱신**, 데이터 없으면(KIS 미연동/장외) 카드 숨김.

## 검증
- 백엔드 `pytest test_kis_client + test_api_tabs + test_realtime` **82 pass**(kis_client +8, api_tabs +4).
- 프론트 `npm run build` 통과.
- **라이브 검증**: 실 KIS 키로 005930 호가 조회 — asks 322,500(11.3만주)/bids 322,000(5만주)/총잔량 정상. (KIS는 장 외에도 최근 스냅샷 반환.)

## 후속 ("하나씩" 큐)
KIS WebSocket 실시간 → 푸시(VAPID) → 유료 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)