### PR TITLE
F-3: 로컬 금융 감성 분석 (KR-FinBert-SC, 선택적)

### DIFF
--- a/ETF_RAG/.env.example
+++ b/ETF_RAG/.env.example
@@ -54,3 +54,9 @@ JWT_EXPIRE_MINUTES=10080
 # 미설정 시 해당 엔드포인트 403(비활성). GHA secret: CRON_TOKEN + PUSH_ALERT_URL.
 # CRON_TOKEN=long-random-secret
 # WATCHLIST_ALERT_THRESHOLD=5.0   # 급등/급락 알림 임계 ±%
+
+# --- F-3 로컬 감성 분석 (선택) ---
+# transformers+torch 설치 시 뉴스 감성을 로컬 KR-FinBert-SC로 분류(비용 0).
+# 미설치 시 자동 GPT fallback. LOCAL_SENTIMENT=0이면 설치돼 있어도 강제 GPT.
+# LOCAL_SENTIMENT=1
+# SENTIMENT_MODEL=snunlp/KR-FinBert-SC

--- a/ETF_RAG/config.py
+++ b/ETF_RAG/config.py
@@ -50,6 +50,13 @@ VAPID = {
 CRON_TOKEN = os.getenv("CRON_TOKEN", "")
 WATCHLIST_ALERT_THRESHOLD = float(os.getenv("WATCHLIST_ALERT_THRESHOLD", "5.0"))
 
+# 로컬 금융 감성 분류 (F-3) — KR-FinBert-SC. transformers/torch 설치 시 사용,
+# 미설치 시 자동으로 GPT-4o-mini fallback(news.py). 비용 0 + 데이터 외부 미전송.
+SENTIMENT = {
+    "enabled": os.getenv("LOCAL_SENTIMENT", "1") != "0",  # 0이면 강제 비활성(GPT)
+    "model": os.getenv("SENTIMENT_MODEL", "snunlp/KR-FinBert-SC"),
+}
+
 
 def get_latest_collected_path() -> Optional[Path]:
     """수집 디렉토리에서 가장 최근 ETF 데이터 파일 경로를 반환. 없으면 None."""

--- a/ETF_RAG/requirements.txt
+++ b/ETF_RAG/requirements.txt
@@ -34,3 +34,10 @@ PyJWT>=2.8,<3
 bcrypt>=4.0,<6
 email-validator>=2,<3
 pytest>=7.0.0,<9.0
+
+# --- F-3 로컬 감성 분석 (선택) ---
+# 아래 2개를 설치하면 뉴스 감성 분류를 로컬 KR-FinBert-SC로 수행(비용 0).
+# 미설치 시 자동으로 GPT-4o-mini fallback(src/data/news.py). 배포 이미지 경량
+# 유지를 위해 기본 미포함 — 쓰려면 주석 해제(transformers+torch ~수백MB).
+# transformers>=4.30,<5
+# torch>=2.0,<3

--- a/ETF_RAG/src/data/news.py
+++ b/ETF_RAG/src/data/news.py
@@ -1,8 +1,9 @@
 """
-뉴스 수집 + LLM 감성 분석 모듈
+뉴스 수집 + 감성 분석 모듈
 
 - Google News RSS로 종목 관련 뉴스 수집 (최근 7일)
-- GPT-4o-mini로 감성 분석 (긍정/부정/중립 + 요약)
+- 감성 분류: 로컬 KR-FinBert-SC(설치 시) → GPT-4o-mini fallback (src/data/sentiment.py)
+- 요약/키워드: GPT-4o-mini (로컬 분류 모델은 라벨만 → 요약은 생성 모델 필요)
 - 네이버 크롤링 금지 (ToS 위반) → RSS/API만 사용
 """
 
@@ -81,10 +82,41 @@ def fetch_google_news(
     return articles
 
 
+def _overall(pos: int, neg: int, neu: int) -> str:
+    """긍/부/중 카운트 → 전체 감성."""
+    if pos > neg and pos > neu:
+        return "긍정"
+    if neg > pos and neg > neu:
+        return "부정"
+    if pos == neg and pos > 0:
+        return "혼재"
+    return "중립"
+
+
+def _local_classify(articles: list[dict]) -> Optional[list]:
+    """로컬 모델(KR-FinBert-SC)로 기사 감성 분류. 미설치/실패 시 None.
+
+    제목 + 요약 앞부분을 입력으로 사용. 반환 길이는 articles와 일치.
+    """
+    try:
+        from src.data import sentiment
+    except Exception:
+        return None
+    texts = []
+    for a in articles:
+        t = a.get("title", "")
+        s = a.get("summary", "")
+        texts.append(f"{t} {s[:100]}".strip() if s else t)
+    labels = sentiment.classify_sentiments(texts)
+    if labels is None or len(labels) != len(articles):
+        return None
+    return labels
+
+
 def analyze_sentiment_batch(
     articles: list[dict], stock_name: str
 ) -> dict:
-    """LLM으로 뉴스 감성 분석 (배치).
+    """뉴스 감성 분석 (배치). 감성 분류는 로컬 모델 우선→GPT fallback, 요약은 GPT.
 
     Returns:
         {
@@ -108,7 +140,10 @@ def analyze_sentiment_batch(
             "articles": [],
         }
 
-    # LLM 호출로 감성 분석
+    # 1) 감성 분류: 로컬 모델(KR-FinBert-SC) 우선, 미설치 시 None → GPT가 담당
+    local_sents = _local_classify(articles)
+
+    # LLM 호출로 (요약/키워드 + 필요 시 감성 분류)
     try:
         from src.llm.client import create_client, get_api_key
         import json
@@ -124,7 +159,19 @@ def analyze_sentiment_batch(
             if a["summary"]:
                 articles_text += f"\n    {a['summary'][:100]}"
 
-        prompt = f"""다음은 '{stock_name}' 관련 최근 뉴스 헤드라인입니다.
+        if local_sents is not None:
+            # 감성은 로컬이 결정 → GPT는 요약/키워드만
+            prompt = f"""다음은 '{stock_name}' 관련 최근 뉴스 헤드라인입니다.
+{articles_text}
+
+아래 JSON 형식으로 분석해주세요 (한국어로):
+{{
+  "key_topics": ["주요 키워드 3-5개"],
+  "summary": "전체 뉴스 흐름을 2-3문장으로 요약"
+}}
+JSON만 출력하세요"""
+        else:
+            prompt = f"""다음은 '{stock_name}' 관련 최근 뉴스 헤드라인입니다.
 {articles_text}
 
 아래 JSON 형식으로 분석해주세요 (한국어로):
@@ -155,8 +202,14 @@ def analyze_sentiment_batch(
         else:
             raise ValueError("JSON 파싱 실패")
 
+        # 감성 소스 결정: 로컬 우선, 없으면 GPT 응답
+        if local_sents is not None:
+            sentiments = {i + 1: s for i, s in enumerate(local_sents)}
+        else:
+            sentiments = {s["index"]: s["sentiment"]
+                          for s in analysis.get("sentiments", [])}
+
         # 각 기사에 감성 태깅
-        sentiments = {s["index"]: s["sentiment"] for s in analysis.get("sentiments", [])}
         pos = neg = neu = 0
         for i, a in enumerate(articles, 1):
             sent = sentiments.get(i, "중립")
@@ -168,28 +221,41 @@ def analyze_sentiment_batch(
             else:
                 neu += 1
 
-        # 전체 감성 판정
-        if pos > neg and pos > neu:
-            overall = "긍정"
-        elif neg > pos and neg > neu:
-            overall = "부정"
-        elif pos == neg and pos > 0:
-            overall = "혼재"
-        else:
-            overall = "중립"
-
         return {
-            "overall_sentiment": overall,
+            "overall_sentiment": _overall(pos, neg, neu),
             "positive_count": pos,
             "negative_count": neg,
             "neutral_count": neu,
             "key_topics": analysis.get("key_topics", []),
             "summary": analysis.get("summary", ""),
+            "sentiment_source": "local" if local_sents is not None else "gpt",
             "articles": articles,
         }
 
     except Exception as e:
         logger.warning(f"감성 분석 LLM 호출 실패: {e}")
+
+        # GPT 실패해도 로컬 분류가 있으면 감성은 살린다(요약만 누락)
+        if local_sents is not None:
+            pos = neg = neu = 0
+            for a, sent in zip(articles, local_sents):
+                a["sentiment"] = sent
+                if sent == "긍정":
+                    pos += 1
+                elif sent == "부정":
+                    neg += 1
+                else:
+                    neu += 1
+            return {
+                "overall_sentiment": _overall(pos, neg, neu),
+                "positive_count": pos,
+                "negative_count": neg,
+                "neutral_count": neu,
+                "key_topics": [],
+                "summary": f"로컬 감성 분석 완료 (요약 생성 실패, 뉴스 {len(articles)}건)",
+                "sentiment_source": "local",
+                "articles": articles,
+            }
         # Fallback: 감성 분석 없이 기사만 반환
         for a in articles:
             a["sentiment"] = "분석 불가"

--- a/ETF_RAG/src/data/sentiment.py
+++ b/ETF_RAG/src/data/sentiment.py
@@ -1,0 +1,100 @@
+"""
+로컬 금융 뉴스 감성 분류 (F-3) — KR-FinBert-SC 사전학습 모델.
+
+선택적 의존: transformers/torch가 설치돼 있으면 로컬 분류 사용, 없으면 None을
+반환 → 호출자(news.py)가 GPT-4o-mini로 fallback. 배포 이미지 경량 유지.
+
+모델: snunlp/KR-FinBert-SC (3-class: negative/neutral/positive, 금융 코퍼스 파인튜닝).
+분류만 로컬에서 하고, 요약/키워드는 호출자가 GPT로 처리(하이브리드).
+"""
+
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# 영문 라벨 → 한국어 (news.py 계약: 긍정/부정/중립)
+_LABEL_MAP = {
+    "positive": "긍정",
+    "negative": "부정",
+    "neutral": "중립",
+    "LABEL_2": "긍정",   # id2label 없이 LABEL_n으로 나올 때 대비 (0=neg,1=neu,2=pos)
+    "LABEL_0": "부정",
+    "LABEL_1": "중립",
+}
+
+# 파이프라인 싱글턴: None=미초기화, False=사용불가(로드 실패), 그 외=pipeline 객체
+_pipeline = None
+
+
+def _model_name() -> str:
+    from config import SENTIMENT
+    return SENTIMENT.get("model", "snunlp/KR-FinBert-SC")
+
+
+def _get_pipeline():
+    """text-classification 파이프라인 lazy 로드. 실패/미설치 시 False 캐시."""
+    global _pipeline
+    if _pipeline is not None:
+        return _pipeline or None  # False면 None
+
+    from config import SENTIMENT
+    if not SENTIMENT.get("enabled", True):
+        _pipeline = False
+        return None
+    try:
+        from transformers import pipeline  # torch 포함 — 미설치면 ImportError
+        _pipeline = pipeline(
+            "text-classification",
+            model=_model_name(),
+            top_k=1,
+            truncation=True,
+            max_length=256,
+        )
+        logger.info(f"로컬 감성 모델 로드: {_model_name()}")
+    except Exception as e:
+        logger.info(f"로컬 감성 모델 미사용 (GPT fallback): {e}")
+        _pipeline = False
+        return None
+    return _pipeline
+
+
+def is_available() -> bool:
+    """로컬 감성 분류 사용 가능 여부 (transformers 설치 + 모델 로드 성공)."""
+    return _get_pipeline() is not None
+
+
+def _to_korean(label: str) -> str:
+    return _LABEL_MAP.get(str(label).lower(),
+                          _LABEL_MAP.get(str(label), "중립"))
+
+
+def classify_sentiments(texts: List[str]) -> Optional[List[str]]:
+    """텍스트 목록 → 긍정/부정/중립 라벨 목록. 사용 불가/실패 시 None.
+
+    호출자는 None이면 GPT 등 다른 경로로 fallback한다.
+    """
+    if not texts:
+        return []
+    pipe = _get_pipeline()
+    if pipe is None:
+        return None
+    try:
+        results = pipe(texts)
+        labels = []
+        for r in results:
+            # top_k=1 → [{"label","score"}] 형태 (transformers 버전에 따라 dict일 수도)
+            item = r[0] if isinstance(r, list) else r
+            labels.append(_to_korean(item["label"]))
+        if len(labels) != len(texts):
+            return None
+        return labels
+    except Exception as e:
+        logger.warning(f"로컬 감성 분류 실패 (GPT fallback): {e}")
+        return None
+
+
+def reset():
+    """싱글턴 초기화 (테스트용)."""
+    global _pipeline
+    _pipeline = None

--- a/ETF_RAG/src/llm/tools/financial.py
+++ b/ETF_RAG/src/llm/tools/financial.py
@@ -270,7 +270,8 @@ def get_stock_news(name_or_ticker: str, max_articles: int = 8) -> str:
         "긍정": "🟢", "부정": "🔴", "중립": "⚪", "혼재": "🟡",
     }
     emoji = sentiment_emoji.get(result["overall_sentiment"], "⚪")
-    lines.append(f"**전체 감성:** {emoji} {result['overall_sentiment']}")
+    src_tag = " (로컬 모델)" if result.get("sentiment_source") == "local" else ""
+    lines.append(f"**전체 감성:** {emoji} {result['overall_sentiment']}{src_tag}")
     lines.append(
         f"  긍정 {result['positive_count']}건 / "
         f"부정 {result['negative_count']}건 / "

--- a/ETF_RAG/tests/test_sentiment.py
+++ b/ETF_RAG/tests/test_sentiment.py
@@ -1,0 +1,158 @@
+"""로컬 금융 감성 분류 (KR-FinBert-SC) + news.py 하이브리드 경로 테스트.
+
+transformers/torch는 테스트 환경에 없으므로 pipeline을 mock하거나 미설치
+경로(None)를 검증한다.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.data import sentiment
+
+
+@pytest.fixture(autouse=True)
+def _reset_sentiment():
+    sentiment.reset()
+    yield
+    sentiment.reset()
+
+
+# ── 라벨 매핑 ─────────────────────────────────────────────
+def test_to_korean_english_labels():
+    assert sentiment._to_korean("positive") == "긍정"
+    assert sentiment._to_korean("negative") == "부정"
+    assert sentiment._to_korean("neutral") == "중립"
+
+
+def test_to_korean_label_n_form():
+    # id2label 없이 LABEL_n으로 나올 때 (0=neg,1=neu,2=pos)
+    assert sentiment._to_korean("LABEL_2") == "긍정"
+    assert sentiment._to_korean("LABEL_0") == "부정"
+    assert sentiment._to_korean("LABEL_1") == "중립"
+
+
+def test_to_korean_unknown_defaults_neutral():
+    assert sentiment._to_korean("weird") == "중립"
+
+
+# ── 미설치/비활성 → None (GPT fallback) ───────────────────
+def test_classify_none_when_transformers_missing():
+    # transformers import 실패 시뮬레이션 → _get_pipeline False
+    with patch("src.data.sentiment._get_pipeline", return_value=None):
+        assert sentiment.classify_sentiments(["삼성전자 신고가"]) is None
+
+
+def test_classify_empty_returns_empty_list():
+    assert sentiment.classify_sentiments([]) == []
+
+
+def test_is_available_false_when_disabled():
+    with patch("config.SENTIMENT", {"enabled": False, "model": "x"}):
+        assert sentiment.is_available() is False
+
+
+# ── pipeline mock으로 분류 동작 ───────────────────────────
+def test_classify_with_mocked_pipeline():
+    fake_pipe = MagicMock(return_value=[
+        [{"label": "positive", "score": 0.9}],
+        [{"label": "negative", "score": 0.8}],
+        [{"label": "neutral", "score": 0.7}],
+    ])
+    with patch("src.data.sentiment._get_pipeline", return_value=fake_pipe):
+        out = sentiment.classify_sentiments(["a", "b", "c"])
+    assert out == ["긍정", "부정", "중립"]
+
+
+def test_classify_dict_result_form():
+    """일부 transformers 버전은 top_k=1에서 dict 1개를 반환."""
+    fake_pipe = MagicMock(return_value=[{"label": "positive", "score": 0.9}])
+    with patch("src.data.sentiment._get_pipeline", return_value=fake_pipe):
+        out = sentiment.classify_sentiments(["삼성전자 신고가"])
+    assert out == ["긍정"]
+
+
+def test_classify_length_mismatch_returns_none():
+    fake_pipe = MagicMock(return_value=[{"label": "positive"}])  # 입력 2개인데 1개
+    with patch("src.data.sentiment._get_pipeline", return_value=fake_pipe):
+        assert sentiment.classify_sentiments(["a", "b"]) is None
+
+
+def test_classify_inference_error_returns_none():
+    fake_pipe = MagicMock(side_effect=RuntimeError("oom"))
+    with patch("src.data.sentiment._get_pipeline", return_value=fake_pipe):
+        assert sentiment.classify_sentiments(["a"]) is None
+
+
+# ── news.py 하이브리드 경로 ───────────────────────────────
+def test_news_uses_local_sentiment_when_available():
+    """로컬 분류 성공 → 감성은 로컬, GPT는 요약만. sentiment_source=local."""
+    from src.data.news import analyze_sentiment_batch
+
+    articles = [
+        {"title": "삼성전자 신고가 경신", "source": "한경", "summary": "사상 최고"},
+        {"title": "삼성전자 리콜 논란", "source": "매경", "summary": "결함"},
+    ]
+    # GPT는 요약/키워드만 반환
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = (
+        '{"key_topics": ["반도체"], "summary": "엇갈린 뉴스."}'
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    with patch("src.data.news._local_classify", return_value=["긍정", "부정"]), \
+         patch("src.llm.client.create_client", return_value=mock_client), \
+         patch("src.llm.client.get_api_key", return_value="k"):
+        r = analyze_sentiment_batch(articles, "삼성전자")
+
+    assert r["sentiment_source"] == "local"
+    assert r["positive_count"] == 1
+    assert r["negative_count"] == 1
+    assert r["overall_sentiment"] == "혼재"
+    assert r["articles"][0]["sentiment"] == "긍정"
+    assert r["summary"] == "엇갈린 뉴스."  # 요약은 GPT
+
+
+def test_news_local_sentiment_survives_gpt_failure():
+    """로컬 분류 성공 + GPT 실패 → 감성은 살고 요약만 누락."""
+    from src.data.news import analyze_sentiment_batch
+
+    articles = [{"title": "삼성전자 신고가", "source": "한경", "summary": ""}]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError("API down")
+
+    with patch("src.data.news._local_classify", return_value=["긍정"]), \
+         patch("src.llm.client.create_client", return_value=mock_client), \
+         patch("src.llm.client.get_api_key", return_value="k"):
+        r = analyze_sentiment_batch(articles, "삼성전자")
+
+    assert r["sentiment_source"] == "local"
+    assert r["positive_count"] == 1
+    assert r["overall_sentiment"] == "긍정"
+    assert "요약 생성 실패" in r["summary"]
+
+
+def test_news_falls_back_to_gpt_when_local_unavailable():
+    """로컬 미설치(None) → 기존 GPT 분류 경로. sentiment_source=gpt."""
+    from src.data.news import analyze_sentiment_batch
+
+    articles = [{"title": "삼성전자 신고가", "source": "한경", "summary": ""}]
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = (
+        '{"sentiments": [{"index": 1, "sentiment": "긍정"}], '
+        '"key_topics": ["반도체"], "summary": "호재."}'
+    )
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    with patch("src.data.news._local_classify", return_value=None), \
+         patch("src.llm.client.create_client", return_value=mock_client), \
+         patch("src.llm.client.get_api_key", return_value="k"):
+        r = analyze_sentiment_batch(articles, "삼성전자")
+
+    assert r["sentiment_source"] == "gpt"
+    assert r["positive_count"] == 1
+    assert r["overall_sentiment"] == "긍정"


### PR DESCRIPTION
## 배경
로드맵 F-3 — 뉴스 감성 분석을 로컬 사전학습 모델로. GPT 비용 0 + 데이터 외부 미전송. 결정: **사전학습 금융 모델(파인튜닝 X)** + **선택적 설치 + GPT fallback**(배포 이미지 경량).

## 핵심 설계
GPT-4o-mini가 현재 **감성 분류 + 요약**을 함께 함. 로컬 분류 모델(KR-FinBert-SC)은 라벨만 줌 → **하이브리드**: 분류는 로컬(있으면), 요약/키워드는 GPT 유지.

## 변경
- `src/data/sentiment.py`(신규): `snunlp/KR-FinBert-SC` text-classification lazy 싱글턴. transformers/torch **미설치·로드 실패 시 None** → GPT fallback. 영문/`LABEL_n`(0=neg/1=neu/2=pos) → 긍정/부정/중립 매핑.
- `news.analyze_sentiment_batch`: 분류 **로컬 우선**(있으면 GPT는 요약/키워드만), 없으면 기존 GPT 경로. **GPT 실패해도 로컬 감성 보존**. `sentiment_source` 추가.
- `financial.py`: 출력에 "(로컬 모델)" 표기.
- `config.SENTIMENT`(LOCAL_SENTIMENT=0이면 강제 GPT) + requirements/.env.example 선택 설치(torch 기본 미포함).

## 검증
- 전체 **766 pass**(sentiment 13개). 기존 news 17 무회귀. pyflakes 클린. transformers 미설치 환경(=현 배포)에서 GPT fallback 동작 확인.

## 사용자 액션
requirements의 transformers/torch 주석 해제·설치 시 자동 로컬 분류(첫 호출 ~400MB 다운로드). 안 하면 기존대로 GPT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)