### PR TITLE
관심종목 일일 자동 푸시 알림 (배치 발송)

### DIFF
--- a/.github/workflows/daily-collect.yml
+++ b/.github/workflows/daily-collect.yml
@@ -162,6 +162,24 @@ jobs:
           git pull --rebase origin main
           git push
 
+      # ── 관심종목 푸시 알림 트리거 (Railway 백엔드 호출) ──────
+      # 수집 후 백엔드가 관심종목 ±임계% 종목을 구독 유저에게 push.
+      # PUSH_ALERT_URL/CRON_TOKEN secret 미설정 시 스크립트가 자동 skip(무해).
+      - name: Trigger watchlist push alerts
+        continue-on-error: true
+        env:
+          PUSH_ALERT_URL: ${{ secrets.PUSH_ALERT_URL }}
+          CRON_TOKEN: ${{ secrets.CRON_TOKEN }}
+        run: |
+          if [ -z "$PUSH_ALERT_URL" ] || [ -z "$CRON_TOKEN" ]; then
+            echo "PUSH_ALERT_URL/CRON_TOKEN 미설정 — 알림 트리거 skip"
+            exit 0
+          fi
+          echo "관심종목 알림 트리거: $PUSH_ALERT_URL"
+          curl -fsS -X POST "$PUSH_ALERT_URL" \
+            -H "X-Cron-Token: $CRON_TOKEN" \
+            --max-time 120 || echo "알림 트리거 실패(무시)"
+
   # ── 실패 시 GitHub Issue 자동 생성 ──────────────────────
   notify-failure:
     runs-on: ubuntu-latest

--- a/ETF_RAG/.env.example
+++ b/ETF_RAG/.env.example
@@ -48,3 +48,9 @@ JWT_EXPIRE_MINUTES=10080
 # VAPID_PUBLIC_KEY=...
 # VAPID_PRIVATE_KEY=...
 # VAPID_SUBJECT=mailto:you@example.com
+
+# --- 관심종목 일일 푸시 알림 배치 (선택) ---
+# GitHub Actions가 수집 후 POST /push/run-watchlist-alerts 호출 시 인증 토큰.
+# 미설정 시 해당 엔드포인트 403(비활성). GHA secret: CRON_TOKEN + PUSH_ALERT_URL.
+# CRON_TOKEN=long-random-secret
+# WATCHLIST_ALERT_THRESHOLD=5.0   # 급등/급락 알림 임계 ±%

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -181,3 +181,10 @@ class VapidPublicKeyResponse(BaseModel):
 class PushStatusResponse(BaseModel):
     ok: bool
     detail: Optional[str] = None
+
+
+class WatchlistAlertResponse(BaseModel):
+    ok: bool
+    users_notified: int
+    pushes_sent: int
+    movers: int

--- a/ETF_RAG/api/push.py
+++ b/ETF_RAG/api/push.py
@@ -7,7 +7,7 @@
 import json
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
@@ -18,8 +18,9 @@ from api.models import (
     PushSubscribeRequest,
     PushUnsubscribeRequest,
     VapidPublicKeyResponse,
+    WatchlistAlertResponse,
 )
-from api.models_db import PushSubscription, User
+from api.models_db import PushSubscription, User, Watchlist
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/push", tags=["push"])
@@ -150,3 +151,78 @@ def send_test(
     })
     return PushStatusResponse(ok=sent > 0,
                               detail=f"{sent}개 기기로 발송")
