### PR TITLE
웹 푸시 구독 인프라 (VAPID + 구독 토글)

### DIFF
--- a/ETF_RAG/.env.example
+++ b/ETF_RAG/.env.example
@@ -41,3 +41,10 @@ JWT_EXPIRE_MINUTES=10080
 # KIS_APP_SECRET=your-app-secret
 # KIS_ACCOUNT_NO=00000000          # 종합계좌 8자리 (주문 시 필요, 시세 조회엔 불필요)
 # KIS_ENV=real
+
+# --- 웹 푸시 알림 (VAPID, 선택) ---
+# python scripts/gen_vapid_keys.py 로 1회 생성해 고정. 미설정 시 푸시 비활성.
+# 키를 바꾸면 기존 구독은 전부 무효가 된다.
+# VAPID_PUBLIC_KEY=...
+# VAPID_PRIVATE_KEY=...
+# VAPID_SUBJECT=mailto:you@example.com

--- a/ETF_RAG/api/main.py
+++ b/ETF_RAG/api/main.py
@@ -44,6 +44,7 @@ from api.models import (
 from api.tabs import router as tabs_router
 from api.auth import router as auth_router, get_current_user_optional
 from api.user_data import router as user_data_router
+from api.push import router as push_router
 from api.models_db import User
 from src.utils.logging import log_feedback
 
@@ -92,6 +93,8 @@ app.include_router(tabs_router)
 app.include_router(auth_router)
 # 유저별 저장 — 관심종목/대화이력 (/me/*)
 app.include_router(user_data_router)
+# 웹 푸시 알림 — 구독/VAPID (/push/*)
+app.include_router(push_router)
 
 
 def _require_ready() -> None:

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -155,3 +155,29 @@ class OverviewResponse(BaseModel):
     top_etfs: List[InstrumentItem]
     top_stocks: List[InstrumentItem]
     sectors: List[str]  # 주식 섹터 목록
+
+
+# ── 웹 푸시 (VAPID) ─────────────────────────────────────
+class PushKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+
+class PushSubscribeRequest(BaseModel):
+    """브라우저 PushSubscription.toJSON() 형태."""
+    endpoint: str
+    keys: PushKeys
+
+
+class PushUnsubscribeRequest(BaseModel):
+    endpoint: str
+
+
+class VapidPublicKeyResponse(BaseModel):
+    public_key: str        # applicationServerKey (URL-safe base64). 미설정 시 ""
+    enabled: bool
+
+
+class PushStatusResponse(BaseModel):
+    ok: bool
+    detail: Optional[str] = None

--- a/ETF_RAG/api/models_db.py
+++ b/ETF_RAG/api/models_db.py
@@ -55,6 +55,22 @@ class Watchlist(Base):
     )
 
 
+class PushSubscription(Base):
+    """웹 푸시 구독 (브라우저 PushSubscription). user_id별, endpoint unique."""
+    __tablename__ = "push_subscriptions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), index=True, nullable=False
+    )
+    endpoint: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    p256dh: Mapped[str] = mapped_column(String(255), nullable=False)  # 구독 공개키
+    auth: Mapped[str] = mapped_column(String(255), nullable=False)    # 인증 시크릿
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, server_default=func.now()
+    )
+
+
 class ChatHistory(Base):
     __tablename__ = "chat_histories"
 

