### PR TITLE
KIS WebSocket 실시간 체결 (기술 탭 실시간 시세)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2262,5 +2262,22 @@ PR #50(KIS REST 현재가)을 SaaS 프론트에 실제로 보이게 함. 사용�
 
 ---
 
-_Last Updated: 2026-06-12 (PR #50 KIS REST 현재가 + #51 모바일 사이드바 드로워 + #52 기술탭 실시간 시세카드. KIS: kis_client.py OAuth캐시+FHKST01010100, realtime KIS우선→yfinance fallback, /tabs/price(source 배지·장중 30초 폴링). 모바일: 사이드바 lg:block→드로워(ChromeShell)+데이터탭 반응형. 테스트 671→api_tabs 24. 다음: KIS 호가→WebSocket→푸시→유료전환, Railway KIS env)_
+## Phase F-2: KIS 호가 10단계 (2026-06-12, PR #53)
+
+"하나씩" 큐 2번째. 현재가(#50/#52)와 동일 패턴 — REST 조회→백엔드→프론트.
+
+**kis_client `get_orderbook(ticker)`**: `FHKST01010200`, `/uapi/.../inquire-asking-price-exp-ccn`, 시장구분 J. **output1**(호가정보; output2는 예상체결)에서 askp/bidp 1~10 가격 + askp_rsqn/bidp_rsqn 잔량 + total_askp_rsqn/total_bidp_rsqn 파싱 → `{asks[10],bids[10],total_ask_qty,total_bid_qty}`. **5초 캐시**(호가는 빨리 변함). 전부 0이면 None. 기존 토큰/캐시/Lock 인프라 재사용(get_current_price와 병렬 구조, _orderbook_cache 별도).
+
+**백엔드 `GET /tabs/orderbook?ticker=`**: `_orderbook_blocking`(종목 해석→KIS 조회). **호가는 KIS만 제공(yfinance 미지원) → fallback 없음** — 미연동/장외/실패 시 404. OrderbookResponse/OrderbookLevel.
+
+**프론트 OrderbookCard**: 매도호가(파랑, 위, API 1단계=최저가라 reverse해서 고가 위로)/매수호가(빨강, 아래) 10단계 + 잔량 비례 막대 + 총잔량. **5초 자동 갱신**, null이면(KIS 미연동/장외) **카드 숨김**. 기술 탭 PriceCard 아래.
+
+**검증**: 백엔드 82 pass(kis_client +8: 파싱 3·조회 5, api_tabs +4). 프론트 build 통과. **라이브**: 005930 asks 322,500(11.3만주)/bids 322,000(5만주)/총잔량 정상. **발견**: KIS는 장 외에도 최근(종가) 호가 스냅샷을 반환 → OrderbookCard가 장외에도 표시됨(의도대로 동작, 무해).
+
+### 다음
+- (남은 "하나씩" 큐) KIS WebSocket 실시간 스트리밍 → 푸시(VAPID) → 유료 전환. + Railway KIS env 등록(사용자), 블로그 9편.
+
+---
+
+_Last Updated: 2026-06-12 (PR #50 KIS REST 현재가 + #51 모바일 드로워 + #52 기술탭 시세카드 + #53 KIS 호가 10단계. KIS: kis_client.py(현재가 FHKST01010100 + 호가 FHKST01010200), /tabs/price·/tabs/orderbook, 기술탭 PriceCard+OrderbookCard(장중 폴링·source 배지). 모바일: 드로워(ChromeShell)+반응형. 테스트 kis_client 30·api_tabs 28. 다음: KIS WebSocket→푸시→유료전환, Railway KIS env)_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -528,7 +528,7 @@ ETF_RAG/
 
 ---
 
-_Last Updated: 2026-06-12 (Phase F-2 진행 — KIS 실시간 현재가 REST PR #50(kis_client.py OAuth캐시+FHKST01010100, realtime KIS우선→yfinance) + 모바일 사이드바 드로워 PR #51(ChromeShell, 데이터탭 반응형) + 기술탭 실시간 시세카드 PR #52(/tabs/price, source 배지·장중 30초 폴링). 장중 라이브 검증. 도구 14개, eval 172개, Hit Rate 100%, F=0.688, AR=0.709, CR=0.854. 상세: CLAUDE.local.md "Phase F-2"/"Phase F-mobile")_
+_Last Updated: 2026-06-12 (Phase F-2 진행 — KIS 실시간 현재가 REST PR #50(kis_client.py OAuth캐시+FHKST01010100, realtime KIS우선→yfinance) + 모바일 사이드바 드로워 PR #51(ChromeShell, 데이터탭 반응형) + 기술탭 실시간 시세카드 PR #52(/tabs/price) + KIS 호가 10단계 PR #53(FHKST01010200, /tabs/orderbook, 기술탭 OrderbookCard). 장중 라이브 검증. 도구 14개, eval 172개, Hit Rate 100%, F=0.688, AR=0.709, CR=0.854. 상세: CLAUDE.local.md "Phase F-2"/"Phase F-mobile")_
 
 > ✅ **CI 액션 Node 24 대응 완료** (2026-06-08): `checkout@v4→v6`, `setup-python@v5→v6` (ci.yml + daily-collect.yml 4곳). CI green 확인. 2026-06-16 Node 24 강제 전환 대비.
 

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -7,11 +7,14 @@ src/ui/tabs.py는 streamlit 의존이라 import 금지 — _build_sector_stats�
 이벤트 루프 보호, None이면 404. summary는 name을 안 주므로 _find_structured_data로 먼저 해석.
 """
 
+import asyncio
+import json
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
+from sse_starlette.sse import EventSourceResponse
 
 from api.deps import require_ready
 from api.models import (
@@ -313,6 +316,41 @@ async def price(ticker: str = Query(..., min_length=1)):
     if not result:
         raise HTTPException(404, f"'{ticker}'을(를) 찾을 수 없습니다.")
     return PriceResponse(**result)
+
+
+@router.get("/price/stream")
+async def price_stream(request: Request, ticker: str = Query(..., min_length=1)):
+    """체결 틱 실시간 SSE (KIS WebSocket). KIS 미연동/연결 실패 시 `unavailable`
+    이벤트 1건 후 종료 → 프론트는 REST 폴링으로 fallback.
+
+    이벤트: tick(체결 dict) / unavailable / (자동 close)
+    """
+    # 종목 해석 (이름/티커 → 6자리 티커)
+    data = await run_in_threadpool(_find_structured_data, ticker)
+    code = data.get("ticker") if data else ticker
+
+    from src.data import kis_ws
+    mgr = kis_ws.get_manager()
+
+    async def _source():
+        q = await mgr.subscribe(code)
+        if q is None:
+            yield {"event": "unavailable", "data": "KIS 실시간 미연동"}
+            return
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    tick = await asyncio.wait_for(q.get(), timeout=15)
+                    yield {"event": "tick",
+                           "data": json.dumps(tick, ensure_ascii=False)}
+                except asyncio.TimeoutError:
+                    yield {"event": "ping", "data": ""}  # keep-alive
+        finally:
+            await mgr.unsubscribe(code, q)
+
+    return EventSourceResponse(_source())
 
 
 # ── 호가 10단계 (KIS 전용, 장중) ───────────────────────────

--- a/ETF_RAG/frontend/src/components/PriceCard.tsx
+++ b/ETF_RAG/frontend/src/components/PriceCard.tsx
@@ -1,56 +1,92 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { getPrice } from "@/lib/api";
+import { getPrice, streamPrice } from "@/lib/api";
 import type { PriceData } from "@/lib/types";
 
 /**
  * 종목 실시간 시세 카드.
- * - 장중: KIS 실시간(또는 yfinance 지연)을 30초마다 자동 갱신
- * - 장 외: 수집 종가 1회 표시(자동 갱신 없음)
- * source 배지로 출처 구분(🔴 실시간 / 🟡 지연 / 종가).
+ * - 1순위: KIS WebSocket SSE(체결 틱 실시간) — source 배지 "실시간 (KIS)"
+ * - fallback: SSE 미연동/장외/오류 시 REST 폴링(장중 30초; KIS우선→yfinance→종가)
+ * 먼저 REST 1회로 기준값(prev_close 등)을 채운 뒤 SSE 틱으로 price/change를 갱신한다.
  */
 export default function PriceCard({ ticker }: { ticker: string }) {
   const [data, setData] = useState<PriceData | null>(null);
   const [loading, setLoading] = useState(true);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [live, setLive] = useState(false); // SSE 틱 수신 중인지
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const sseCtrl = useRef<AbortController | null>(null);
 
   useEffect(() => {
     let alive = true;
     setLoading(true);
     setData(null);
+    setLive(false);
 
-    const load = async () => {
-      try {
-        const p = await getPrice(ticker);
-        if (alive) setData(p);
-      } catch {
-        if (alive) setData(null);
-      } finally {
-        if (alive) setLoading(false);
-      }
+    const clearPoll = () => {
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      pollTimer.current = null;
     };
 
-    load().then(() => {
-      // 장중일 때만 30초 폴링 (load 결과는 다음 tick에서 확인 — is_live 기준)
-      if (timer.current) clearInterval(timer.current);
-      timer.current = setInterval(async () => {
+    const startPolling = () => {
+      clearPoll();
+      pollTimer.current = setInterval(async () => {
         try {
           const p = await getPrice(ticker);
           if (alive && p && p.is_live) setData(p);
-          else if (alive && p && !p.market_open && timer.current) {
-            clearInterval(timer.current); // 장 마감 감지 시 폴링 중단
-          }
+          else if (alive && p && !p.market_open) clearPoll(); // 장 마감
         } catch {
-          /* 일시 오류 무시 */
+          /* ignore */
         }
       }, 30_000);
-    });
+    };
+
+    // 1) REST 1회로 기준값 확보
+    getPrice(ticker)
+      .then((p) => {
+        if (!alive) return;
+        if (p) setData(p);
+        setLoading(false);
+
+        // 2) KIS WebSocket SSE 시도 (틱 수신 시 live, 아니면 폴링 fallback)
+        sseCtrl.current = streamPrice(ticker, {
+          onTick: (t) => {
+            if (!alive) return;
+            setLive(true);
+            clearPoll(); // 실시간 받으면 폴링 불필요
+            setData((prev) => ({
+              ...(prev ?? ({} as PriceData)),
+              name: prev?.name ?? "",
+              ticker: t.ticker || ticker,
+              price: t.price,
+              change: t.change,
+              change_pct: t.change_pct,
+              volume: t.volume ?? prev?.volume ?? null,
+              prev_close: prev?.prev_close ?? null,
+              source: "kis",
+              is_live: true,
+              market_open: true,
+              timestamp: t.timestamp ?? prev?.timestamp ?? null,
+            }));
+          },
+          onUnavailable: () => {
+            if (alive) startPolling(); // KIS 미연동/장외 → 폴링
+          },
+          onError: () => {
+            if (alive && !live) startPolling();
+          },
+        });
+      })
+      .catch(() => {
+        if (alive) setLoading(false);
+      });
 
     return () => {
       alive = false;
-      if (timer.current) clearInterval(timer.current);
+      clearPoll();
+      if (sseCtrl.current) sseCtrl.current.abort();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ticker]);
 
   if (loading) {
@@ -67,8 +103,11 @@ export default function PriceCard({ ticker }: { ticker: string }) {
   const color = up ? "text-red-600" : down ? "text-blue-600" : "text-gray-500";
 
   const badge =
-    data.source === "kis"
-      ? { label: "🔴 실시간 (KIS)", cls: "bg-red-50 text-red-600" }
+    live || data.source === "kis"
+      ? {
+          label: live ? "🔴 실시간 (KIS)" : "🔴 KIS",
+          cls: "bg-red-50 text-red-600",
+        }
       : data.source === "yfinance"
         ? { label: "🟡 15분 지연 (yfinance)", cls: "bg-yellow-50 text-yellow-700" }
         : { label: "종가", cls: "bg-gray-100 text-gray-500" };
@@ -90,7 +129,9 @@ export default function PriceCard({ ticker }: { ticker: string }) {
             </span>
           )}
         </div>
-        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] ${badge.cls}`}>
+        <span
+          className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] ${badge.cls} ${live ? "animate-pulse" : ""}`}
+        >
           {badge.label}
         </span>
       </div>

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -157,6 +157,45 @@ export async function getPrice(ticker: string): Promise<PriceData | null> {
   return (await res.json()) as PriceData;
 }
 
+/**
+ * 체결 틱 실시간 SSE (KIS WebSocket). 콜백으로 틱/unavailable 전달.
+ * AbortController 반환 — .abort()로 연결 종료(구독 해제 트리거).
+ * KIS 미연동/장외면 onUnavailable 호출(프론트가 REST 폴링으로 fallback).
+ */
+export function streamPrice(
+  ticker: string,
+  cb: {
+    onTick: (t: PriceData) => void;
+    onUnavailable: () => void;
+    onError?: () => void;
+  },
+): AbortController {
+  const ctrl = new AbortController();
+  const url = new URL(`${API_BASE}/tabs/price/stream`);
+  url.searchParams.set("ticker", ticker);
+  fetchEventSource(url.toString(), {
+    signal: ctrl.signal,
+    openWhenHidden: true,
+    onmessage(ev) {
+      if (ev.event === "tick") {
+        try {
+          cb.onTick(JSON.parse(ev.data) as PriceData);
+        } catch {
+          /* ignore */
+        }
+      } else if (ev.event === "unavailable") {
+        cb.onUnavailable();
+      }
+      // "ping"은 keep-alive — 무시
+    },
+    onerror(err) {
+      cb.onError?.();
+      throw err; // 자동 재연결 중단 (fallback은 PriceCard가 담당)
+    },
+  });
+  return ctrl;
+}
+
 /** 호가 10단계 (KIS 전용). KIS 미연동/장 외/실패 시 null. */
 export async function getOrderbook(ticker: string): Promise<OrderbookData | null> {
   const url = new URL(`${API_BASE}/tabs/orderbook`);

--- a/ETF_RAG/requirements.txt
+++ b/ETF_RAG/requirements.txt
@@ -26,6 +26,7 @@ fastapi>=0.110.0,<1.0
 uvicorn>=0.27.0,<1.0
 sse-starlette>=2.0.0,<3.0
 httpx>=0.27.0,<1.0
+websockets>=12.0,<16  # KIS WebSocket 실시간 체결 (kis_ws.py)
 sqlalchemy>=2.0,<3
 psycopg2-binary>=2.9,<3
 PyJWT>=2.8,<3

--- a/ETF_RAG/src/data/kis_ws.py
+++ b/ETF_RAG/src/data/kis_ws.py
@@ -1,0 +1,261 @@
+"""
+한국투자증권(KIS) WebSocket 실시간 체결가 — 온디맨드 구독 매니저 (F-2)
+
+설계: 프로세스당 KIS WS 단일 연결을 공유하고, 종목별 구독을 refcount로 관리한다.
+- 첫 구독 시 lazy 연결, 마지막 구독 해제 시 연결 종료 → 유휴 시 연결 0
+- H0STCNT0(실시간 체결) 파싱 → 최신 틱을 ticker별로 보관 + 구독자 큐로 broadcast
+- KIS는 H0STCNT0+H0STASP0 합산 20종목 제한 → 온디맨드라 단일 종목 위주로 자연 회피
+- 비활성(키 없음)이면 connect()가 False → 호출자(SSE)가 REST 폴링으로 fallback
+
+asyncio 기반 — FastAPI 이벤트 루프 안에서 동작. websockets 패키지 사용.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+KST = timezone(timedelta(hours=9))
+
+# H0STCNT0 실시간 체결 — 레코드당 필드 수(메뉴 항목 수)
+_CNT0_FIELDS = 46
+
+
+def _ws_url() -> str:
+    """KIS WebSocket URL (real/vps)."""
+    from config import KIS
+    return ("ws://ops.koreainvestment.com:31000"
+            if KIS.get("env") == "vps"
+            else "ws://ops.koreainvestment.com:21000")
+
+
+def _get_approval_key() -> Optional[str]:
+    """WebSocket 접속키(approval_key) 발급. REST 토큰과 별개 (oauth2/Approval)."""
+    from config import KIS
+    if not KIS.get("enabled"):
+        return None
+    import requests
+    url = f"{KIS['base_url']}/oauth2/Approval"
+    body = {
+        "grant_type": "client_credentials",
+        "appkey": KIS["app_key"],
+        "secretkey": KIS["app_secret"],   # ⚠️ Approval은 secretkey (토큰은 appsecret)
+    }
+    try:
+        resp = requests.post(url, json=body, timeout=KIS.get("timeout", 5))
+        resp.raise_for_status()
+        return resp.json().get("approval_key")
+    except Exception as e:
+        logger.warning(f"KIS approval_key 발급 실패: {e}")
+        return None
+
+
+def parse_cnt0_record(fields: list) -> Optional[dict]:
+    """H0STCNT0 레코드(46필드, '^' split) → 체결 틱 dict.
+
+    필드: 0=종목코드 1=체결시간 2=현재가 3=전일대비부호 4=전일대비 5=전일대비율
+          13=누적거래량
+    """
+    if len(fields) < 14:
+        return None
+
+    def _f(i):
+        try:
+            return float(fields[i])
+        except (TypeError, ValueError, IndexError):
+            return None
+
+    def _i(i):
+        v = _f(i)
+        return int(v) if v is not None else None
+
+    price = _f(2)
+    if price is None or price <= 0:
+        return None
+    sign = fields[3] if len(fields) > 3 else ""   # 4·5=하락
+    change = _f(4)
+    change_pct = _f(5)
+    if change is not None and sign in ("4", "5"):
+        change = -abs(change)
+    if change_pct is not None and sign in ("4", "5"):
+        change_pct = -abs(change_pct)
+
+    hhmmss = fields[1] if len(fields) > 1 else ""
+    ts = datetime.now(KST).strftime("%Y-%m-%d %H:%M")
+    if len(hhmmss) == 6:
+        ts = f"{hhmmss[:2]}:{hhmmss[2:4]}:{hhmmss[4:6]}"
+
+    return {
+        "ticker": fields[0],
+        "price": round(price),
+        "change": round(change) if change is not None else None,
+        "change_pct": round(change_pct, 2) if change_pct is not None else None,
+        "volume": _i(13),
+        "timestamp": ts,
+        "source": "kis-ws",
+    }
+
+
+class KisWsManager:
+    """KIS WebSocket 단일 연결 + 종목별 refcount 구독 매니저 (싱글턴)."""
+
+    def __init__(self):
+        self._ws = None
+        self._task: Optional[asyncio.Task] = None
+        self._lock = asyncio.Lock()
+        self._approval: Optional[str] = None
+        # ticker → 구독자 asyncio.Queue 집합
+        self._subscribers: dict = {}
+        # ticker → 최신 틱 dict
+        self._latest: dict = {}
+
+    def is_enabled(self) -> bool:
+        from config import KIS
+        return bool(KIS.get("enabled"))
+
+    async def _connect(self) -> bool:
+        """WS 연결 + 수신 루프 시작 (이미 연결돼 있으면 True)."""
+        if self._ws is not None:
+            return True
+        if not self.is_enabled():
+            return False
+        self._approval = await asyncio.get_running_loop().run_in_executor(
+            None, _get_approval_key)
+        if not self._approval:
+            return False
+        try:
+            import websockets
+            self._ws = await websockets.connect(
+                _ws_url(), ping_interval=None, max_size=None)
+        except Exception as e:
+            logger.warning(f"KIS WS 연결 실패: {e}")
+            self._ws = None
+            return False
+        self._task = asyncio.ensure_future(self._recv_loop())
+        logger.info("KIS WS 연결됨")
+        return True
+
+    async def _disconnect(self):
+        if self._task:
+            self._task.cancel()
+            self._task = None
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+        self._approval = None
+        logger.info("KIS WS 연결 종료")
+
+    def _sub_msg(self, ticker: str, register: bool) -> str:
+        """H0STCNT0 구독/해제 메시지. tr_type 1=등록, 2=해제."""
+        return json.dumps({
+            "header": {
+                "approval_key": self._approval,
+                "custtype": "P",
+                "tr_type": "1" if register else "2",
+                "content-type": "utf-8",
+            },
+            "body": {"input": {"tr_id": "H0STCNT0", "tr_key": ticker}},
+        })
+
+    async def _recv_loop(self):
+        """WS 수신 → H0STCNT0 파싱 → 최신 틱 보관 + 구독자 broadcast. PINGPONG 응답."""
+        try:
+            while self._ws is not None:
+                data = await self._ws.recv()
+                if not data:
+                    continue
+                if data[0] in ("0", "1"):
+                    # 실시간 데이터: '0|H0STCNT0|<count>|<fields^...>'
+                    parts = data.split("|", 3)
+                    if len(parts) < 4 or parts[1] != "H0STCNT0":
+                        continue
+                    try:
+                        count = int(parts[2])
+                    except ValueError:
+                        count = 1
+                    fields_all = parts[3].split("^")
+                    for n in range(count):
+                        rec = fields_all[n * _CNT0_FIELDS:(n + 1) * _CNT0_FIELDS]
+                        tick = parse_cnt0_record(rec)
+                        if tick:
+                            self._latest[tick["ticker"]] = tick
+                            self._broadcast(tick["ticker"], tick)
+                else:
+                    # JSON: 구독 응답 or PINGPONG
+                    try:
+                        obj = json.loads(data)
+                    except Exception:
+                        continue
+                    if obj.get("header", {}).get("tr_id") == "PINGPONG":
+                        try:
+                            await self._ws.pong(data)
+                        except Exception:
+                            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"KIS WS 수신 루프 종료: {e}")
+            # 연결이 끊김 — 정리 (재구독 시 _connect가 다시 연결)
+            self._ws = None
+
+    def _broadcast(self, ticker: str, tick: dict):
+        for q in list(self._subscribers.get(ticker, ())):
+            try:
+                q.put_nowait(tick)
+            except asyncio.QueueFull:
+                pass  # 느린 구독자는 드롭(최신성 우선)
+
+    async def subscribe(self, ticker: str) -> Optional[asyncio.Queue]:
+        """종목 구독 → 틱 수신용 Queue 반환. 비활성/연결 실패 시 None."""
+        async with self._lock:
+            if not await self._connect():
+                return None
+            first = ticker not in self._subscribers
+            q: asyncio.Queue = asyncio.Queue(maxsize=100)
+            self._subscribers.setdefault(ticker, set()).add(q)
+            if first:
+                try:
+                    await self._ws.send(self._sub_msg(ticker, True))
+                except Exception as e:
+                    logger.warning(f"KIS WS 구독 전송 실패 ({ticker}): {e}")
+            # 최신 틱이 이미 있으면 즉시 1건 제공(첫 화면 공백 방지)
+            if ticker in self._latest:
+                try:
+                    q.put_nowait(self._latest[ticker])
+                except asyncio.QueueFull:
+                    pass
+            return q
+
+    async def unsubscribe(self, ticker: str, q: asyncio.Queue):
+        """구독 해제. 해당 종목 구독자 0이면 KIS 구독 해제, 전체 0이면 연결 종료."""
+        async with self._lock:
+            subs = self._subscribers.get(ticker)
+            if subs and q in subs:
+                subs.discard(q)
+            if subs is not None and not subs:
+                self._subscribers.pop(ticker, None)
+                self._latest.pop(ticker, None)
+                if self._ws is not None:
+                    try:
+                        await self._ws.send(self._sub_msg(ticker, False))
+                    except Exception:
+                        pass
+            if not self._subscribers:
+                await self._disconnect()
+
+
+# 프로세스 싱글턴
+_manager: Optional[KisWsManager] = None
+
+
+def get_manager() -> KisWsManager:
+    global _manager
+    if _manager is None:
+        _manager = KisWsManager()
+    return _manager

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -376,6 +376,23 @@ def test_orderbook_404_when_unresolved(client):
     assert r.status_code == 404
 
 
+# ── 실시간 체결 SSE /tabs/price/stream ─────────────────────────────
+def test_price_stream_unavailable_when_subscribe_none(client):
+    """KIS WS 구독 실패(None) → unavailable 이벤트 1건 후 종료."""
+    structured = {"ticker": "005930", "name": "삼성전자"}
+
+    async def _no_sub(code):
+        return None
+
+    fake_mgr = MagicMock()
+    fake_mgr.subscribe = _no_sub
+    with patch("api.tabs._find_structured_data", return_value=structured), \
+         patch("src.data.kis_ws.get_manager", return_value=fake_mgr):
+        r = client.get("/tabs/price/stream", params={"ticker": "삼성전자"})
+    assert r.status_code == 200
+    assert "unavailable" in r.text
+
+
 # ── 가드 ───────────────────────────────────────────────────────────
 def test_tabs_require_ready_503(client):
     # ready=False면 503 (require_ready 의존성)

--- a/ETF_RAG/tests/test_kis_ws.py
+++ b/ETF_RAG/tests/test_kis_ws.py
@@ -1,0 +1,173 @@
+"""KIS WebSocket 실시간 체결 — 파서 + 온디맨드 구독 매니저 테스트."""
+
+import asyncio
+import json
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+from src.data import kis_ws
+
+
+# ── H0STCNT0 레코드 파서 ──────────────────────────────────
+
+def _cnt0_fields(price="70000", sign="2", change="500", pct="0.72",
+                 vol="12000000", t="103015", ticker="005930"):
+    """46필드 레코드 생성 (필요 인덱스만 채움)."""
+    f = [""] * kis_ws._CNT0_FIELDS
+    f[0] = ticker
+    f[1] = t
+    f[2] = price
+    f[3] = sign
+    f[4] = change
+    f[5] = pct
+    f[13] = vol
+    return f
+
+
+def test_parse_cnt0_rising():
+    p = kis_ws.parse_cnt0_record(_cnt0_fields())
+    assert p["ticker"] == "005930"
+    assert p["price"] == 70000
+    assert p["change"] == 500
+    assert p["change_pct"] == 0.72
+    assert p["volume"] == 12000000
+    assert p["timestamp"] == "10:30:15"
+    assert p["source"] == "kis-ws"
+
+
+def test_parse_cnt0_falling_sign():
+    p = kis_ws.parse_cnt0_record(
+        _cnt0_fields(sign="5", change="1000", pct="1.25"))
+    assert p["change"] == -1000
+    assert p["change_pct"] == -1.25
+
+
+def test_parse_cnt0_zero_price_none():
+    assert kis_ws.parse_cnt0_record(_cnt0_fields(price="0")) is None
+
+
+def test_parse_cnt0_too_short_none():
+    assert kis_ws.parse_cnt0_record(["005930", "1", "2"]) is None
+
+
+# ── 매니저: 구독/해제/broadcast ───────────────────────────
+
+ENABLED = {"enabled": True, "app_key": "k", "app_secret": "s",
+           "env": "real", "base_url": "https://x", "timeout": 5}
+DISABLED = {**ENABLED, "enabled": False}
+
+
+@pytest.fixture
+def mgr():
+    m = kis_ws.KisWsManager()
+    return m
+
+
+async def _block_forever(*a, **k):
+    """recv가 영원히 대기 → 수신 루프가 즉시 끝나지 않게."""
+    await asyncio.sleep(3600)
+
+
+def _fake_ws():
+    ws = MagicMock()
+    ws.send = AsyncMock()
+    ws.close = AsyncMock()
+    ws.pong = AsyncMock()
+    ws.recv = AsyncMock(side_effect=_block_forever)
+    return ws
+
+
+# pytest-asyncio 미사용 — 전용 이벤트 루프로 코루틴 구동.
+# (asyncio.run은 Python 3.9에서 현재 루프를 None으로 남겨 다음 테스트 setup이
+#  get_event_loop()에서 깨지므로, 직접 루프를 만들고 끝나면 새 루프로 교체한다.)
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        try:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        except Exception:
+            pass
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def test_subscribe_disabled_returns_none(mgr):
+    async def body():
+        with patch("config.KIS", DISABLED):
+            return await mgr.subscribe("005930")
+    assert _run(body()) is None
+
+
+def test_subscribe_connect_fail_returns_none(mgr):
+    async def body():
+        with patch("config.KIS", ENABLED), \
+             patch("src.data.kis_ws._get_approval_key", return_value=None):
+            return await mgr.subscribe("005930")
+    assert _run(body()) is None
+
+
+def test_subscribe_sends_register_and_broadcast(mgr):
+    fake = _fake_ws()
+
+    async def body():
+        with patch("config.KIS", ENABLED), \
+             patch("src.data.kis_ws._get_approval_key", return_value="appr"), \
+             patch("websockets.connect", AsyncMock(return_value=fake)):
+            q = await mgr.subscribe("005930")
+            assert q is not None
+            sent = json.loads(fake.send.call_args[0][0])
+            assert sent["body"]["input"]["tr_id"] == "H0STCNT0"
+            assert sent["body"]["input"]["tr_key"] == "005930"
+            assert sent["header"]["tr_type"] == "1"
+
+            # broadcast → 구독자 큐에 도달
+            mgr._broadcast("005930", {"ticker": "005930", "price": 71000})
+            got = await asyncio.wait_for(q.get(), timeout=1)
+            assert got["price"] == 71000
+            await mgr._disconnect()
+
+    _run(body())
+
+
+def test_unsubscribe_last_disconnects(mgr):
+    fake = _fake_ws()
+
+    async def body():
+        with patch("config.KIS", ENABLED), \
+             patch("src.data.kis_ws._get_approval_key", return_value="appr"), \
+             patch("websockets.connect", AsyncMock(return_value=fake)):
+            q = await mgr.subscribe("005930")
+            assert "005930" in mgr._subscribers
+            await mgr.unsubscribe("005930", q)
+        assert "005930" not in mgr._subscribers
+        assert mgr._ws is None
+        last = json.loads(fake.send.call_args[0][0])
+        assert last["header"]["tr_type"] == "2"  # 해제 메시지
+
+    _run(body())
+
+
+def test_refcount_two_subscribers_one_register(mgr):
+    fake = _fake_ws()
+
+    async def body():
+        with patch("config.KIS", ENABLED), \
+             patch("src.data.kis_ws._get_approval_key", return_value="appr"), \
+             patch("websockets.connect", AsyncMock(return_value=fake)):
+            q1 = await mgr.subscribe("005930")
+            q2 = await mgr.subscribe("005930")  # 같은 종목 2번째
+            register_sends = [c for c in fake.send.call_args_list
+                              if json.loads(c[0][0])["header"]["tr_type"] == "1"]
+            assert len(register_sends) == 1   # refcount → 등록 1회
+            assert len(mgr._subscribers["005930"]) == 2
+
+            await mgr.unsubscribe("005930", q1)
+            assert "005930" in mgr._subscribers  # q2 남음
+            await mgr.unsubscribe("005930", q2)
+            assert "005930" not in mgr._subscribers
+
+    _run(body())


### PR DESCRIPTION
## 배경
"하나씩" 큐 3번째 — KIS WebSocket 실시간 체결 틱. REST 폴링(#52)과 달리 체결 단위 즉시 갱신. **온디맨드 구독** 구조(사용자 합의): 종목을 볼 때만 연결·구독, 떠나면 해제.

## 변경
**`src/data/kis_ws.py` (신규)** — KisWsManager 싱글턴
- approval_key 발급(`oauth2/Approval`, ⚠️ `secretkey` 필드 — REST 토큰의 appsecret과 다름).
- 프로세스당 **단일 WS 연결** 공유, 종목별 **refcount 구독**(같은 종목 N구독→등록 1회).
- H0STCNT0 체결 파싱(46필드/레코드, 0=코드·2=현재가·4=전일대비·5=등락률·13=거래량, 하락부호 보정).
- 구독자 `asyncio.Queue` broadcast, 첫 구독 시 최신 틱 즉시 1건. PINGPONG 응답.
- **마지막 구독 해제 시 연결 종료** → 유휴 시 연결 0.

**백엔드 `GET /tabs/price/stream` (SSE)** — 구독→`tick` push, 클라 끊기면 unsubscribe. KIS 미연동/연결 실패 시 `unavailable` 1건 후 종료(프론트 fallback 트리거). 15초마다 ping keep-alive.

**프론트** — `streamPrice()` + PriceCard
- REST 1회로 기준값 확보 → KIS WS SSE 틱으로 price/change 실시간 갱신(배지 "🔴 실시간 (KIS)" + pulse).
- `unavailable`/오류 시 기존 **REST 30초 폴링으로 자동 fallback**.

**requirements**: `websockets` 명시(기존 yfinance transitive → 직접 의존).

## 검증
- 전체 **741 pass**(kis_ws 9: 파서 4 + 매니저 5, asyncio.run 직접 구동 — pytest-asyncio 미사용; api_tabs price_stream unavailable 1).
- 프론트 build 통과.
- **라이브 검증(월 11:12 KST 장중)**: 005930 체결 틱 실시간 수신(336,500→336,250원, change/거래량/시각) + 구독 해제 시 WS 연결 정상 종료.

## 후속 ("하나씩" 큐)
푸시(VAPID) → 유료 전환. + Railway 백엔드 KIS env 등록(사용자) 시 라이브에서도 실시간(미등록 시 REST fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)