+
+
+# ── 관심종목 일일 알림 (배치) ─────────────────────────────
+def run_watchlist_alerts(db: Session) -> dict:
+    """구독 유저별 관심종목 중 당일 ±임계% 종목을 묶어 1건씩 push.
+
+    종목 등락률은 _find_structured_data(현재 로드된 deploy/DB 데이터)로 조회.
+    Returns {"users_notified", "pushes_sent", "movers"}.
+    """
+    from config import WATCHLIST_ALERT_THRESHOLD as THR
+    from src.llm.tools import _find_structured_data
+
+    # 구독이 있는 유저만 대상 (구독 없으면 보낼 곳 없음)
+    user_ids = db.execute(
+        select(PushSubscription.user_id).distinct()
+    ).scalars().all()
+
+    users_notified = 0
+    pushes_sent = 0
+    total_movers = 0
+
+    for uid in user_ids:
+        tickers = db.execute(
+            select(Watchlist.ticker).where(Watchlist.user_id == uid)
+        ).scalars().all()
+        if not tickers:
+            continue
+
+        movers = []
+        for t in tickers:
+            data = _find_structured_data(t)
+            if not data:
+                continue
+            pct = data.get("change_pct")
+            if pct is None or abs(pct) < THR:
+                continue
+            movers.append((data.get("name", t), pct))
+
+        if not movers:
+            continue
+        total_movers += len(movers)
+
+        # 알림 본문: "삼성전자 +6.2%, SK하이닉스 -5.4%"
+        movers.sort(key=lambda x: abs(x[1]), reverse=True)
+        parts = [f"{n} {p:+.1f}%" for n, p in movers]
+        title = f"관심종목 {len(movers)}개 급변동"
+        body = ", ".join(parts[:5]) + ("…" if len(parts) > 5 else "")
+        sent = send_push_to_user(db, uid, {
+            "title": title, "body": body, "url": "/technical",
+        })
+        if sent:
+            users_notified += 1
+            pushes_sent += sent
+
+    return {"users_notified": users_notified,
+            "pushes_sent": pushes_sent,
+            "movers": total_movers}
+
+
+@router.post("/run-watchlist-alerts", response_model=WatchlistAlertResponse)
+def run_alerts(
+    x_cron_token: str = Header(None, alias="X-Cron-Token"),
+    db: Session = Depends(get_db),
+) -> WatchlistAlertResponse:
+    """관심종목 일일 알림 발송 (GitHub Actions 수집 후 호출). X-Cron-Token 보호.
+
+    CRON_TOKEN 미설정 시 403(비활성). VAPID 미설정 시 발송은 no-op(0건).
+    """
+    from config import CRON_TOKEN
+    if not CRON_TOKEN:
+        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
+    if x_cron_token != CRON_TOKEN:
+        raise HTTPException(403, "잘못된 토큰")
+    result = run_watchlist_alerts(db)
+    return WatchlistAlertResponse(ok=True, **result)

--- a/ETF_RAG/config.py
+++ b/ETF_RAG/config.py
@@ -45,6 +45,11 @@ VAPID = {
     "enabled": bool(os.getenv("VAPID_PUBLIC_KEY") and os.getenv("VAPID_PRIVATE_KEY")),
 }
 
+# 크론/배치 트리거 보호 토큰 (GitHub Actions가 푸시 발송 엔드포인트 호출 시).
+# 미설정 시 해당 엔드포인트 비활성(403). 관심종목 알림 임계값(±%)도 여기서 조정.
+CRON_TOKEN = os.getenv("CRON_TOKEN", "")
+WATCHLIST_ALERT_THRESHOLD = float(os.getenv("WATCHLIST_ALERT_THRESHOLD", "5.0"))
+
 
 def get_latest_collected_path() -> Optional[Path]:
     """수집 디렉토리에서 가장 최근 ETF 데이터 파일 경로를 반환. 없으면 None."""

--- a/ETF_RAG/tests/test_push.py
+++ b/ETF_RAG/tests/test_push.py
@@ -153,3 +153,83 @@ def test_send_push_to_user_removes_gone_subscription(client, auth):
         assert s.query(PushSubscription).count() == 0  # 만료 → 삭제
     finally:
         s.close()