--- a/ETF_RAG/api/push.py
+++ b/ETF_RAG/api/push.py
@@ -1,0 +1,152 @@
+"""웹 푸시 알림 — 구독 등록/해제 + VAPID 공개키 + 발송 헬퍼 (Phase F 푸시 A).
+
+구독은 로그인 유저별(user_id) 저장. 발송 헬퍼 send_push_to_user는 PR-B(관심종목
+일일 알림)에서 재사용한다. VAPID 미설정 시 모든 발송은 graceful no-op.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from api.auth import get_current_user
+from api.db import get_db
+from api.models import (
+    PushStatusResponse,
+    PushSubscribeRequest,
+    PushUnsubscribeRequest,
+    VapidPublicKeyResponse,
+)
+from api.models_db import PushSubscription, User
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/push", tags=["push"])
+
+
+def _vapid():
+    from config import VAPID
+    return VAPID
+
+
+def send_push(subscription_info: dict, payload: dict) -> bool:
+    """단일 구독에 푸시 전송. 성공 True. 410/404(만료)면 False(호출자가 삭제).
+
+    VAPID 미설정/pywebpush 미설치 시 False (no-op).
+    """
+    cfg = _vapid()
+    if not cfg.get("enabled"):
+        return False
+    try:
+        from pywebpush import webpush, WebPushException
+    except ImportError:
+        logger.warning("pywebpush 미설치 — 푸시 발송 불가")
+        return False
+    try:
+        webpush(
+            subscription_info=subscription_info,
+            data=json.dumps(payload, ensure_ascii=False),
+            vapid_private_key=cfg["private_key"],
+            vapid_claims={"sub": cfg["subject"]},
+        )
+        return True
+    except WebPushException as e:
+        status = getattr(getattr(e, "response", None), "status_code", None)
+        if status in (404, 410):
+            logger.info(f"푸시 구독 만료(삭제 대상): {status}")
+            raise _SubscriptionGone()  # 호출자가 DB에서 삭제
+        logger.warning(f"푸시 발송 실패: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"푸시 발송 예외: {e}")
+        return False
+
+
+class _SubscriptionGone(Exception):
+    """구독이 만료(410/404) — DB에서 삭제해야 함."""
+
+
+def send_push_to_user(db: Session, user_id: int, payload: dict) -> int:
+    """유저의 모든 구독에 발송. 만료 구독은 삭제. 성공 발송 수 반환."""
+    subs = db.execute(
+        select(PushSubscription).where(PushSubscription.user_id == user_id)
+    ).scalars().all()
+    sent = 0
+    for s in subs:
+        info = {"endpoint": s.endpoint,
+                "keys": {"p256dh": s.p256dh, "auth": s.auth}}
+        try:
+            if send_push(info, payload):
+                sent += 1
+        except _SubscriptionGone:
+            db.delete(s)
+    db.commit()
+    return sent
+
+
+# ── 엔드포인트 ────────────────────────────────────────────
+@router.get("/vapid-public-key", response_model=VapidPublicKeyResponse)
+def vapid_public_key() -> VapidPublicKeyResponse:
+    """프론트 applicationServerKey용 공개키 (인증 불필요). 미설정 시 enabled=false."""
+    cfg = _vapid()
+    return VapidPublicKeyResponse(
+        public_key=cfg.get("public_key", ""), enabled=bool(cfg.get("enabled"))
+    )
+
+
+@router.put("/subscribe", response_model=PushStatusResponse)
+def subscribe(
+    req: PushSubscribeRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PushStatusResponse:
+    """브라우저 푸시 구독 저장(멱등 — endpoint 기준 upsert)."""
+    existing = db.execute(
+        select(PushSubscription).where(PushSubscription.endpoint == req.endpoint)
+    ).scalar_one_or_none()
+    if existing:
+        existing.user_id = user.id
+        existing.p256dh = req.keys.p256dh
+        existing.auth = req.keys.auth
+    else:
+        db.add(PushSubscription(
+            user_id=user.id, endpoint=req.endpoint,
+            p256dh=req.keys.p256dh, auth=req.keys.auth,
+        ))
+    db.commit()
+    return PushStatusResponse(ok=True)
+
+
+@router.post("/unsubscribe", response_model=PushStatusResponse)
+def unsubscribe(
+    req: PushUnsubscribeRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PushStatusResponse:
+    """구독 해제 (해당 유저의 endpoint만)."""
+    db.execute(
+        delete(PushSubscription).where(
+            PushSubscription.endpoint == req.endpoint,
+            PushSubscription.user_id == user.id,
+        )
+    )
+    db.commit()
+    return PushStatusResponse(ok=True)
+
+
+@router.post("/test", response_model=PushStatusResponse)
+def send_test(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PushStatusResponse:
+    """내 구독 전체로 테스트 알림 발송 (구독 검증용)."""
+    if not _vapid().get("enabled"):
+        raise HTTPException(503, "푸시 미설정 (VAPID 키 없음)")
+    sent = send_push_to_user(db, user.id, {
+        "title": "투자 AI 알림 테스트",
+        "body": "푸시 알림이 정상 동작합니다 🎉",
+        "url": "/",
+    })
+    return PushStatusResponse(ok=sent > 0,
+                              detail=f"{sent}개 기기로 발송")

--- a/ETF_RAG/config.py
+++ b/ETF_RAG/config.py
@@ -36,6 +36,15 @@ if JWT_SECRET == "dev-insecure-change-me":
         "JWT_SECRET 미설정 — dev 기본값 사용 중. 프로덕션에서는 반드시 환경변수로 설정하세요."
     )
 
+# 웹 푸시 알림 (VAPID) — scripts/gen_vapid_keys.py 로 1회 생성해 고정.
+# 키 3종 모두 설정돼야 활성화. 미설정 시 푸시 비활성(구독/발송 비활성, 다른 기능 무관).
+VAPID = {
+    "public_key": os.getenv("VAPID_PUBLIC_KEY", ""),
+    "private_key": os.getenv("VAPID_PRIVATE_KEY", ""),
+    "subject": os.getenv("VAPID_SUBJECT", "mailto:admin@example.com"),
+    "enabled": bool(os.getenv("VAPID_PUBLIC_KEY") and os.getenv("VAPID_PRIVATE_KEY")),
+}
+
 
 def get_latest_collected_path() -> Optional[Path]:
     """수집 디렉토리에서 가장 최근 ETF 데이터 파일 경로를 반환. 없으면 None."""

--- a/ETF_RAG/frontend/public/sw.js
+++ b/ETF_RAG/frontend/public/sw.js
@@ -20,6 +20,42 @@ self.addEventListener("activate", (event) => {
   );
 });
 
+// 웹 푸시 수신 → 알림 표시. payload: {title, body, url}
+self.addEventListener("push", (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = { title: "투자 AI 알림", body: event.data ? event.data.text() : "" };
+  }
+  const title = data.title || "투자 AI 알림";
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: data.body || "",
+      icon: "/icons/icon-192.png",
+      badge: "/icons/icon-192.png",
+      data: { url: data.url || "/" },
+    }),
+  );
+});
+
+// 알림 클릭 → 해당 URL로 포커스/이동
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || "/";
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((cs) => {
+      for (const c of cs) {
+        if ("focus" in c) {
+          c.navigate(target);
+          return c.focus();
+        }
+      }
+      return self.clients.openWindow(target);
+    }),
+  );
+});
+
 self.addEventListener("fetch", (event) => {
   const req = event.request;
   const url = new URL(req.url);

--- a/ETF_RAG/frontend/src/components/PushToggle.tsx
+++ b/ETF_RAG/frontend/src/components/PushToggle.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/AuthContext";
+import {
+  getVapidInfo,
+  getCurrentSubscription,
+  subscribePush,
+  unsubscribePush,
+  sendTestPush,
+  pushSupported,
+} from "@/lib/push";
+
+/**
+ * 관심종목 푸시 알림 구독 토글. 로그인 + VAPID 활성 + 브라우저 지원 시에만 표시.
+ * 일일 관심종목 급등/급락 알림(자동 발송)은 후속 PR이며, 이 토글로 구독을 등록한다.
+ */
+export default function PushToggle() {
+  const { user } = useAuth();
+  const [vapidKey, setVapidKey] = useState<string | null>(null);
+  const [subscribed, setSubscribed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user || !pushSupported()) return;
+    let alive = true;
+    (async () => {
+      const info = await getVapidInfo();
+      if (!alive) return;
+      if (!info.enabled) {
+        setVapidKey(null);
+        return;
+      }
+      setVapidKey(info.public_key);
+      const sub = await getCurrentSubscription();
+      if (alive) setSubscribed(!!sub);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [user]);
+
+  // 로그인 안 함 / 미지원 / VAPID 미설정 → 숨김
+  if (!user || !pushSupported() || !vapidKey) return null;
+
+  const toggle = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      if (subscribed) {
+        await unsubscribePush();
+        setSubscribed(false);
+        setMsg("알림 해제됨");
+      } else {
+        const ok = await subscribePush(vapidKey);
+        setSubscribed(ok);
+        setMsg(ok ? "알림 구독됨 🔔" : "알림 권한이 거부되었어요");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const test = async () => {
+    setBusy(true);
+    setMsg(null);
+    const ok = await sendTestPush();
+    setMsg(ok ? "테스트 알림 발송됨" : "발송 실패");
+    setBusy(false);
+  };
+
+  return (
+    <div className="mt-3 border-t border-gray-100 pt-3">
+      <div className="text-xs font-semibold text-gray-700">🔔 관심종목 알림</div>
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        className={[
+          "mt-1 w-full rounded-lg px-2 py-1.5 text-xs",
+          subscribed
+            ? "bg-blue-600 text-white hover:bg-blue-700"
+            : "border border-gray-300 text-gray-600 hover:bg-gray-100",
+          busy ? "opacity-60" : "",
+        ].join(" ")}
+      >
+        {busy ? "처리 중…" : subscribed ? "알림 켜짐 (끄기)" : "알림 받기"}
+      </button>
+      {subscribed && (
+        <button
+          type="button"
+          onClick={test}
+          disabled={busy}
+          className="mt-1 w-full rounded-lg px-2 py-1 text-[11px] text-gray-400 hover:bg-gray-100"
+        >
+          테스트 알림 보내기
+        </button>
+      )}
+      {msg && <div className="mt-1 text-[11px] text-gray-400">{msg}</div>}
+      <p className="mt-1 text-[11px] leading-relaxed text-gray-400">
+        관심종목 급등/급락 시 알림을 받습니다 (장 마감 후 1회).
+      </p>
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/components/Sidebar.tsx
+++ b/ETF_RAG/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getOverview, getVisitor } from "@/lib/api";
+import PushToggle from "@/components/PushToggle";
 import type {
   InstrumentItem,
   OverviewResponse,
@@ -188,6 +189,9 @@ export default function Sidebar({
           filtered.map((it) => <ItemRow key={it.ticker} it={it} onClick={() => go(it)} />)
         )}
       </div>
+
+      {/* 관심종목 푸시 알림 (로그인 + VAPID 활성 시) */}
+      <PushToggle />
 
       {/* 투자 유의 */}
       <p className="mt-4 border-t border-gray-100 pt-3 text-[11px] leading-relaxed text-gray-400">

--- a/ETF_RAG/frontend/src/lib/push.ts
+++ b/ETF_RAG/frontend/src/lib/push.ts
@@ -1,0 +1,89 @@
+// 웹 푸시 구독 — VAPID 공개키 조회 + 브라우저 구독/해제 + 백엔드 등록.
+import { authHeader } from "./auth";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
+
+export interface VapidInfo {
+  public_key: string;
+  enabled: boolean;
+}
+
+export async function getVapidInfo(): Promise<VapidInfo> {
+  const res = await fetch(`${API_BASE}/push/vapid-public-key`, { cache: "no-store" });
+  if (!res.ok) return { public_key: "", enabled: false };
+  return (await res.json()) as VapidInfo;
+}
+
+/** 브라우저가 웹 푸시를 지원하는지 */
+export function pushSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+  return arr;
+}
+
+/** 현재 구독 상태 조회 (브라우저 기준) */
+export async function getCurrentSubscription(): Promise<PushSubscription | null> {
+  if (!pushSupported()) return null;
+  const reg = await navigator.serviceWorker.ready;
+  return reg.pushManager.getSubscription();
+}
+
+/** 푸시 구독 — 권한 요청 → SW 구독 → 백엔드 등록. 성공 true. */
+export async function subscribePush(vapidPublicKey: string): Promise<boolean> {
+  if (!pushSupported() || !vapidPublicKey) return false;
+  const perm = await Notification.requestPermission();
+  if (perm !== "granted") return false;
+
+  const reg = await navigator.serviceWorker.ready;
+  let sub = await reg.pushManager.getSubscription();
+  if (!sub) {
+    sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as BufferSource,
+    });
+  }
+  const json = sub.toJSON() as {
+    endpoint: string;
+    keys: { p256dh: string; auth: string };
+  };
+  const res = await fetch(`${API_BASE}/push/subscribe`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
+  });
+  return res.ok;
+}
+
+/** 푸시 해제 — 백엔드 삭제 + 브라우저 unsubscribe */
+export async function unsubscribePush(): Promise<boolean> {
+  const sub = await getCurrentSubscription();
+  if (!sub) return true;
+  await fetch(`${API_BASE}/push/unsubscribe`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ endpoint: sub.endpoint }),
+  }).catch(() => {});
+  await sub.unsubscribe().catch(() => {});
+  return true;
+}
+
+/** 테스트 알림 발송 (내 구독으로) */
+export async function sendTestPush(): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/push/test`, {
+    method: "POST",
+    headers: authHeader(),
+  });
+  return res.ok;
+}

--- a/ETF_RAG/requirements.txt
+++ b/ETF_RAG/requirements.txt
@@ -27,6 +27,7 @@ uvicorn>=0.27.0,<1.0
 sse-starlette>=2.0.0,<3.0
 httpx>=0.27.0,<1.0
 websockets>=12.0,<16  # KIS WebSocket 실시간 체결 (kis_ws.py)
+pywebpush>=2.0,<3  # 웹 푸시 알림 (VAPID)
 sqlalchemy>=2.0,<3
 psycopg2-binary>=2.9,<3
 PyJWT>=2.8,<3

--- a/ETF_RAG/scripts/gen_vapid_keys.py
+++ b/ETF_RAG/scripts/gen_vapid_keys.py
@@ -1,0 +1,38 @@
+"""VAPID 키쌍 생성 — 웹 푸시 알림용 (Phase F 푸시).
+
+실행: python scripts/gen_vapid_keys.py
+출력된 PUBLIC/PRIVATE를 .env (및 Railway env)에 설정:
+  VAPID_PUBLIC_KEY=...   (프론트 applicationServerKey로도 노출 — /push/vapid-public-key)
+  VAPID_PRIVATE_KEY=...
+  VAPID_SUBJECT=mailto:you@example.com
+
+키는 1회만 생성해 고정한다. 키를 바꾸면 기존 구독은 전부 무효가 된다.
+"""
+
+import base64
+
+from cryptography.hazmat.primitives import serialization
+from py_vapid import Vapid01
+
+
+def main():
+    v = Vapid01()
+    v.generate_keys()
+
+    pub = v.public_key.public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+    pub_b64 = base64.urlsafe_b64encode(pub).rstrip(b"=").decode()
+
+    priv_raw = v.private_key.private_numbers().private_value.to_bytes(32, "big")
+    priv_b64 = base64.urlsafe_b64encode(priv_raw).rstrip(b"=").decode()
+
+    print("# .env / Railway env 에 추가:")
+    print(f"VAPID_PUBLIC_KEY={pub_b64}")
+    print(f"VAPID_PRIVATE_KEY={priv_b64}")
+    print("VAPID_SUBJECT=mailto:you@example.com")
+
+
+if __name__ == "__main__":
+    main()

--- a/ETF_RAG/tests/test_push.py
+++ b/ETF_RAG/tests/test_push.py
@@ -1,0 +1,155 @@
+"""웹 푸시 구독/발송 테스트 (Phase F 푸시 A).
+
+test_user_data.py와 동일한 StaticPool 인메모리 sqlite 패턴.
+"""
+
+import os
+
+os.environ["API_SKIP_INIT"] = "1"
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from unittest.mock import patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import api.db as db  # noqa: E402
+from api.db import Base, get_db  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_sse_global():
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit_event = None
+    yield
+
+
+@pytest.fixture
+def client():
+    test_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, expire_on_commit=False)
+    db.engine = test_engine
+    db.SessionLocal = TestSession
+    Base.metadata.create_all(test_engine)
+
+    from api.main import app
+
+    def _override_db():
+        s = TestSession()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(test_engine)
+
+
+@pytest.fixture
+def auth(client):
+    r = client.post("/auth/signup", json={"email": "p@b.com", "password": "pw123456"})
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+SUB = {
+    "endpoint": "https://push.example.com/abc",
+    "keys": {"p256dh": "BPp2...", "auth": "xyz"},
+}
+
+
+# ── VAPID 공개키 (인증 불필요) ────────────────────────────
+def test_vapid_public_key_disabled(client):
+    with patch("config.VAPID", {"public_key": "", "private_key": "",
+                                "subject": "mailto:x", "enabled": False}):
+        r = client.get("/push/vapid-public-key")
+    assert r.status_code == 200
+    assert r.json() == {"public_key": "", "enabled": False}
+
+
+def test_vapid_public_key_enabled(client):
+    with patch("config.VAPID", {"public_key": "PUBKEY", "private_key": "p",
+                                "subject": "mailto:x", "enabled": True}):
+        r = client.get("/push/vapid-public-key")
+    assert r.json()["public_key"] == "PUBKEY"
+    assert r.json()["enabled"] is True
+
+
+# ── 구독/해제 ─────────────────────────────────────────────
+def test_subscribe_requires_auth(client):
+    assert client.put("/push/subscribe", json=SUB).status_code == 401
+
+
+def test_subscribe_and_unsubscribe(client, auth):
+    r = client.put("/push/subscribe", json=SUB, headers=auth)
+    assert r.status_code == 200 and r.json()["ok"] is True
+    # 멱등 — 같은 endpoint 재구독 OK (중복 행 없음)
+    r2 = client.put("/push/subscribe", json=SUB, headers=auth)
+    assert r2.status_code == 200
+
+    from api.models_db import PushSubscription
+    s = db.SessionLocal()
+    try:
+        assert s.query(PushSubscription).count() == 1
+    finally:
+        s.close()
+
+    r3 = client.post("/push/unsubscribe",
+                     json={"endpoint": SUB["endpoint"]}, headers=auth)
+    assert r3.status_code == 200
+    s = db.SessionLocal()
+    try:
+        assert s.query(PushSubscription).count() == 0
+    finally:
+        s.close()
+
+
+# ── 테스트 발송 ───────────────────────────────────────────
+def test_send_test_503_when_disabled(client, auth):
+    client.put("/push/subscribe", json=SUB, headers=auth)
+    with patch("config.VAPID", {"enabled": False}):
+        r = client.post("/push/test", headers=auth)
+    assert r.status_code == 503
+
+
+def test_send_test_calls_webpush(client, auth):
+    client.put("/push/subscribe", json=SUB, headers=auth)
+    with patch("config.VAPID", {"enabled": True, "private_key": "pk",
+                                "public_key": "pub", "subject": "mailto:x"}), \
+         patch("api.push.send_push", return_value=True) as sp:
+        r = client.post("/push/test", headers=auth)
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    sp.assert_called_once()
+
+
+# ── 발송 헬퍼: 만료 구독 삭제 ─────────────────────────────
+def test_send_push_to_user_removes_gone_subscription(client, auth):
+    client.put("/push/subscribe", json=SUB, headers=auth)
+    from api import push
+    from api.models_db import PushSubscription, User
+
+    s = db.SessionLocal()
+    try:
+        uid = s.query(User).first().id
+
+        def _gone(info, payload):
+            raise push._SubscriptionGone()
+
+        with patch("api.push.send_push", side_effect=_gone):
+            sent = push.send_push_to_user(s, uid, {"title": "t", "body": "b"})
+        assert sent == 0
+        assert s.query(PushSubscription).count() == 0  # 만료 → 삭제
+    finally:
+        s.close()


### PR DESCRIPTION
## 배경
"하나씩" 큐 4번째 — 푸시 알림. **두 PR로 분할** 중 1번째: 구독 인프라. (자동 발송 = 관심종목 일일 알림은 PR-B.)

## 변경
**백엔드**
- `scripts/gen_vapid_keys.py`: VAPID 키쌍 생성(1회 고정).
- `config.VAPID`(public/private/subject, 키 2종 있으면 enabled) + requirements `pywebpush`.
- `PushSubscription` 모델(user_id+endpoint unique).
- `api/push.py`:
  - `GET /push/vapid-public-key`(공개 — 프론트 applicationServerKey)
  - `PUT /push/subscribe`(멱등) / `POST /push/unsubscribe` / `POST /push/test`(내 구독 발송)
  - `send_push` / `send_push_to_user` 헬퍼 — 410/404 만료 구독 자동 삭제. **PR-B 자동발송에서 재사용.**
- VAPID 미설정 시 모든 발송 graceful no-op.

**프론트**
- `sw.js`: `push`(payload→showNotification) + `notificationclick`(URL 포커스/이동) 핸들러.
- `lib/push.ts`: VAPID 키 조회 + 브라우저 구독/해제 + 백엔드 등록 + 테스트 발송.
- `PushToggle`: 로그인 + VAPID 활성 + 브라우저 지원 시에만 표시. 구독 토글 + 테스트 알림. Sidebar 배치.

## 검증
- 전체 **748 pass**(push 7: 공개키 enabled/disabled, 구독 멱등, 해제, test 503/발송, 만료 자동삭제).
- 프론트 build 통과.

## 사용자 액션 (배포 시)
`python scripts/gen_vapid_keys.py` → Railway 백엔드 env에 `VAPID_PUBLIC_KEY/PRIVATE_KEY/SUBJECT` 등록. 미등록 시 토글 자체가 안 보임(다른 기능 무관).

## 후속 (PR-B)
관심종목 급등/급락 감지 → `send_push_to_user` 자동 발송(GitHub Actions 일일 수집 연동).

🤖 Generated with [Claude Code](https://claude.com/claude-code)