### PR TITLE
fix(kis-ws): WS 재연결 시 기존 구독 종목 재등록

### DIFF
--- a/ETF_RAG/src/data/kis_ws.py
+++ b/ETF_RAG/src/data/kis_ws.py
@@ -136,6 +136,14 @@ class KisWsManager:
             return False
         self._task = asyncio.ensure_future(self._recv_loop())
         logger.info("KIS WS 연결됨")
+
+        # 재연결인 경우: 수신 루프 death로 _ws만 None이 됐고 구독자(_subscribers)는
+        # 남아 있다 → 새 연결에 기존 구독 종목을 전부 재등록(없으면 틱이 안 옴).
+        for ticker in list(self._subscribers):
+            try:
+                await self._ws.send(self._sub_msg(ticker, True))
+            except Exception as e:
+                logger.warning(f"KIS WS 재구독 실패 ({ticker}): {e}")
         return True
 
     async def _disconnect(self):

--- a/ETF_RAG/tests/test_kis_ws.py
+++ b/ETF_RAG/tests/test_kis_ws.py
@@ -171,3 +171,41 @@ def test_refcount_two_subscribers_one_register(mgr):
             assert "005930" not in mgr._subscribers
 
     _run(body())
+
+
+def test_reconnect_resubscribes_existing(mgr):
+    """회귀: WS 수신 루프 death(_ws=None, 구독자 유지) 후 새 subscribe가
+    재연결 시 기존 종목을 재등록해야 한다(이전엔 first=False라 누락 → 틱 끊김)."""
+    fake1 = _fake_ws()
+    fake2 = _fake_ws()
+
+    async def body():
+        with patch("config.KIS", ENABLED), \
+             patch("src.data.kis_ws._get_approval_key", return_value="appr"):
+            with patch("websockets.connect", AsyncMock(return_value=fake1)):
+                q1 = await mgr.subscribe("005930")
+                assert q1 is not None
+
+            # 수신 루프 death 시뮬레이션: _ws만 None, 구독자(_subscribers) 유지
+            if mgr._task:
+                mgr._task.cancel()
+            mgr._ws = None
+            assert "005930" in mgr._subscribers  # 구독자 남아 있음
+
+            # 새 종목 구독 → 재연결 발생 → fake2에 기존 005930 재등록돼야 함
+            with patch("websockets.connect", AsyncMock(return_value=fake2)):
+                q2 = await mgr.subscribe("000660")
+                assert q2 is not None
+
+            # fake2(새 연결)에 005930 register(tr_type=1)가 전송됐는지
+            new_conn_sends = [json.loads(c[0][0]) for c in fake2.send.call_args_list]
+            registered = {
+                m["body"]["input"]["tr_key"]
+                for m in new_conn_sends
+                if m["header"]["tr_type"] == "1"
+            }
+            assert "005930" in registered  # 기존 종목 재등록 ✓ (회귀 방지)
+            assert "000660" in registered  # 신규 종목도 등록
+            await mgr._disconnect()
+
+    _run(body())


### PR DESCRIPTION
## 배경
코드 점검 라운드(PR #50~#56, ~972줄) 결과 — KIS WebSocket 매니저에서 **실버그 1건** 발견·수정. 나머지 파일은 pyflakes 클린 + 정독 결과 추가 이슈 없음.

## 버그
`kis_ws._recv_loop`가 네트워크 오류로 죽으면 `_ws=None`이 되지만 `_subscribers`(구독자 큐)는 유지됨. 이후 새 `subscribe()`가 `_connect()`로 재연결하는데:
- 기존 종목은 `first = ticker not in self._subscribers` → **False** → H0STCNT0 register를 **새 소켓에 다시 보내지 않음**.
- → 재연결 후 그 종목 틱이 **영구히 끊김**(구독자는 큐만 들고 15초 ping만 받으며 무한 대기).

## 수정
`_connect()`가 (재)연결 성공 직후 현재 `_subscribers`의 모든 종목을 재등록. 신규 `subscribe`는 `_connect` 뒤에 `_subscribers`에 추가되므로 중복 register 없음.

## 검증
- **회귀 테스트** 추가: 수신 루프 death(`_ws=None`, 구독자 유지) → 새 종목 subscribe → 새 연결에 기존 종목 register 전송 검증. **수정 제거 시 이 테스트가 실패함을 확인**(진짜 버그 재현).
- 전체 **753 pass**. pyflakes(kis_ws/kis_client/push/tabs/realtime/models) 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)