### PR TITLE
RAG 품질: 신규 도구 eval 커버리지 + 실버그 2건 (sector 별칭·news SSL)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2381,5 +2381,23 @@ PR #50~#56(~972줄, KIS REST/WS + 푸시) 점검. **실버그 1건 발견·수�
 
 ---
 
-_Last Updated: 2026-06-16 (PR #50~#54 KIS + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57 + F-3 로컬감성 #58(KR-FinBert-SC 선택적, 분류 로컬→GPT fallback, 요약 GPT 하이브리드). 테스트 766. 다음: 유료전환/블로그9편, Railway env, 로컬감성 torch 설치)_
+## RAG 품질: 신규 도구 평가 커버리지 + 실버그 2건 (2026-06-18)
+
+"Hit Rate 100%가 진짜 천장인가, 측정 안 된 영역인가" 검증. 최근 3개월 추가한 도구(predict_price_outlook/get_stock_news/analyze_sector)가 eval 172개에 한 번도 안 들어가 응답 품질 사각지대였음.
+
+- **eval 커버리지**: forecast 8 + news 6 + sector 6 = 20개 추가(172→192). forecast가 기존 `technical`로 라벨돼 stratified 샘플링에서 신규 도구 누락되던 것도 별도 유형으로 분리. `run_eval.py --types a,b,c` 필터 옵션 신설.
+- **retrieval은 천장 맞음**: 192개 + 신규 20개 모두 Hit Rate 100%, 신규 유형도 **rank-1 정확**. 검색은 문제 없었음.
+- **진짜 사각지대 = 신규 도구 응답 품질(RAGAS)**. 신규 20개 RAGAS에서 AR 0.501(전체 0.709 대비 낮음) → **실버그 2건 발견**:
+  1. **analyze_sector 통속 업종명**: "자동차"는 KRX 분류에 없음(공식명 "운송장비·부품") → "현대차 섹터 밸류에이션" 질문이 빈 응답(AR=0.0). `_SECTOR_ALIASES`(자동차/반도체/바이오/2차전지/철강 등 → KRX 29개 공식명) 추가. 종목명("현대차")이 별칭("차")에 안 끌려가게 역인덱스 종목 가드.
+  2. **news RSS SSL**: feedparser 기본 경로가 시스템 CA 미설치 환경(macOS Python)에서 `CERTIFICATE_VERIFY_FAILED` → 뉴스 **0건** → 감성 분석 전체 무력화(삼성전자도 0건). `_fetch_feed`가 certifi CA 번들로 직접 fetch 후 bytes 전달, 실패 시 기존 경로 fallback. requirements certifi 명시. **Railway(Linux)는 정상이었을 수 있으나 환경 무관 견고화.**
+- **효과(RAGAS news+sector 재측정)**: **AR 0.501→0.747(+0.246, +49%)**, F 0.874→0.895. 테스트 766→**771**(sector 별칭 3 + news SSL 2). 잔존: "NAVER 뉴스 요약" AR=0.0이나 F=1.0(RAGAS 요약형 역질문 측정 한계, 도구 정상) / "현대차 섹터" AR=0.28(빈 응답은 해소, 프롬프트 개선 여지).
+- 커밋(브랜치 rag-eval-newtools-coverage, 2개): fix(tools) 실버그2 + test(eval) 커버리지. **교훈: Hit Rate 100%는 retrieval만 봄 — 도구 응답 품질은 RAGAS로만 잡힘. 신규 도구 추가 시 eval 유형도 함께 추가할 것.**
+
+### 다음
+- 유료 전환 / 블로그 9편 / 현대차 섹터 AR 프롬프트 개선(선택). 위 브랜치 PR→merge.
+
+---
+
+_Last Updated: 2026-06-18 (RAG 품질: 신규 도구 eval 커버리지 20개 추가(192) + 실버그 2건 수정(sector 통속명 별칭·news certifi SSL) → RAGAS AR 0.501→0.747. 테스트 771. 브랜치 rag-eval-newtools-coverage. 다음: 유료전환/블로그9편)_
+_2026-06-16 (PR #50~#54 KIS + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57 + F-3 로컬감성 #58). 테스트 766_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -441,14 +441,14 @@ ETF_RAG/
 │   │   ├── styles.py       # 커스텀 CSS (반응형, 테이블 스타일, 모바일 대응: 768px 태블릿 + 480px 소형 폰)
 │   │   └── components.py   # render_example_questions(동적+기본), generate_dynamic_examples(급등/급락/거래대금), render_feedback_buttons(부정사유 수집)
 ├── eval/
-│   ├── eval_dataset.json          # RAGAS 평가 데이터셋 (172개 질문, 8개 유형)
+│   ├── eval_dataset.json          # RAGAS 평가 데이터셋 (192개 질문, 11개 유형 — forecast/news/sector 포함)
 │   ├── run_eval.py                # 평가 실행 스크립트 (--no-llm / full RAGAS)
 │   └── results/                   # 평가 결과 JSON (eval_YYYYMMDD_HHMMSS.json)
 │   └── utils/
 │       ├── formatters.py   # 공통 포맷터 (format_market_cap, format_trade_value, format_number)
 │       └── logging.py      # log_interaction(), log_feedback()
 ├── .gitignore              # Python/SQLite/IDE/OS 파일 제외 (.env, *.db, collected/, logs/ 등)
-├── tests/                  # pytest 584개
+├── tests/                  # pytest 771개
 ├── .github/
 │   └── workflows/
 │       ├── daily-collect.yml          # GitHub Actions 자동 수집 (18:30 KST, deploy/ JSON + Release DB 갱신 + 실패 시 Issue)
@@ -534,7 +534,7 @@ ETF_RAG/
 
 ---
 
-_Last Updated: 2026-06-16 (Phase F 진행 — KIS #50·#52·#53·#54 + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57(kis_ws 재연결) + F-3 로컬감성 #58(KR-FinBert-SC 선택적, 분류 로컬→GPT fallback·요약 GPT). 장중 라이브 검증. 테스트 766, 도구 14개, eval 172개, Hit Rate 100%, F=0.688, AR=0.709, CR=0.854. 상세: CLAUDE.local.md "Phase F-2"/"Phase F-3"/"Phase F: 웹 푸시")_
+_Last Updated: 2026-06-18 (RAG 품질 — 신규 도구(forecast/news/sector) eval 커버리지 20개 추가(eval 172→192) + 실버그 2건 수정(analyze_sector 통속 업종명 별칭·news RSS certifi SSL) → RAGAS news/sector AR 0.501→0.747. 테스트 766→771. 상세: CLAUDE.local.md "RAG 품질: 신규 도구 평가 커버리지". 이전: 2026-06-16 Phase F KIS #50~#54 + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57 + F-3 로컬감성 #58)_
 
 > ✅ **CI 액션 Node 24 대응 완료** (2026-06-08): `checkout@v4→v6`, `setup-python@v5→v6` (ci.yml + daily-collect.yml 4곳). CI green 확인. 2026-06-16 Node 24 강제 전환 대비.
 

--- a/ETF_RAG/eval/eval_dataset.json
+++ b/ETF_RAG/eval/eval_dataset.json
@@ -1254,5 +1254,145 @@
     "question_type": "technical",
     "expected_ticker": "005490",
     "asset_type": "stock"
+  },
+  {
+    "question": "삼성전자 1개월 가격 전망 알려줘",
+    "ground_truth": "삼성전자(005930)의 4축 종합 전망(기술적+펀더멘털+Ridge회귀+Prophet)으로 1개월 가격 방향, 시나리오 확률, Bootstrap 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "005930",
+    "asset_type": "stock"
+  },
+  {
+    "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+    "ground_truth": "SK하이닉스(000660)의 4축 종합 전망으로 3개월 가격 방향, 시나리오 확률, 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "000660",
+    "asset_type": "stock"
+  },
+  {
+    "question": "현대차 향후 6개월 전망 분석해줘",
+    "ground_truth": "현대차(005380)의 4축 종합 전망으로 6개월 가격 방향, 시나리오 확률, 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "005380",
+    "asset_type": "stock"
+  },
+  {
+    "question": "NAVER 주가 1년 전망 예측",
+    "ground_truth": "NAVER(035420)의 4축 종합 전망으로 1년 가격 방향, 시나리오 확률, 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "035420",
+    "asset_type": "stock"
+  },
+  {
+    "question": "기아 목표가 전망 알려줘",
+    "ground_truth": "기아(000270)의 4축 종합 전망(기술적+펀더멘털+Ridge회귀+Prophet)으로 가격 방향과 시나리오 확률을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "000270",
+    "asset_type": "stock"
+  },
+  {
+    "question": "LG화학 앞으로 오를까 내릴까?",
+    "ground_truth": "LG화학(051910)의 4축 종합 전망으로 가격 상승/하락 방향과 시나리오 확률, 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "051910",
+    "asset_type": "stock"
+  },
+  {
+    "question": "카카오 단기 가격 전망 분석",
+    "ground_truth": "카카오(035720)의 4축 종합 전망으로 단기 가격 방향, 시나리오 확률, 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "035720",
+    "asset_type": "stock"
+  },
+  {
+    "question": "POSCO홀딩스 3개월 가격 예측해줘",
+    "ground_truth": "POSCO홀딩스(005490)의 4축 종합 전망으로 3개월 가격 방향, 시나리오 확률, 신뢰구간을 제공합니다.",
+    "question_type": "forecast",
+    "expected_ticker": "005490",
+    "asset_type": "stock"
+  },
+  {
+    "question": "삼성전자 최근 뉴스 분위기 어때?",
+    "ground_truth": "삼성전자(005930) 관련 최근 뉴스를 수집하고 전체 감성(긍정/부정/중립/혼재), 긍·부·중 건수, 주요 키워드, 뉴스 흐름 요약을 제공합니다.",
+    "question_type": "news",
+    "expected_ticker": "005930",
+    "asset_type": "stock"
+  },
+  {
+    "question": "SK하이닉스 뉴스 여론 분석해줘",
+    "ground_truth": "SK하이닉스(000660) 관련 최근 뉴스의 전체 감성, 긍·부·중 건수, 주요 키워드, 뉴스 흐름 요약을 제공합니다.",
+    "question_type": "news",
+    "expected_ticker": "000660",
+    "asset_type": "stock"
+  },
+  {
+    "question": "현대차 관련 최근 뉴스 감성 어때?",
+    "ground_truth": "현대차(005380) 관련 최근 뉴스의 전체 감성(긍정/부정/중립/혼재), 건수, 키워드, 요약을 제공합니다.",
+    "question_type": "news",
+    "expected_ticker": "005380",
+    "asset_type": "stock"
+  },
+  {
+    "question": "NAVER 뉴스 흐름 요약해줘",
+    "ground_truth": "NAVER(035420) 관련 최근 뉴스를 수집해 전체 감성, 긍·부·중 건수, 주요 키워드, 뉴스 흐름 요약을 제공합니다.",
+    "question_type": "news",
+    "expected_ticker": "035420",
+    "asset_type": "stock"
+  },
+  {
+    "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+    "ground_truth": "카카오(035720) 관련 최근 뉴스의 전체 감성과 긍·부·중 건수, 주요 키워드, 요약을 제공합니다.",
+    "question_type": "news",
+    "expected_ticker": "035720",
+    "asset_type": "stock"
+  },
+  {
+    "question": "LG에너지솔루션 뉴스 감성 분석",
+    "ground_truth": "LG에너지솔루션(373220) 관련 최근 뉴스의 전체 감성, 긍·부·중 건수, 주요 키워드, 뉴스 흐름 요약을 제공합니다.",
+    "question_type": "news",
+    "expected_ticker": "373220",
+    "asset_type": "stock"
+  },
+  {
+    "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+    "ground_truth": "삼성전자(005930)를 보유한 ETF 목록과 비중, 소속 업종/섹터, 업종 내 밸류에이션 상대 위치(PER/PBR 백분위)를 분석합니다.",
+    "question_type": "sector",
+    "expected_ticker": "005930",
+    "asset_type": "stock"
+  },
+  {
+    "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+    "ground_truth": "SK하이닉스(000660)를 편입한 ETF 목록과 비중, 소속 섹터, 업종 내 밸류에이션 상대 위치를 분석합니다.",
+    "question_type": "sector",
+    "expected_ticker": "000660",
+    "asset_type": "stock"
+  },
+  {
+    "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+    "ground_truth": "현대차(005380)의 소속 업종 내 밸류에이션 상대 위치(PER/PBR 백분위)와 보유 ETF, 섹터 분포를 분석합니다.",
+    "question_type": "sector",
+    "expected_ticker": "005380",
+    "asset_type": "stock"
+  },
+  {
+    "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+    "ground_truth": "KB금융(105560)을 보유한 ETF 목록과 비중, 소속 금융 업종, 업종 내 밸류에이션 상대 위치를 분석합니다.",
+    "question_type": "sector",
+    "expected_ticker": "105560",
+    "asset_type": "stock"
+  },
+  {
+    "question": "POSCO홀딩스 섹터 분석",
+    "ground_truth": "POSCO홀딩스(005490)의 소속 업종, 보유 ETF 목록과 비중, 업종 내 밸류에이션 상대 위치를 분석합니다.",
+    "question_type": "sector",
+    "expected_ticker": "005490",
+    "asset_type": "stock"
+  },
+  {
+    "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+    "ground_truth": "NAVER(035420)를 보유한 ETF 목록과 비중, 소속 업종, 업종 내 밸류에이션 상대 위치를 분석합니다.",
+    "question_type": "sector",
+    "expected_ticker": "035420",
+    "asset_type": "stock"
   }
 ]

--- a/ETF_RAG/eval/results/eval_20260617_190957.json
+++ b/ETF_RAG/eval/results/eval_20260617_190957.json
@@ -1,0 +1,3104 @@
+{
+  "timestamp": "20260617_190957",
+  "total_questions": 192,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.528,
+    "avg_recall": 0.987,
+    "by_type": {
+      "simple": {
+        "hit_rate": 1.0,
+        "total": 44,
+        "hits": 44
+      },
+      "compare": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "recommend": {
+        "hit_rate": 1.0,
+        "total": 20,
+        "hits": 20
+      },
+      "risk": {
+        "hit_rate": 1.0,
+        "total": 5,
+        "hits": 5
+      },
+      "general": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "technical": {
+        "hit_rate": 1.0,
+        "total": 49,
+        "hits": 49
+      },
+      "correlation": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "portfolio": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "forecast": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      },
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      },
+      "sector": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "etf": {
+        "hit_rate": 1.0,
+        "total": 62,
+        "hits": 62
+      },
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 122,
+        "hits": 122
+      },
+      "mixed": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "KODEX 200 ETF의 오늘 종가는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "337160",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 ETF 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "390390",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 주요 보유종목이 뭐야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "140700",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 ETF의 NAV는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 등락률이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "337160"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "401470"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "486290",
+        "497570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 차이나전기차 ETF 최근 성과가 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "371460",
+      "retrieved_tickers": [
+        "371460",
+        "371160",
+        "438320"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "0100K0",
+        "462330"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 인버스 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "114800",
+      "retrieved_tickers": [
+        "114800",
+        "261260",
+        "140710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 반도체TOP10 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "396500",
+      "retrieved_tickers": [
+        "396500",
+        "091230",
+        "494670"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "229200",
+      "retrieved_tickers": [
+        "229200",
+        "360140",
+        "359210"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500 ETF 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "360750",
+      "retrieved_tickers": [
+        "360750",
+        "448290",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국S&P500 수익률 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379800",
+      "retrieved_tickers": [
+        "379800",
+        "449180",
+        "453630"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 종가가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "462330",
+        "252670"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국나스닥100 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379810",
+      "retrieved_tickers": [
+        "379810",
+        "449190",
+        "411420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ACE 200 ETF 거래량이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "105190",
+      "retrieved_tickers": [
+        "105190",
+        "332500",
+        "438080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "069500 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "329660",
+        "131890"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 200이랑 KODEX 200 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "102110"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "102110",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체와 KODEX 200 중에 수익률이 더 좋은 건?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "0162L0"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "나스닥이랑 반도체 ETF 뭐가 더 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "133690",
+        "091160",
+        "368590",
+        "381180",
+        "395160",
+        "390390",
+        "0069M0",
+        "091230",
+        "367380",
+        "476030"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "0069M0",
+        "449190"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지와 KODEX 인버스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "122630",
+        "114800"
+      ],
+      "retrieved_tickers": [
+        "122630",
+        "114800",
+        "0100K0"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500이랑 KODEX 미국S&P500 차이가 뭐야?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "360750",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "379800",
+        "488500"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 RISE 200 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "148020"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "148020",
+        "475720"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지와 KODEX 코스닥150 비교",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "233740",
+        "229200"
+      ],
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "450910"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체레버리지와 TIGER 반도체TOP10레버리지 어떤 게 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "494310",
+        "488080"
+      ],
+      "retrieved_tickers": [
+        "488080",
+        "396500",
+        "494310"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "289250",
+        "468380"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "안정적인 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "289250",
+        "438080"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 비중이 높은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "448330",
+        "0195R0",
+        "367760"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "해외 ETF 중에 수익률 좋은 거 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468380",
+        "0057H0",
+        "289250"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당 수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "266160",
+        "360750",
+        "192720"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래량 많은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "482730",
+        "182480"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방산 관련 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "490480",
+        "449450",
+        "0177A0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "305720",
+        "305540",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "인버스 ETF 투자할 때 위험한 점이 뭐야?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "252670",
+        "114800",
+        "252410",
+        "251340",
+        "145670",
+        "123310"
+      ],
+      "retrieved_tickers": [
+        "145670",
+        "261270",
+        "217770"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.167,
+      "num_sources": 3
+    },
+    {
+      "question": "레버리지 ETF 위험성에 대해 알려줘",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "152500",
+        "243880",
+        "225040"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지 투자해도 되나?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "233740",
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "359210"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 장기 보유하면 어떻게 돼?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "261270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 지금 투자해도 괜찮을까?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "305720",
+        "305540",
+        "458260"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ETF란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "433880",
+        "0040Y0",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAV가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "448100",
+        "0100K0",
+        "409810"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "괴리율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "453060",
+        "496090",
+        "453010"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "추적오차율이 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "371160",
+        "138540",
+        "394660"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "비트코인 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468370",
+        "0137W0",
+        "314250"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "테슬라 주가 알려줘",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "457480",
+        "494330",
+        "0047P0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "미국 국채 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "0083S0",
+        "114820",
+        "468370"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "금 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "139320",
+        "468370",
+        "289250"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 ETF 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "395160",
+        "390390",
+        "381180",
+        "091230"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "0005A0"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "코스닥 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "354500",
+        "450910",
+        "233740"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "S&P500 추종하는 ETF 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "360200",
+        "0052S0",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 오늘 종가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 주가 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 PER이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 시가총액이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "016360"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 배당수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "170030",
+        "267250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차와 삼성SDI 중에 PER이 낮은 건?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "006400",
+        "005380",
+        "005389"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래대금 많은 주식이 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "003540",
+        "024060",
+        "099410"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당수익률 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "185750",
+        "097955",
+        "003547"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "PBR이 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "368770",
+        "048770",
+        "338100"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 ETF에 많이 들어가 있어?",
+      "question_type": "simple",
+      "asset_type": "mixed",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "448330",
+        "0195R0",
+        "102780",
+        "005930",
+        "028050",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.167,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 관련 주식이랑 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "473590",
+        "475310",
+        "042700",
+        "254490",
+        "080220"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "한화에어로스페이스 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "451800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER랑 카카오 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "자동차 관련 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "005387",
+        "347860",
+        "031210"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "바이오 관련 주식 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "048410",
+        "038460",
+        "314930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 PER이랑 PBR 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "278470",
+        "415640"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "060980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "024110",
+        "211050",
+        "039010"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "시가총액 큰 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267290",
+        "264900",
+        "476830"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 주가랑 KODEX 반도체 ETF 비교하면 어때?",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "091160"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "395160",
+        "278540",
+        "005930",
+        "227950",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "삼성전자 RSI가 얼마야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 골든크로스 났어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 MACD 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 볼린저 밴드 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 기술적 분석 해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 이동평균선 추세가 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "005387",
+        "001440"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 데드크로스 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 RSI가 과매수야 과매도야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "069730",
+        "491000"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 기술적 지표 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "486290",
+        "497570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 MACD 신호 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "443060"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 이동평균선 위에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "158430"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 RSI 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "0100K0",
+        "462330"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 볼린저 밴드 돌파했어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "042420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 골든크로스 나왔나?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "117730",
+        "310210"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 기술적 분석 부탁해",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "005250",
+        "192400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 추세가 상승이야 하락이야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "246960",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 기술적 지표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "462330",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 RSI랑 MACD 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "267270",
+        "218410"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자와 SK하이닉스 상관관계가 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차랑 기아 주가 연동성이 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "025620"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 베타가 얼마야?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "032830"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER와 카카오 상관계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 같이 움직여?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 베타 계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 KODEX 200 상관관계는?",
+      "question_type": "correlation",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "102780",
+        "005930",
+        "052900",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "KB금융이랑 신한지주 같이 움직이나?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 베타가 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "365330"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스랑 현대제철 상관관계 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005490",
+        "004020"
+      ],
+      "retrieved_tickers": [
+        "005490",
+        "004020",
+        "192400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온이랑 삼성바이오로직스 연관성 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "068270",
+        "207940"
+      ],
+      "retrieved_tickers": [
+        "207940",
+        "068270",
+        "338840"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 베타 계수가 1보다 커?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "126700",
+        "254120"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 50% SK하이닉스 50%로 포트폴리오 시뮬레이션 해줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 30% 현대차 30% KODEX 200 40% 백테스트 해줘",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "005380",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "278530",
+        "091180",
+        "005930",
+        "005380",
+        "095610"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 주식으로만 포트폴리오 만들면 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "042700",
+        "320000",
+        "214680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 TIGER 미국S&P500 반반 넣으면 수익률이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "360750"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "069500",
+        "449180"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 SK하이닉스 NAVER 균등 비중으로 3년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660",
+        "035420"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "035420",
+        "005930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 50% 기아 50% 포트폴리오 MDD가 어떻게 돼?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "080160"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 100% 단일 종목 투자하면 샤프 비율이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "006660",
+        "028260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 포트폴리오 시뮬레이션 해줘. KB금융 50% 신한지주 50%",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "228670"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 60% KODEX 미국S&P500 40%로 2년 시뮬레이션",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "379800",
+        "069500",
+        "463690"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 삼성SDI 포스코홀딩스 균등 비중 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400",
+        "005490"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "005490",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방어적인 포트폴리오 만들어줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "010640",
+        "047050",
+        "187660"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 40% KODEX 200 30% TIGER 미국나스닥100 30% 5년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500",
+        "133690"
+      ],
+      "retrieved_tickers": [
+        "133690",
+        "069500",
+        "379810",
+        "005930",
+        "095610",
+        "006200"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "골든크로스가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "117730",
+        "141080",
+        "054220"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "RSI가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "177900",
+        "192250",
+        "069730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MACD는 어떻게 해석해?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "015590",
+        "067310",
+        "305090"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "볼린저 밴드가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "013990",
+        "279570",
+        "448900"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "베타 계수가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "402340",
+        "317690",
+        "003670"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "샤프 비율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "032680",
+        "082920",
+        "368770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MDD가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "086960",
+        "0088M0",
+        "068790"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "상관계수가 1이면 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "474650",
+        "004800",
+        "001290"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 분기 매출이랑 영업이익 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "006660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 영업이익률 추이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 실적 보여줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 매출 성장률이 어떻게 돼?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "039860",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 영업이익률 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "영업이익률이 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "024110",
+        "267980",
+        "072130"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 재무제표 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "066570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 순이익이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "053210",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 관련 종목 실적 비교해줘",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "474590",
+        "471990",
+        "042700",
+        "320000",
+        "046890"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "영업이익률이란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267980",
+        "240810",
+        "072130"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 스토캐스틱 지표 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 과매수 과매도 상태 확인",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 일목균형표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 구름대 위에 있어? 아래에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 CCI 지표가 어떻게 되나요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "337160"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 추세 강도 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "419050"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 거래량 추세 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "027040"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 변동성이 요즘 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "477380",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 앞으로 전망 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "049950",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 목표가 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 일목균형표 어떻게 돼?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "0100K0",
+        "138910"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 가격 예측",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 다음주 오를까 내릴까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "085620"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 향후 전망이 어떤가요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "266370"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "477380",
+        "340360"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 어때? 살만해?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 투자해도 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "051905"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체주 전반적으로 전망이 어때?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "442580",
+        "042700",
+        "254490",
+        "046890"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "TIGER 미국나스닥100 ETF 향후 전망은?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "486290",
+        "497570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 3개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "060310",
+        "032620"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 1주일 뒤에 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "158430"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 앞으로 어떻게 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "192400",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 ETF 전망이 어때?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "462330",
+        "219480"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 지금 사도 돼?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "034120",
+        "454910"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 6개월 뒤 주가 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "006660",
+        "0126Z0"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 투자 전망 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "100790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 관련 이슈가 뭐야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 뉴스 감성 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 최근 소식이랑 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "097520",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 호재 악재 뭐가 있어?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "0015N0",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 Prophet 모델로 3개월 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "417970",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 1년 뒤 주가 전망",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "051905"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 뉴스 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "0190G0",
+        "471990"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 뉴스랑 기술적 분석 같이 봐줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "463020",
+        "007340"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 시계열 예측 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "005250",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "009155",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "477380",
+        "001500"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "477380",
+        "006805"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "025560",
+        "218150"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "051915"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "00279K",
+        "042420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "263810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "389650",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "0126Z0"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "039010",
+        "307950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "038500"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "031980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "477380",
+        "168360"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ]
+}

--- a/ETF_RAG/eval/results/eval_20260617_192111.json
+++ b/ETF_RAG/eval/results/eval_20260617_192111.json
@@ -1,0 +1,584 @@
+{
+  "timestamp": "20260617_192111",
+  "total_questions": 20,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.333,
+    "avg_recall": 1.0,
+    "by_type": {
+      "forecast": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      },
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      },
+      "sector": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 20,
+        "hits": 20
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "009155",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "100790",
+        "001500"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "396690",
+        "006805"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "025560",
+        "396690"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "051915"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "00279K",
+        "042420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "389650",
+        "051370"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "0126Z0"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "039010",
+        "307950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "475230"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "031980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "168360",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ],
+  "ragas": {
+    "faithfulness": 0.874,
+    "answer_relevancy": 0.501,
+    "context_recall": 1.0,
+    "faithfulness_rag_only": 0.874,
+    "context_recall_rag_only": 1.0
+  },
+  "ragas_per_question": [
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 922,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "삼성전자의 1개월 가격 전망입니다.\n\n1. **현재가**: 346,500원\n\n2. **종합 판단**: 강세 전망 (점수: +0.663, 신뢰도: B등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 59% (목표 +35.6%) — 기술적 모멘텀과 펀더멘털 지지 시\n   - ➡️ 횡보: 30% (예상 +8.2%)\n   - 📉 하락: 11% (목표 -1",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.892,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 711,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "SK하이닉스(티커: 000660)의 3개월 후 주가 전망 분석 결과입니다.\n\n1. **현재가**: 2,521,000원\n\n2. **종합 판단**: 약한 강세 (점수: +0.176, 신뢰도: B등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 48% (목표 +124.0%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +44.6%)\n   ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.827,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 850,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현대차(005380)의 향후 6개월 전망 분석 결과입니다.\n\n1. **현재가**: 618,000원\n\n2. **종합 판단**: 중립 (점수: -0.084, 신뢰도: B등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 34% (목표 +139.3%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +31.2%)\n   - 📉 하락: 36% (목",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.885,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 863,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "NAVER(035420)의 1년 전망 예측 결과입니다.\n\n1. **현재가**: 243,500원\n\n2. **종합 판단**: 약한 약세 (점수: -0.173, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 **상승**: 28% (목표 +46.0%) — 시장 전반 강세 시\n   - ➡️ **횡보**: 30% (예상 -4.6%)\n   - 📉 **하",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.832,
+      "context_recall": 1.0
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 720,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "기아의 1개월 목표가 전망입니다.\n\n1. **현재가**: 166,300원\n\n2. **종합 판단**: 약한 강세 (점수: +0.105, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 42% (목표 +20.8%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +2.7%)\n   - 📉 하락: 28% (목표 -10.7%) — 외",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.648,
+      "context_recall": 1.0
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 803,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "LG화학의 1개월 가격 전망 분석 결과입니다.\n\n1. **현재가**: 361,000원\n2. **종합 판단**: 약한 강세 (점수: +0.230, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 42% (목표 +34.7%) — 기술적 모멘텀과 펀더멘털 지지가 있을 경우\n   - ➡️ 횡보: 30% (예상 +1.4%)\n   - 📉 하락: ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 930,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "카카오(035720)의 1개월 가격 전망 분석 결과입니다.\n\n1. **현재가**: 40,550원\n\n2. **종합 판단**: 약한 약세 (점수: -0.217, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 31% (목표 +35.7%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +1.6%)\n   - 📉 하락: 39% (목",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.775,
+      "context_recall": 1.0
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 814,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "POSCO홀딩스(005490)의 3개월 가격 예측 결과입니다.\n\n1. **현재가**: 384,500원\n\n2. **종합 판단**: 약한 약세 (점수: -0.251, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 30% (목표 +25.4%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +3.8%)\n   - 📉 하락: 40%",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.93,
+      "context_recall": 1.0
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 146,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "삼성전자에 대한 최근 뉴스는 수집되지 않았습니다. 따라서 긍정적, 부정적, 중립적 뉴스가 모두 없는 상태입니다. \n\n추가적으로 다른 정보나 분석이 필요하시면 말씀해 주세요. 데이터 기반 참고 정보이며, 실제 투자 시에는 추가적인 조사와 전문가 상담을 권장합니다.",
+      "faithfulness": 0.571,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 180,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현재 SK하이닉스에 대한 최근 뉴스가 없어 여론 분석을 진행할 수 없습니다. 긍정적, 부정적, 중립적 뉴스가 각각 0건으로 나타났습니다. \n\n추가적인 정보나 다른 종목에 대한 뉴스 분석이 필요하시면 말씀해 주세요! \n\n📌 위 내용은 데이터 기반 참고 정보입니다. 실제 투자 시에는 추가적인 조사와 전문가 상담을 권장합니다.",
+      "faithfulness": 0.625,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 126,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현대차에 대한 최근 뉴스는 수집되지 않았습니다. 따라서 뉴스 감성 분석 결과는 제공할 수 없습니다. 긍정적인 뉴스, 부정적인 뉴스, 중립적인 뉴스 모두 0건으로 나타났습니다.\n\n추가적으로 궁금한 사항이 있으시면 말씀해 주세요!",
+      "faithfulness": 0.833,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 151,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현재 'NAVER'에 대한 최근 뉴스가 없습니다. 따라서 뉴스 흐름에 대한 요약을 제공할 수 없습니다. 추가적인 정보가 필요하시면 다른 질문을 해주시기 바랍니다. \n\n📌 위 내용은 데이터 기반 참고 정보입니다. 실제 투자 시에는 추가적인 조사와 전문가 상담을 권장합니다.",
+      "faithfulness": 0.4,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 225,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현재 카카오에 대한 최근 뉴스가 수집되지 않아 감성 분석을 제공할 수 없습니다. 긍정적, 부정적, 중립적인 뉴스가 모두 0건으로 나타났습니다. \n\n뉴스가 없다는 것은 현재 카카오에 대한 주요 이슈나 사건이 없음을 의미할 수 있습니다. 추가적인 정보가 필요하시면 다른 질문을 해주시면 좋겠습니다. \n\n📌 위 내용은 데이터 기반 참고 정보입니다. 실제 투자 시에",
+      "faithfulness": 0.429,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 145,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "LG에너지솔루션에 대한 최근 뉴스 감성 분석 결과, 현재 관련 뉴스가 없어 긍정적, 부정적, 중립적인 기사가 모두 0건으로 나타났습니다. 따라서 감성 분석을 진행할 수 있는 데이터가 없습니다.\n\n추가적인 정보나 다른 종목에 대한 질문이 있으시면 말씀해 주세요!",
+      "faithfulness": 0.75,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 427,
+      "model": "gpt-4o",
+      "has_context": true,
+      "answer_preview": "삼성전자는 여러 ETF에 많이 포함되어 있습니다. 그 중에서 삼성전자의 비중이 높은 ETF는 다음과 같습니다:\n\n1. **SOL 200타겟위클리커버드콜 (0167B0)** - 비중: 34.09%\n2. **TIGER 200 (102110)** - 비중: 33.94%\n3. **KODEX 200TR (278530)** - 비중: 33.93%\n4. **KODEX ",
+      "faithfulness": 0.923,
+      "answer_relevancy": 0.878,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 724,
+      "model": "gpt-4o",
+      "has_context": true,
+      "answer_preview": "SK하이닉스가 편입된 ETF와 전기·전자 섹터 분석 결과입니다.\n\n### SK하이닉스가 편입된 주요 ETF\nSK하이닉스는 여러 ETF에 편입되어 있으며, 그 중 비중이 높은 ETF는 다음과 같습니다:\n- **TIGER 코리아TOP10**: 비중 40.83%\n- **TIGER 반도체**: 비중 39.07%\n- **KODEX 반도체**: 비중 39.00%\n- ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.802,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 82,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현재 \"자동차\" 섹터에 대한 데이터가 존재하지 않아 밸류에이션 정보를 제공할 수 없습니다. 다른 섹터나 종목에 대한 분석을 원하시면 말씀해 주세요.",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 1121,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "KB금융의 업종 분석과 보유 ETF에 대한 정보입니다.\n\n### 1. 업종 분석 (은행)\n- **시가총액 상위 종목**:\n  1. **기업은행** (024110) | 종가 22,450원 (-2.81%) | 시총 17.9조 | PER 7.0 | PBR 0.49\n  2. **카카오뱅크** (323410) | 종가 23,650원 (-2.07%) | 시총 11.3",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.899,
+      "context_recall": 1.0
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 682,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "POSCO홀딩스의 섹터 분석 결과입니다.\n\n1. **업종 정보**: \n   - **업종**: 금속\n   - **시가총액**: 업종 내 1위 (104개 중 1위)\n\n2. **밸류에이션**:\n   - **PER**: 44.2배 (업종 평균 45.4배, 상위 24%)\n   - **PBR**: 0.52배 (업종 평균 1.38배, 상위 62%)\n   - **배당수익",
+      "faithfulness": 0.944,
+      "answer_relevancy": 0.828,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 1144,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "NAVER가 포함된 ETF와 업종 분석 결과는 다음과 같습니다.\n\n### NAVER가 포함된 ETF\n1. **KODEX 로봇액티브** (티커: 445290)\n   - 비중: 4.09%\n2. **TIGER 코리아TOP10** (티커: 292150)\n   - 비중: 2.76%\n3. **RISE ESG사회책임투자** (티커: 290130)\n   - 비중: 1.5",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.823,
+      "context_recall": 1.0
+    }
+  ]
+}

--- a/ETF_RAG/eval/results/eval_20260618_120241.json
+++ b/ETF_RAG/eval/results/eval_20260618_120241.json
@@ -1,0 +1,363 @@
+{
+  "timestamp": "20260618_120241",
+  "total_questions": 12,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.333,
+    "avg_recall": 1.0,
+    "by_type": {
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      },
+      "sector": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "389650",
+        "051370"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "0126Z0"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "039010",
+        "307950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "475230"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "031980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "168360",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ],
+  "ragas": {
+    "faithfulness": 0.895,
+    "answer_relevancy": 0.747,
+    "context_recall": 1.0,
+    "faithfulness_rag_only": 0.895,
+    "context_recall_rag_only": 1.0
+  },
+  "ragas_per_question": [
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 513,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "삼성전자에 대한 최근 뉴스 분위기는 전반적으로 긍정적입니다. 전체 감성 분석 결과, 긍정적인 뉴스가 5건, 부정적인 뉴스가 2건, 중립적인 뉴스가 1건으로 나타났습니다. \n\n주요 키워드로는 \"삼성전자\", \"주식\", \"외국인 투자\", \"주식 보상\", \"메모리 반도체\" 등이 있으며, 긍정적인 투자 전망과 외국인 투자자의 매매 패턴에 대한 논의가 주를 이루고 있",
+      "faithfulness": 0.667,
+      "answer_relevancy": 0.963,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 965,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "SK하이닉스에 대한 최근 뉴스 여론 분석 결과입니다.\n\n### 전체 감성\n- **긍정적**: 7건\n- **부정적**: 0건\n- **중립적**: 1건\n\n### 주요 키워드\n- 주가 상승\n- 외국인 투자\n- 시가총액\n- 신사업\n- 메모리반도체\n\n### 뉴스 흐름 요약\n최근 SK하이닉스에 대한 긍정적인 뉴스가 많아 주가가 상승하고 있으며, 외국인 투자자들의 관심",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.843,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 695,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현대차에 대한 최근 뉴스 감성은 긍정적입니다. 총 5건의 뉴스 중 모두 긍정적인 내용으로, 부정적인 기사는 없습니다. 주요 키워드로는 삼성증권, 현대차, 테슬라 전략, 레버리지 등이 언급되고 있습니다.\n\n### 최근 뉴스 흐름 요약:\n- 삼성증권이 신규 고객에게 현대차와 삼성전자 주식을 제공하는 이벤트를 진행하고 있습니다.\n- 현대차의 테슬라 전략에 대한 ",
+      "faithfulness": 0.727,
+      "answer_relevancy": 0.907,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 840,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "NAVER의 최근 뉴스 흐름 요약입니다.\n\n**전체 감성:** 🟢 긍정 (긍정 4건 / 부정 1건 / 중립 3건)\n\n**주요 키워드:** 네이버페이, 주식 투자, 반도체, 주가 상승, 코스피\n\n**뉴스 흐름 요약:**\n최근 네이버는 두나무의 네이버페이 지분을 294억원에 인수하는 긍정적인 소식을 전했습니다. 하지만 주식 시장 전반에서는 주가 하락에 대한 우",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 204,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "카카오에 대한 최근 뉴스 분위기는 중립적입니다. 긍정적인 기사는 없고, 부정적인 기사도 없으며, 중립적인 기사 3건이 보도되었습니다. 주요 내용은 카카오와 고영에 대한 주식 선택에 대한 논의가 이루어지고 있으며, 이는 투자자들에게 중립적인 정보로 해석됩니다.\n\n📌 위 내용은 데이터 기반 참고 정보입니다. 실제 투자 시에는 추가적인 조사와 전문가 상담을 권장",
+      "faithfulness": 0.75,
+      "answer_relevancy": 0.86,
+      "context_recall": 1.0
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 602,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "LG에너지솔루션에 대한 최근 뉴스 감성 분석 결과입니다.\n\n**전체 감성:** 🔴 부정  \n- 긍정: 1건  \n- 부정: 3건  \n- 중립: 0건  \n\n**주요 키워드:** 주가, ESS 흑자전환, 증권사, 2차 발행, 오버행\n\n**뉴스 흐름 요약:** 최근 LG에너지솔루션 관련 뉴스에서는 주가 상승과 ESS(에너지 저장 시스템) 흑자전환 가능성이 긍정적으",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.904,
+      "context_recall": 1.0
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 438,
+      "model": "gpt-4o",
+      "has_context": true,
+      "answer_preview": "삼성전자는 여러 ETF에 포함되어 있으며, 특히 다음과 같은 ETF에서 높은 비중을 차지하고 있습니다:\n\n1. **SOL 200타겟위클리커버드콜 (0167B0)**: 비중 34.09%\n2. **TIGER 200 (102110)**: 비중 33.94%\n3. **KODEX 200TR (278530)**: 비중 33.93%\n4. **KODEX 200 (06950",
+      "faithfulness": 0.923,
+      "answer_relevancy": 0.868,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 820,
+      "model": "gpt-4o",
+      "has_context": true,
+      "answer_preview": "SK하이닉스가 편입된 ETF와 전기·전자 섹터 분석 결과입니다.\n\n### SK하이닉스가 편입된 주요 ETF\n1. **TIGER 코리아TOP10 (292150)**: SK하이닉스 비중 40.83%\n2. **TIGER 반도체 (091230)**: SK하이닉스 비중 39.07%\n3. **KODEX 반도체 (091160)**: SK하이닉스 비중 39.00%\n4. ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.785,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 476,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현대차(005380)의 섹터 내 밸류에이션 위치는 다음과 같습니다.\n\n1. **현대차 밸류에이션**:\n   - **PER**: 17.1배\n   - **PBR**: 1.41배\n\n2. **업종 평균 및 통계**:\n   - **PER 평균**: 72.6배, 중간값 10.9배 (최저 1.6배 ~ 최고 3116.7배)\n   - **PBR 평균**: 1.76배 (PB",
+      "faithfulness": 0.765,
+      "answer_relevancy": 0.285,
+      "context_recall": 1.0
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 1220,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "KB금융의 업종 분석과 보유 ETF에 대한 정보입니다.\n\n### 1. 업종 분석 (은행)\n- **시가총액 상위 종목**:\n  1. **기업은행 (024110)**: 종가 22,450원 (-2.81%), 시가총액 17.9조, PER 7.0, PBR 0.49\n  2. **카카오뱅크 (323410)**: 종가 23,650원 (-2.07%), 시가총액 11.3조,",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.898,
+      "context_recall": 1.0
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 656,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "POSCO홀딩스의 섹터 분석 결과입니다.\n\n1. **업종 및 밸류에이션**:\n   - **업종**: 금속\n   - **PER**: 44.2배 (업종 평균 45.4배, 상위 24%)\n   - **PBR**: 0.52배 (업종 평균 1.38배, 상위 62%)\n   - **배당수익률**: 2.60% (업종 평균 3.16%, 상위 45%)\n   - **시가총액**",
+      "faithfulness": 0.913,
+      "answer_relevancy": 0.828,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "answer_length": 890,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "NAVER가 포함된 ETF와 업종 분석 결과는 다음과 같습니다.\n\n### NAVER가 포함된 ETF\n1. **KODEX 로봇액티브**\n   - 비중: 4.09%\n2. **TIGER 코리아TOP10**\n   - 비중: 2.76%\n3. **RISE ESG사회책임투자**\n   - 비중: 1.59%\n4. **KODEX 코스피100**\n   - 비중: 0.77%\n5",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.822,
+      "context_recall": 1.0
+    }
+  ]
+}

--- a/ETF_RAG/eval/run_eval.py
+++ b/ETF_RAG/eval/run_eval.py
@@ -6,6 +6,7 @@ RAGAS 평가 파이프라인
     .venv/bin/python eval/run_eval.py              # 전체 평가 (검색 + RAGAS)
     .venv/bin/python eval/run_eval.py --no-llm     # 검색만 평가 (API 비용 없음)
     .venv/bin/python eval/run_eval.py --sample 10  # 샘플 N개만 RAGAS 평가 (비용 절감)
+    .venv/bin/python eval/run_eval.py --types forecast,news,sector  # 특정 유형만 평가
 
 평가 지표:
     - Hit Rate / Precision / Recall: 검색 품질 (API 비용 없음)
@@ -38,9 +39,14 @@ DATASET_PATH = EVAL_DIR / "eval_dataset.json"
 RESULTS_DIR = EVAL_DIR / "results"
 
 
-def load_eval_dataset():
+def load_eval_dataset(types=None):
+    """평가 데이터셋 로드. types가 주어지면 해당 question_type만 필터링."""
     with open(DATASET_PATH, "r", encoding="utf-8") as f:
-        return json.load(f)
+        data = json.load(f)
+    if types:
+        type_set = set(types)
+        data = [it for it in data if it.get("question_type") in type_set]
+    return data
 
 
 def init_retriever():
@@ -572,13 +578,19 @@ def main():
     no_llm = "--no-llm" in sys.argv
 
     # --sample N 옵션: RAGAS 평가 시 샘플 수 제한 (비용 절감)
+    # --types a,b,c 옵션: 특정 question_type만 평가 (신규 도구 집중 평가용)
     sample_size = None
+    types = None
     for i, arg in enumerate(sys.argv):
         if arg == "--sample" and i + 1 < len(sys.argv):
             sample_size = int(sys.argv[i + 1])
+        if arg == "--types" and i + 1 < len(sys.argv):
+            types = [t.strip() for t in sys.argv[i + 1].split(",") if t.strip()]
 
     logger.info("평가 데이터셋 로드...")
-    dataset = load_eval_dataset()
+    dataset = load_eval_dataset(types=types)
+    if types:
+        logger.info(f"  유형 필터: {types}")
     logger.info(f"  {len(dataset)}개 질문")
 
     logger.info("Retriever 초기화...")

--- a/ETF_RAG/requirements.txt
+++ b/ETF_RAG/requirements.txt
@@ -19,6 +19,7 @@ python-dotenv>=1.0.0,<2.0
 zstandard>=0.20.0,<1.0
 dart-fss>=0.4.0,<1.0
 feedparser>=6.0.0,<7.0
+certifi>=2023.0.0  # 뉴스 RSS SSL 검증 CA 번들 (news.py _fetch_feed)
 prophet>=1.1.0,<2.0
 pinecone-client>=3.0.0,<6.0
 langchain-pinecone>=0.1.0,<0.4

--- a/ETF_RAG/src/data/news.py
+++ b/ETF_RAG/src/data/news.py
@@ -9,6 +9,8 @@
 
 import logging
 import re
+import ssl
+import urllib.request
 from datetime import datetime, timedelta
 from typing import Optional
 from urllib.parse import quote
@@ -19,6 +21,21 @@ logger = logging.getLogger(__name__)
 
 # Google News RSS 엔드포인트
 GOOGLE_NEWS_RSS_URL = "https://news.google.com/rss/search?q={query}&hl=ko&gl=KR&ceid=KR:ko"
+
+
+def _fetch_feed(url: str):
+    """RSS URL을 파싱. feedparser 기본 경로가 SSL 인증서를 못 찾는 환경
+    (시스템 CA 미설치 macOS Python 등)을 대비해 certifi CA 번들로 직접
+    fetch한 bytes를 넘긴다. 직접 fetch 실패 시 feedparser 기본 경로로 fallback."""
+    try:
+        import certifi
+        ctx = ssl.create_default_context(cafile=certifi.where())
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+            return feedparser.parse(resp.read())
+    except Exception as e:
+        logger.info(f"certifi fetch 실패, feedparser 기본 경로 사용: {e}")
+        return feedparser.parse(url)
 
 
 def fetch_google_news(
@@ -36,7 +53,7 @@ def fetch_google_news(
     """
     url = GOOGLE_NEWS_RSS_URL.format(query=quote(query))
     try:
-        feed = feedparser.parse(url)
+        feed = _fetch_feed(url)
     except Exception as e:
         logger.warning(f"Google News RSS 파싱 실패: {e}")
         return []

--- a/ETF_RAG/src/llm/tools/analysis.py
+++ b/ETF_RAG/src/llm/tools/analysis.py
@@ -13,6 +13,50 @@ from src.utils.formatters import format_market_cap
 
 logger = logging.getLogger(__name__)
 
+# 통속 업종명 → KRX 공식 업종명 별칭.
+# 사용자/LLM이 "자동차", "반도체" 같은 일반 명칭을 쓰면 KRX 공식 분류명
+# ("운송장비·부품", "전기·전자")과 달라 섹터 매칭이 실패하던 문제를 보완.
+# 값은 _sector_index 키(위 KRX 29개 업종)와 일치해야 한다.
+_SECTOR_ALIASES = {
+    "자동차": "운송장비·부품",
+    "차": "운송장비·부품",
+    "운송장비": "운송장비·부품",
+    "부품": "운송장비·부품",
+    "반도체": "전기·전자",
+    "전자": "전기·전자",
+    "it": "IT 서비스",
+    "아이티": "IT 서비스",
+    "소프트웨어": "IT 서비스",
+    "바이오": "제약",
+    "제약·바이오": "제약",
+    "헬스케어": "제약",
+    "2차전지": "전기·전자",
+    "배터리": "전기·전자",
+    "에너지": "전기·가스",
+    "전력": "전기·가스",
+    "유틸리티": "전기·가스",
+    "철강": "금속",
+    "조선": "운송장비·부품",
+    "항공": "운송·창고",
+    "물류": "운송·창고",
+    "해운": "운송·창고",
+    "엔터": "오락·문화",
+    "엔터테인먼트": "오락·문화",
+    "게임": "오락·문화",
+    "미디어": "출판·매체복제",
+    "식품": "음식료·담배",
+    "음식료": "음식료·담배",
+    "섬유": "섬유·의류",
+    "의류": "섬유·의류",
+    "패션": "섬유·의류",
+    "기계": "기계·장비",
+    "장비": "기계·장비",
+    "의료기기": "의료·정밀기기",
+    "정밀기기": "의료·정밀기기",
+    "건설사": "건설",
+    "통신사": "통신",
+}
+
 
 def _format_cap(value: int) -> str:
     """시가총액을 조/억 단위 문자열로 (접미사 '원' 없음)"""
@@ -235,6 +279,21 @@ def analyze_sector(query: str) -> str:
                 matched_sector = sector_name
                 matched_stocks = stocks
                 break
+
+        # 별칭 매칭 — 통속 업종명("자동차")을 KRX 공식명("운송장비·부품")으로 변환.
+        # 단, 종목명("현대차")이 별칭("차")에 끌려가지 않도록 역인덱스에
+        # 종목으로 존재하는 query는 별칭 매칭에서 제외한다.
+        if not matched_sector:
+            is_known_stock = bool(
+                _state._holdings_reverse_index
+                and (_state._holdings_reverse_index.get(query_lower)
+                     or _state._holdings_reverse_index.get(query))
+            )
+            if not is_known_stock:
+                alias = _SECTOR_ALIASES.get(query_lower) or _SECTOR_ALIASES.get(query)
+                if alias and alias in _state._sector_index:
+                    matched_sector = alias
+                    matched_stocks = _state._sector_index[alias]
 
         # 부분 매칭
         if not matched_sector:

--- a/ETF_RAG/tests/test_news.py
+++ b/ETF_RAG/tests/test_news.py
@@ -41,7 +41,7 @@ def _make_entry(title, days_ago=0, source="한경", summary=""):
     return entry
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_basic(mock_parse):
     """기본 뉴스 수집"""
     entries = [
@@ -56,7 +56,7 @@ def test_fetch_google_news_basic(mock_parse):
     assert articles[0]["source"] == "한경"
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_date_filter(mock_parse):
     """오래된 기사 필터링"""
     entries = [
@@ -70,7 +70,7 @@ def test_fetch_google_news_date_filter(mock_parse):
     assert "최신" in articles[0]["title"]
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_max_articles(mock_parse):
     """최대 기사 수 제한"""
     entries = [_make_entry(f"뉴스 {i}", days_ago=i) for i in range(5)]
@@ -80,7 +80,7 @@ def test_fetch_google_news_max_articles(mock_parse):
     assert len(articles) == 3
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_empty(mock_parse):
     """뉴스 없음"""
     mock_parse.return_value = _make_mock_feed([])
@@ -89,7 +89,7 @@ def test_fetch_google_news_empty(mock_parse):
     assert articles == []
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_parse_error(mock_parse):
     """RSS 파싱 에러 처리"""
     mock_parse.side_effect = Exception("Network error")
@@ -98,7 +98,7 @@ def test_fetch_google_news_parse_error(mock_parse):
     assert articles == []
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_html_summary(mock_parse):
     """HTML 태그가 포함된 요약 정리"""
     entries = [
@@ -213,7 +213,7 @@ def test_get_stock_news_summary_retry(mock_fetch, mock_analyze):
 
 # ── 엣지 케이스 테스트 ────────────────────────────────────────
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_missing_published(mock_parse):
     """published_parsed 없는 엔트리 처리"""
     entry = MagicMock()
@@ -234,7 +234,7 @@ def test_fetch_google_news_missing_published(mock_parse):
     assert isinstance(articles, list)
 
 
-@patch("src.data.news.feedparser.parse")
+@patch("src.data.news._fetch_feed")
 def test_fetch_google_news_source_extraction(mock_parse):
     """다양한 제목 형식에서 출처 추출"""
     entries = [
@@ -283,3 +283,41 @@ def test_get_stock_news_summary_no_articles(mock_fetch, mock_analyze):
 
     result = get_stock_news_summary("존재하지않는종목")
     assert result["overall_sentiment"] == "데이터 없음"
+
+
+# ── _fetch_feed: certifi 우선 + fallback (RSS SSL 검증 방어) ─────
+
+@patch("src.data.news.urllib.request.urlopen")
+def test_fetch_feed_uses_certifi_path(mock_urlopen):
+    """certifi 컨텍스트로 직접 fetch 성공 시 그 bytes를 feedparser에 넘긴다.
+
+    macOS Python 등 시스템 CA 미설치 환경에서 feedparser 기본 경로가
+    SSL CERTIFICATE_VERIFY_FAILED로 0건 반환하던 문제(2026-06-17 RAGAS
+    평가에서 뉴스 0건 → AR=0.0으로 발견)를 보완한 경로.
+    """
+    from src.data.news import _fetch_feed
+
+    resp_cm = MagicMock()
+    resp_cm.__enter__.return_value.read.return_value = b"<rss></rss>"
+    mock_urlopen.return_value = resp_cm
+
+    with patch("src.data.news.feedparser.parse") as mock_parse:
+        mock_parse.return_value = _make_mock_feed([])
+        _fetch_feed("https://news.google.com/rss/search?q=x")
+
+    # urlopen이 호출되고(=certifi 경로), feedparser.parse는 bytes로 호출됨
+    assert mock_urlopen.called
+    mock_parse.assert_called_once_with(b"<rss></rss>")
+
+
+@patch("src.data.news.urllib.request.urlopen", side_effect=Exception("SSL fail"))
+def test_fetch_feed_fallback_on_certifi_failure(mock_urlopen):
+    """certifi 직접 fetch 실패 시 feedparser 기본 경로(URL)로 fallback."""
+    from src.data.news import _fetch_feed
+
+    with patch("src.data.news.feedparser.parse") as mock_parse:
+        mock_parse.return_value = _make_mock_feed([])
+        _fetch_feed("https://news.google.com/rss/search?q=x")
+
+    # fallback은 URL 문자열로 feedparser.parse 호출
+    mock_parse.assert_called_once_with("https://news.google.com/rss/search?q=x")

--- a/ETF_RAG/tests/test_sector.py
+++ b/ETF_RAG/tests/test_sector.py
@@ -281,3 +281,36 @@ def test_analyze_sector_stock_with_sector_info():
     result = analyze_sector.invoke({"query": "삼성전자"})
     assert "전기·전자" in result
     assert "동일 업종" in result
+
+
+# ── 통속 업종명 별칭 매핑 (자동차 → 운송장비·부품 등) ──────────
+
+def test_analyze_sector_alias_automobile():
+    """통속명 '자동차' → KRX 공식명 '운송장비·부품' 매핑.
+
+    이전엔 KRX 분류에 '자동차' 섹터가 없어 빈 응답이 나오던 사각지대.
+    RAGAS 평가(2026-06-17)에서 '현대차 섹터 내 밸류에이션' 질문이
+    이 경로로 빠져 AR=0.0이 나온 것이 계기.
+    """
+    set_retriever(None, [], etf_data=SAMPLE_ETF_DATA, stock_data=SAMPLE_STOCK_DATA)
+    result = analyze_sector.invoke({"query": "자동차"})
+    assert "운송장비·부품" in result
+    assert "업종 분석" in result
+    assert "현대차" in result
+
+
+def test_analyze_sector_alias_semiconductor():
+    """통속명 '반도체' → '전기·전자' 매핑."""
+    set_retriever(None, [], etf_data=SAMPLE_ETF_DATA, stock_data=SAMPLE_STOCK_DATA)
+    result = analyze_sector.invoke({"query": "반도체"})
+    assert "전기·전자" in result
+    assert "업종 분석" in result
+
+
+def test_analyze_sector_alias_does_not_hijack_stock_name():
+    """종목명('현대차')이 별칭('차')에 끌려가면 안 됨 — 종목 역인덱스 경로 유지."""
+    set_retriever(None, [], etf_data=SAMPLE_ETF_DATA, stock_data=SAMPLE_STOCK_DATA)
+    result = analyze_sector.invoke({"query": "현대차"})
+    # 종목 분석(보유 ETF) 경로여야지 업종 분석이 아니어야 한다
+    assert "보유한 ETF" in result
+    assert "운송장비·부품 업종 분석" not in result


### PR DESCRIPTION
## 배경
\"Hit Rate 100%가 진짜 천장인가, 측정 안 된 사각지대인가?\" 검증. 최근 3개월 추가한 도구(`predict_price_outlook`/`get_stock_news`/`analyze_sector`)가 eval 172개에 한 번도 포함된 적 없어 응답 품질 측정 사각지대였음.

## 변경
### test(eval) — 신규 도구 평가 커버리지
- `eval_dataset.json`: forecast 8 + news 6 + sector 6 = **20개 추가** (172→192, 11유형). forecast가 기존 `technical`로 라벨돼 stratified 샘플링에서 신규 도구가 안 뽑히던 것도 별도 유형으로 분리.
- `run_eval.py`: `--types a,b,c` 필터 옵션 (특정 유형 집중 평가/비용 절감).
- **retrieval은 천장 맞음**: 192개 + 신규 20개 모두 Hit Rate 100%, 신규 유형도 rank-1 정확.

### fix(tools) — RAGAS가 잡아낸 실버그 2건
1. **`analyze_sector` 통속 업종명 별칭**: \"자동차\"는 KRX 분류에 없고 공식명은 \"운송장비·부품\" → \"현대차 섹터 밸류에이션\" 질문이 빈 응답(AR=0.0). `_SECTOR_ALIASES`(자동차/반도체/바이오/2차전지/철강 등 → KRX 29개 공식명) 추가. 종목명(\"현대차\")이 별칭(\"차\")에 끌려가지 않게 역인덱스 종목 가드.
2. **news RSS SSL (certifi)**: feedparser 기본 경로가 시스템 CA 미설치 환경(macOS Python)에서 `CERTIFICATE_VERIFY_FAILED` → 뉴스 0건 → 감성 분석 전체 무력화. `_fetch_feed`가 certifi CA 번들로 직접 fetch 후 fallback. (Railway Linux는 정상이었을 수 있으나 환경 무관 견고화.)

## 효과 (RAGAS news+sector 재측정)
| 지표 | 전 | 후 |
|------|-----|-----|
| Answer Relevancy | 0.501 | **0.747** (+0.246, +49%) |
| Faithfulness | 0.874 | 0.895 |
| 테스트 | 766 | **771** |

## 교훈
Hit Rate 100%는 retrieval만 측정 — 도구 응답 품질은 RAGAS로만 잡힘. **신규 도구 추가 시 eval 유형도 함께 추가할 것.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)