+
+
+# ── 관심종목 일일 알림 ────────────────────────────────────
+def _seed_watchlist(uid, *tickers):
+    from api.models_db import Watchlist
+    s = db.SessionLocal()
+    try:
+        for t in tickers:
+            s.add(Watchlist(user_id=uid, ticker=t))
+        s.commit()
+    finally:
+        s.close()
+
+
+def test_run_alerts_403_without_token(client):
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.post("/push/run-watchlist-alerts")
+    assert r.status_code == 403
+
+
+def test_run_alerts_403_disabled_when_no_cron_token(client):
+    with patch("config.CRON_TOKEN", ""):
+        r = client.post("/push/run-watchlist-alerts",
+                        headers={"X-Cron-Token": "anything"})
+    assert r.status_code == 403
+
+
+def test_run_alerts_sends_for_movers(client, auth):
+    # 구독 + 관심종목 2개 등록
+    client.put("/push/subscribe", json=SUB, headers=auth)
+    from api.models_db import User
+    s = db.SessionLocal()
+    try:
+        uid = s.query(User).first().id
+    finally:
+        s.close()
+    _seed_watchlist(uid, "005930", "000660")
+
+    # 005930 +6.2%(급등), 000660 -1.0%(임계 미만)
+    def _fsd(t):
+        return {
+            "005930": {"name": "삼성전자", "change_pct": 6.2, "close": 70000},
+            "000660": {"name": "SK하이닉스", "change_pct": -1.0, "close": 100000},
+        }.get(t)
+
+    with patch("config.CRON_TOKEN", "secret"), \
+         patch("config.WATCHLIST_ALERT_THRESHOLD", 5.0), \
+         patch("src.llm.tools._find_structured_data", side_effect=_fsd), \
+         patch("api.push.send_push", return_value=True) as sp:
+        r = client.post("/push/run-watchlist-alerts",
+                        headers={"X-Cron-Token": "secret"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["users_notified"] == 1
+    assert b["pushes_sent"] == 1
+    assert b["movers"] == 1  # 005930만 임계 초과
+    # 발송 payload에 삼성전자 포함
+    payload = sp.call_args[0][1]
+    assert "삼성전자" in payload["body"]
+
+
+def test_run_alerts_no_movers_no_send(client, auth):
+    client.put("/push/subscribe", json=SUB, headers=auth)
+    from api.models_db import User
+    s = db.SessionLocal()
+    try:
+        uid = s.query(User).first().id
+    finally:
+        s.close()
+    _seed_watchlist(uid, "005930")
+
+    with patch("config.CRON_TOKEN", "secret"), \
+         patch("config.WATCHLIST_ALERT_THRESHOLD", 5.0), \
+         patch("src.llm.tools._find_structured_data",
+               return_value={"name": "삼성전자", "change_pct": 1.0}), \
+         patch("api.push.send_push", return_value=True) as sp:
+        r = client.post("/push/run-watchlist-alerts",
+                        headers={"X-Cron-Token": "secret"})
+    assert r.json()["users_notified"] == 0
+    sp.assert_not_called()


### PR DESCRIPTION
## 배경
"하나씩" 큐 4번째 푸시 알림의 **B(자동 발송)**. A(구독 인프라 #55)에서 만든 `send_push_to_user`를 재사용. 트리거: 백엔드 엔드포인트(사용자 합의), 임계값 **±5%**.

## 변경
- `config`: `CRON_TOKEN`(배치 트리거 보호) + `WATCHLIST_ALERT_THRESHOLD`(기본 5.0).
- `push.run_watchlist_alerts(db)`: 구독 있는 유저별 관심종목 → `_find_structured_data`로 당일 등락률 조회 → **±임계% 종목만** 등락 큰 순으로 묶어 1건 push("삼성전자 +6.2%, …"). 만료 구독은 헬퍼가 자동 삭제.
- `POST /push/run-watchlist-alerts`: **X-Cron-Token** 보호(CRON_TOKEN 미설정 시 403). `WatchlistAlertResponse{users_notified,pushes_sent,movers}`.
- `daily-collect.yml`: 커밋·푸시 후 트리거 스텝 — `curl POST $PUSH_ALERT_URL`(`PUSH_ALERT_URL`/`CRON_TOKEN` secret). 미설정 시 스크립트가 자동 skip, `continue-on-error`(수집 본작업에 영향 없음).

## 검증
- 전체 **752 pass**(push +4: 토큰 403×2, 급등 종목 발송+payload 검증, 임계 미만 미발송). 워크플로우 YAML 파싱 OK.

## 사용자 액션 (배포 시)
GHA secret `PUSH_ALERT_URL`(=`https://<백엔드>/push/run-watchlist-alerts`) + `CRON_TOKEN`(랜덤) 등록 + Railway 백엔드 env `CRON_TOKEN` 동일값. (+ #55의 VAPID env.)

## 알려진 한계
백엔드는 **부팅 시 로드된 deploy/DB 스냅샷**으로 등락률을 판단 → 당일 최신 반영하려면 재배포/데이터 reload 필요(후속). 무료 티어 재시작·keep-alive로 대체로 최근값.

🤖 Generated with [Claude Code](https://claude.com/claude-code)