### PR TITLE
fix(sector): 종목 경로에서 밸류에이션 위치를 ETF 목록보다 먼저 배치

### DIFF
--- a/ETF_RAG/src/llm/tools/analysis.py
+++ b/ETF_RAG/src/llm/tools/analysis.py
@@ -263,6 +263,11 @@ def analyze_sector(query: str) -> str:
     """특정 종목이 포함된 ETF를 찾거나, 업종별 종목 분석(PER/PBR 비교, 시가총액 상위)을 수행합니다.
     "삼성전자 담고 있는 ETF", "전기전자 업종 분석", "은행 업종 PER 비교", "반도체 관련 ETF" 등의 질문에 사용합니다.
 
+    중요: "현대차 섹터 내 밸류에이션 위치"처럼 **특정 종목의 업종 내 상대 위치**를
+    묻는 질문은 종목명(예: "현대차")으로 호출하세요. 그러면 그 종목의 업종, 업종 내
+    PER/PBR/배당/시총 백분위 위치를 반환합니다. 섹터명("자동차")으로 호출하면 업종
+    전체 종목 목록만 나와 특정 종목의 상대 위치가 강조되지 않습니다.
+
     Args:
         query: 종목명/티커, 업종명, 또는 섹터 키워드 (예: "삼성전자", "전기·전자", "반도체", "은행")
     """
@@ -322,24 +327,14 @@ def analyze_sector(query: str) -> str:
                 seen.add(m["etf_ticker"])
                 unique.append(m)
 
-        lines = [f"[{stock_name}]을(를) 보유한 ETF ({len(unique)}개):\n"]
-        for m in unique[:15]:
-            lines.append(
-                f"- [{m['etf_ticker']}] {m['etf_name']} (비중: {m['weight']:.2f}%)"
-            )
-        if len(unique) > 15:
-            lines.append(f"  ... 외 {len(unique) - 15}개")
+        lines = []
 
-        avg_weight = sum(m["weight"] for m in unique) / len(unique)
-        max_m = unique[0]
-        lines.append(f"\n[통계] 평균 비중: {avg_weight:.2f}%, "
-                      f"최대 비중: {max_m['etf_name']} ({max_m['weight']:.2f}%)")
-
-        # 해당 종목의 업종 정보 + 밸류에이션 위치
+        # 업종 정보 + 밸류에이션 위치를 먼저 — "섹터 내 밸류에이션 위치" 질문이
+        # ETF 목록에 묻히지 않도록 답변 상단에 배치.
         stock_data = _state._stock_data_index.get(query_lower) or _state._stock_data_index.get(query)
         if stock_data and stock_data.get("sector"):
             sector = stock_data["sector"]
-            lines.append(f"\n[업종] {stock_name}: {sector}")
+            lines.append(f"[업종] {stock_name}: {sector}")
 
             if sector in _state._sector_index:
                 sector_stocks = _state._sector_index[sector]
@@ -354,6 +349,20 @@ def analyze_sector(query: str) -> str:
                 if peers:
                     peer_names = ", ".join(p["name"] for p in peers)
                     lines.append(f"[동일 업종] {peer_names}")
+            lines.append("")  # 구분
+
+        lines.append(f"[{stock_name}]을(를) 보유한 ETF ({len(unique)}개):\n")
+        for m in unique[:15]:
+            lines.append(
+                f"- [{m['etf_ticker']}] {m['etf_name']} (비중: {m['weight']:.2f}%)"
+            )
+        if len(unique) > 15:
+            lines.append(f"  ... 외 {len(unique) - 15}개")
+
+        avg_weight = sum(m["weight"] for m in unique) / len(unique)
+        max_m = unique[0]
+        lines.append(f"\n[통계] 평균 비중: {avg_weight:.2f}%, "
+                      f"최대 비중: {max_m['etf_name']} ({max_m['weight']:.2f}%)")
 
         return "\n".join(lines)
 

--- a/ETF_RAG/tests/test_sector.py
+++ b/ETF_RAG/tests/test_sector.py
@@ -314,3 +314,18 @@ def test_analyze_sector_alias_does_not_hijack_stock_name():
     # 종목 분석(보유 ETF) 경로여야지 업종 분석이 아니어야 한다
     assert "보유한 ETF" in result
     assert "운송장비·부품 업종 분석" not in result
+
+
+def test_analyze_sector_valuation_before_etf_list():
+    """종목 경로에서 업종/밸류에이션 위치가 ETF 목록보다 먼저 나와야 한다.
+
+    "현대차 섹터 내 밸류에이션 위치" 질문이 긴 ETF 목록에 묻히던 문제
+    (2026-06-18 RAGAS sector AR=0.28) 보완. 밸류에이션 정보를 답변 상단에 배치.
+    """
+    set_retriever(None, [], etf_data=SAMPLE_ETF_DATA, stock_data=SAMPLE_STOCK_DATA)
+    result = analyze_sector.invoke({"query": "삼성전자"})
+    # [업종] 헤더와 보유 ETF 목록 둘 다 존재
+    assert "[업종]" in result
+    assert "보유한 ETF" in result
+    # 업종/밸류에이션 위치가 ETF 목록보다 앞서야 한다
+    assert result.index("[업종]") < result.index("보유한 ETF")


### PR DESCRIPTION
## 배경
PR #61에서 신규 도구 eval 커버리지를 추가하며 `analyze_sector`의 RAGAS Answer Relevancy가 낮음(AR≈0.28)을 확인했다. "현대차 섹터 내 밸류에이션 위치"처럼 **특정 종목의 업종 내 상대 위치**를 묻는 질문에서, 정작 핵심인 업종/밸류에이션 백분위 정보가 긴 보유 ETF 목록 뒤에 묻혀 답변 관련성이 떨어졌다.

## 변경
- `analyze_sector` 종목 경로: `[업종]` + 밸류에이션 백분위 위치를 **답변 상단**으로 올리고, 보유 ETF 목록을 그 뒤로 재배치
- docstring에 "종목명으로 호출하면 업종 내 상대 위치를 반환, 섹터명으로 호출하면 종목 목록만 나옴" 안내 추가 → LLM의 도구 호출 인자 선택 개선
- 회귀 테스트 추가: `test_analyze_sector_valuation_before_etf_list` (`[업종]`이 `보유한 ETF`보다 앞서는지 검증)

## 테스트
- `tests/test_sector.py` 28개 통과
- 전체(로컬 fastapi 미설치로 API 테스트 제외) 708개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)