### PR TITLE
feat(auth): 계정 관리 — 비밀번호 변경 + 닉네임 + 회원 탈퇴

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2413,11 +2413,44 @@ PR #57 이후 머지된 변경(F-3 로컬 감성 #58 + RAG 품질 #61 + sector �
 - **`_SECTOR_ALIASES` 값 36개 ↔ 실제 KRX DB 업종명 29개 대조: 전부 정확 일치(오타 0)** + `alias in _sector_index` 이중 가드 ✓
 - 관련 테스트(news+sentiment+sector) 60개 통과. 기능 추가 아님, 점검만.
 
+### Railway 유저 DB 영구화 (Postgres 연결) — 2026-06-18 (사용자 작업, 진행 중)
+
+"유료 전환" 의미 정리 중 발견: Railway 백엔드(서비스명 `AI_agent`, URL `aiagent-production-75ca.up.railway.app`)에 **`DATABASE_URL` 환경변수가 없었음** → 유저 DB가 컨테이너 내부 SQLite(`etf_rag_users.db`)로 저장돼 **재배포마다 회원/관심종목/대화이력 소실** 상태였음(DEPLOY.md:33에 경고 기록돼 있던 미완 항목 "영구볼륨").
+
+- **조치(사용자가 Railway 대시보드에서 직접):** 프로젝트 `skillful-presence`에 **PostgreSQL 플러그인 추가**(postgres-volume 영구 디스크 자동 포함) → `AI_agent` 서비스 Variables에 `DATABASE_URL = ${{Postgres.DATABASE_URL}}`(자동 참조) 추가 → 변수 추가 시 Railway가 자동 재배포 시작.
+- 코드는 이미 Postgres 지원(`config.py:28` DATABASE_URL 미설정 시 sqlite, 설정 시 postgresql / `api/db.py` 동일 Engine API / `init_models()`가 부팅 시 `create_all` 자동 — Alembic 마이그레이션은 후속). **코드 변경 0, Railway 설정만.**
+- **검증 남음:** 재배포 로그에서 `사용자 DB 테이블 준비 완료 (postgresql)`(db.py:34) 확인 + 회원가입→관심종목 추가→재배포→데이터 유지 확인.
+- JWT_SECRET은 이미 설정돼 있었음(👍). 프론트 서비스명 `radiant-abundance`.
+- **Railway 상태:** trial 크레딧 **$2.42 / 22일 남음**. 소진되면 서비스 정지 → Hobby($5/월) 전환 필요. Postgres 추가로 크레딧 소모 약간 가속.
+
+### 후원(기부) 기능 — 결정만, 보류 (2026-06-18)
+
+프리미엄 구독(유료화)은 **접음**(틈틈이 만든 개인 앱, 결제 연동 ROI 안 맞음). 대신 **후원 버튼**으로 — 단 "전환" 아니라 "있어도 그만" 톤. **타깃=친구+포트폴리오 방문자**. **결정: BMC 버튼 공개로 두되 클릭 시 Buy Me a Coffee(해외카드)+토스 송금(국내) 둘 다 안내**(친구는 토스, 채용자/방문자는 BMC). 계좌번호 직접 노출은 금지(포트폴리오·불특정 공개라 부적합+프라이버시). **위치=사이드바 하단 구석**(Sidebar.tsx 투자유의 문구 위/아래). 링크는 `NEXT_PUBLIC_DONATE_URL` env placeholder로 빼두고 비어있으면 자동 숨김. **BMC는 후원자 가입 불필요(받는 사람만 1회 가입), 정산은 페이팔 경유**. **사용자가 "해줘" 할 때 구현**(우선 본인 검증 먼저).
+
+### 로그인 기능 보강 — 비번변경 + 탈퇴 + 닉네임 (2026-06-18, 브랜치 phase-f-account-management)
+
+회원가입 후 계정 관리 기능. **범위 합의:** 비번변경/탈퇴/표시용 닉네임 구현, ID찾기는 "이메일=ID" 안내로 대체, 비번찾기(이메일 재설정)는 메일 인프라 필요 → 후속 보류(보안질문 방식은 보안저하라 안 함).
+
+- **백엔드** (`api/`):
+  - `models_db.User`에 `nickname`(VARCHAR40, nullable) 추가. `db.py` `init_models`에 `_migrate_add_columns()`(inspector로 컬럼 존재 확인 후 `ALTER TABLE ADD COLUMN` — create_all이 기존 테이블에 컬럼 추가 못 하는 것 보완, Alembic 미도입 환경용 멱등 마이그레이션).
+  - `auth.py`: `PUT /auth/password`(현재 비번 검증+기존과 동일 거부→204), `PUT /auth/profile`(닉네임 strip+공백거부→UserResponse), `DELETE /auth/me`(비번 재확인 후 Watchlist/ChatHistory/PushSubscription 명시 삭제→계정 삭제, FK cascade 미설정이라 자식 먼저). `/auth/me`·UserResponse에 `nickname` 추가(`_display_nickname`: 미설정 시 이메일 local-part fallback).
+  - models.py: PasswordChangeRequest/ProfileUpdateRequest/AccountDeleteRequest. **테스트 13개 추가(test_auth 8→21, 전체 통과 — 로컬 fastapi/bcrypt/PyJWT 설치 후 검증).**
+- **프론트** (`frontend/`):
+  - lib/auth.ts: AuthUser에 nickname + changePassword/updateNickname/deleteAccount. AuthContext에 `refresh()`(닉네임 변경 후 user 재동기화).
+  - **`/account` 페이지 신설**(닉네임/비번변경/탈퇴 3섹션, 비로그인 시 로그인 안내). NavBar 우측이 이메일→**⚙️ {nickname}** 클릭 시 /account. tsc 통과.
+- **함정:** `init_models` 마이그레이션은 inspector 기반(sqlite/pg `ADD COLUMN IF NOT EXISTS` 미지원 회피). 방금 만든 Postgres는 create_all로 nickname 포함 생성되나, 기존 sqlite/가입자 DB는 이 마이그레이션이 보정.
+
 ### 다음
-- 유료 전환 / 블로그 9편.
+- 계정기능 PR→머지 → (사용자) Railway 재배포 로그 검증 → **UI 개선 4건**(아래) → 가상투자 탭 → 후원("해줘" 시) → 블로그 9편 / 메일 인프라(비번찾기)
+
+### UI 개선 요청 4건 (2026-06-18, 사용자 — TODO)
+1. **'티커' 용어 교체**: 너무 전문적 → 쉬운 말("종목코드" 또는 "종목"). 프론트/백엔드 사용자 노출 문구 전수.
+2. **재무제표 탭**: ETF는 재무제표 없음 → **주식만 검색 허용(ETF 제외)** + 기간 **10년 추가** + **직접설정**(현재 1/2/3/5년).
+3. **비교분석 탭**: 기간 **직접설정** 추가.
+4. **섹터분석 탭**: 현재 **하루치만** 표시 → 기간 선택(1일/1주/1달/3달/6달/1년/2년/3년/5년/10년 + 직접설정). ⚠️ 섹터 등락률 시계열은 데이터/계산 방식 확인 필요(현재 단일일 등락률만 쓰는지).
 
 ---
 
-_Last Updated: 2026-06-18 (코드 점검 라운드 — PR #58/#61/#62(559줄) 정독+별칭값↔DB업종명 대조, 실버그 0건. + sector RAGAS 재측정 AR 0.845 확인. 직전: sector 답변구조 재배치 #62 / 신규 도구 eval 커버리지 20개+실버그 2건 #61. 다음: 유료전환/블로그9편)_
+_Last Updated: 2026-06-18 (Railway 유저DB 영구화 — Postgres 플러그인 추가 + DATABASE_URL=${{Postgres.DATABASE_URL}} 연결로 재배포 시 회원/관심종목 소실 문제 해결(사용자 작업, 재배포 로그 검증 남음). 후원기능=BMC+토스 안내 결정만(보류). 로그인 보강 착수예정: 비번변경+탈퇴(비번찾기는 메일인프라 필요→후속). 직전: 코드점검 라운드 실버그0 + sector RAGAS AR 0.845. 다음: 비번변경/탈퇴 구현)_
 _2026-06-16 (PR #50~#54 KIS + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57 + F-3 로컬감성 #58). 테스트 766_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -534,7 +534,7 @@ ETF_RAG/
 
 ---
 
-_Last Updated: 2026-06-18 (sector 후속 #62 — analyze_sector 종목 경로에서 [업종]/밸류에이션 백분위를 보유 ETF 목록보다 앞으로 재배치(현대차 섹터 AR=0.28 답변구조 보완) + docstring 호출 인자 안내 + 회귀테스트 1개. 직전: RAG 품질 — 신규 도구 eval 커버리지 20개(172→192) + 실버그 2건(sector 별칭·news SSL) → RAGAS AR 0.501→0.747 #61. 그 이전: 2026-06-16 Phase F KIS #50~#54 + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57 + F-3 로컬감성 #58)_
+_Last Updated: 2026-06-18 (Railway 유저DB 영구화 — Postgres 플러그인 추가 + DATABASE_URL 연결로 재배포 시 회원/관심종목 소실 해결(사용자 Railway 작업, 재배포 로그 검증 남음). 로그인 보강 착수예정(비번변경+탈퇴, 비번찾기는 메일인프라 후속). 후원=BMC+토스 안내 결정만 보류. 직전: sector 후속 #62 답변구조 재배치 AR 0.845 + 코드점검 라운드 실버그0 / RAG 품질 eval 커버리지 #61. 상세: CLAUDE.local.md)_
 
 > ✅ **CI 액션 Node 24 대응 완료** (2026-06-08): `checkout@v4→v6`, `setup-python@v5→v6` (ci.yml + daily-collect.yml 4곳). CI green 확인. 2026-06-16 Node 24 강제 전환 대비.
 

--- a/ETF_RAG/api/auth.py
+++ b/ETF_RAG/api/auth.py
@@ -12,13 +12,21 @@ import bcrypt
 import jwt  # PyJWT
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from config import JWT_ALGORITHM, JWT_EXPIRE_MINUTES, JWT_SECRET
 from api.db import get_db
-from api.models import LoginRequest, SignupRequest, TokenResponse, UserResponse
-from api.models_db import User
+from api.models import (
+    AccountDeleteRequest,
+    LoginRequest,
+    PasswordChangeRequest,
+    ProfileUpdateRequest,
+    SignupRequest,
+    TokenResponse,
+    UserResponse,
+)
+from api.models_db import ChatHistory, PushSubscription, User, Watchlist
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -93,9 +101,72 @@ def login(req: LoginRequest, db: Session = Depends(get_db)) -> TokenResponse:
     return TokenResponse(access_token=create_access_token(user.id))
 
 
+def _display_nickname(user: User) -> str:
+    """닉네임 미설정 시 이메일 local-part(앞부분)로 fallback."""
+    if user.nickname and user.nickname.strip():
+        return user.nickname
+    return user.email.split("@", 1)[0]
+
+
+def _user_response(user: User) -> UserResponse:
+    return UserResponse(
+        id=user.id, email=user.email, nickname=_display_nickname(user)
+    )
+
+
 @router.get("/me", response_model=UserResponse)
 def me(user: User = Depends(get_current_user)) -> UserResponse:
-    return UserResponse(id=user.id, email=user.email)
+    return _user_response(user)
+
+
+@router.put("/password", status_code=status.HTTP_204_NO_CONTENT)
+def change_password(
+    req: PasswordChangeRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """현재 비밀번호 확인 후 새 비밀번호로 변경."""
+    if not verify_password(req.current_password, user.password_hash):
+        raise HTTPException(status_code=400, detail="현재 비밀번호가 올바르지 않습니다.")
+    if req.new_password == req.current_password:
+        raise HTTPException(status_code=400, detail="기존과 다른 비밀번호를 사용하세요.")
+    user.password_hash = hash_password(req.new_password)
+    db.commit()
+
+
+@router.put("/profile", response_model=UserResponse)
+def update_profile(
+    req: ProfileUpdateRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserResponse:
+    """닉네임 변경. 공백만 입력은 거부."""
+    nickname = req.nickname.strip()
+    if not nickname:
+        raise HTTPException(status_code=400, detail="닉네임을 입력하세요.")
+    user.nickname = nickname
+    db.commit()
+    db.refresh(user)
+    return _user_response(user)
+
+
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
+def delete_account(
+    req: AccountDeleteRequest,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """회원 탈퇴 — 비밀번호 재확인 후 계정 + 연관 데이터(관심종목/대화이력/푸시구독) 삭제.
+
+    FK relationship/cascade를 모델에 안 걸었으므로 명시적으로 자식 행을 먼저 지운다."""
+    if not verify_password(req.password, user.password_hash):
+        raise HTTPException(status_code=400, detail="비밀번호가 올바르지 않습니다.")
+    uid = user.id
+    db.execute(delete(Watchlist).where(Watchlist.user_id == uid))
+    db.execute(delete(ChatHistory).where(ChatHistory.user_id == uid))
+    db.execute(delete(PushSubscription).where(PushSubscription.user_id == uid))
+    db.delete(user)
+    db.commit()
 
 
 # Phase C용 — 로그인 시 서버 영속, 비로그인 시 localStorage fallback.

--- a/ETF_RAG/api/db.py
+++ b/ETF_RAG/api/db.py
@@ -31,7 +31,25 @@ def init_models() -> None:
     """테이블이 없으면 생성. 멱등 — API_SKIP_INIT과 무관하게 매 부팅 호출(테이블만, 싸다)."""
     from api import models_db  # noqa: F401 — 모델 등록(임포트 부수효과)
     Base.metadata.create_all(engine)
+    _migrate_add_columns()
     logger.info("사용자 DB 테이블 준비 완료 (%s)", engine.url.drivername)
+
+
+def _migrate_add_columns() -> None:
+    """create_all은 기존 테이블에 신규 컬럼을 추가하지 못함(Alembic 미도입).
+    이미 users 테이블이 있는 환경(기존 가입자 보유 DB)을 위한 경량 멱등 마이그레이션.
+    sqlite/postgres 모두 ADD COLUMN IF NOT EXISTS를 지원하지 않는 경우가 있어
+    inspector로 존재 여부를 먼저 확인한다."""
+    from sqlalchemy import inspect, text
+
+    insp = inspect(engine)
+    if "users" not in insp.get_table_names():
+        return  # create_all이 방금 최신 스키마로 생성 → 보정 불필요
+    cols = {c["name"] for c in insp.get_columns("users")}
+    if "nickname" not in cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE users ADD COLUMN nickname VARCHAR(40)"))
+        logger.info("마이그레이션: users.nickname 컬럼 추가")
 
 
 def get_db() -> Iterator[Session]:

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -62,6 +62,22 @@ class TokenResponse(BaseModel):
 class UserResponse(BaseModel):
     id: int
     email: EmailStr
+    nickname: str  # 미설정 시 이메일 local-part로 fallback (auth.py에서 채움)
+
+
+class PasswordChangeRequest(BaseModel):
+    current_password: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+
+class ProfileUpdateRequest(BaseModel):
+    # 1~40자. 공백만 입력 방지는 라우터에서 strip 후 검증.
+    nickname: str = Field(..., min_length=1, max_length=40)
+
+
+class AccountDeleteRequest(BaseModel):
+    # 탈퇴는 되돌릴 수 없으므로 비밀번호 재확인.
+    password: str = Field(..., min_length=1)
 
 
 # ── 유저별 저장 (관심종목 / 대화이력) ──────────────────────

--- a/ETF_RAG/api/models_db.py
+++ b/ETF_RAG/api/models_db.py
@@ -34,6 +34,9 @@ class User(Base):
         String(320), unique=True, index=True, nullable=False
     )
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    # 표시용 닉네임(선택). 로그인은 이메일로, 이건 화면 표시·가상투자 랭킹 등에 사용.
+    # 기존 유저/미입력은 NULL → 응답 시 이메일 local-part로 fallback.
+    nickname: Mapped[Optional[str]] = mapped_column(String(40), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, server_default=func.now()
     )

--- a/ETF_RAG/frontend/src/app/account/page.tsx
+++ b/ETF_RAG/frontend/src/app/account/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import Link from "next/link";
+import { useAuth } from "@/lib/AuthContext";
+import { changePassword, deleteAccount, updateNickname } from "@/lib/auth";
+
+export default function AccountPage() {
+  const { user, loading, logout, refresh } = useAuth();
+  const router = useRouter();
+
+  // 비로그인 안내
+  if (!loading && !user) {
+    return (
+      <main className="mx-auto w-full max-w-sm px-4 py-10 text-center">
+        <p className="mb-4 text-sm text-gray-600">
+          계정 설정은 로그인 후 이용할 수 있어요.
+        </p>
+        <Link
+          href="/login"
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white"
+        >
+          로그인하러 가기
+        </Link>
+      </main>
+    );
+  }
+  if (loading || !user) return null;
+
+  return (
+    <main className="mx-auto w-full max-w-sm px-4 py-8">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">계정 설정</h1>
+      <p className="mb-6 text-xs text-gray-500">
+        로그인 계정: <span className="text-gray-700">{user.email}</span>
+        <br />
+        (이메일이 곧 아이디예요)
+      </p>
+
+      <NicknameSection
+        current={user.nickname}
+        onSaved={refresh}
+      />
+      <PasswordSection />
+      <DeleteSection
+        onDeleted={() => {
+          logout();
+          router.push("/");
+        }}
+      />
+    </main>
+  );
+}
+
+function Card({
+  title,
+  desc,
+  children,
+}: {
+  title: string;
+  desc?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-5 rounded-xl border border-gray-200 p-4">
+      <h2 className="text-sm font-semibold text-gray-800">{title}</h2>
+      {desc && <p className="mt-0.5 text-xs text-gray-500">{desc}</p>}
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function Notice({ msg, kind }: { msg: string; kind: "ok" | "err" }) {
+  return (
+    <p
+      className={`mt-2 text-xs ${kind === "ok" ? "text-green-600" : "text-red-600"}`}
+    >
+      {msg}
+    </p>
+  );
+}
+
+const inputCls =
+  "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none";
+const btnCls =
+  "rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50";
+
+function NicknameSection({
+  current,
+  onSaved,
+}: {
+  current: string;
+  onSaved: () => Promise<void>;
+}) {
+  const [value, setValue] = useState(current);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ k: "ok" | "err"; t: string } | null>(null);
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMsg(null);
+    setBusy(true);
+    try {
+      await updateNickname(value.trim());
+      await onSaved();
+      setMsg({ k: "ok", t: "닉네임을 변경했어요." });
+    } catch (err) {
+      setMsg({ k: "err", t: err instanceof Error ? err.message : "오류" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card title="닉네임" desc="화면에 표시되는 이름이에요. 로그인에는 영향 없어요.">
+      <form onSubmit={save} className="flex gap-2">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          maxLength={40}
+          placeholder="닉네임"
+          className={inputCls}
+        />
+        <button
+          type="submit"
+          disabled={busy || !value.trim() || value.trim() === current}
+          className={btnCls + " shrink-0"}
+        >
+          저장
+        </button>
+      </form>
+      {msg && <Notice msg={msg.t} kind={msg.k} />}
+    </Card>
+  );
+}
+
+function PasswordSection() {
+  const [cur, setCur] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ k: "ok" | "err"; t: string } | null>(null);
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMsg(null);
+    if (next.length < 8) {
+      setMsg({ k: "err", t: "새 비밀번호는 8자 이상이어야 해요." });
+      return;
+    }
+    if (next !== confirm) {
+      setMsg({ k: "err", t: "새 비밀번호 확인이 일치하지 않아요." });
+      return;
+    }
+    setBusy(true);
+    try {
+      await changePassword(cur, next);
+      setCur("");
+      setNext("");
+      setConfirm("");
+      setMsg({ k: "ok", t: "비밀번호를 변경했어요." });
+    } catch (err) {
+      setMsg({ k: "err", t: err instanceof Error ? err.message : "오류" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card title="비밀번호 변경">
+      <form onSubmit={save} className="space-y-2">
+        <input
+          type="password"
+          value={cur}
+          onChange={(e) => setCur(e.target.value)}
+          placeholder="현재 비밀번호"
+          autoComplete="current-password"
+          className={inputCls}
+        />
+        <input
+          type="password"
+          value={next}
+          onChange={(e) => setNext(e.target.value)}
+          placeholder="새 비밀번호 (8자 이상)"
+          autoComplete="new-password"
+          className={inputCls}
+        />
+        <input
+          type="password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder="새 비밀번호 확인"
+          autoComplete="new-password"
+          className={inputCls}
+        />
+        <button
+          type="submit"
+          disabled={busy || !cur || !next || !confirm}
+          className={btnCls + " w-full"}
+        >
+          비밀번호 변경
+        </button>
+      </form>
+      {msg && <Notice msg={msg.t} kind={msg.k} />}
+    </Card>
+  );
+}
+
+function DeleteSection({ onDeleted }: { onDeleted: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [pw, setPw] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const remove = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    setBusy(true);
+    try {
+      await deleteAccount(pw);
+      onDeleted();
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : "오류");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card
+      title="회원 탈퇴"
+      desc="계정과 관심종목·대화 이력·알림 설정이 모두 삭제돼요. 되돌릴 수 없어요."
+    >
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+        >
+          회원 탈퇴
+        </button>
+      ) : (
+        <form onSubmit={remove} className="space-y-2">
+          <input
+            type="password"
+            value={pw}
+            onChange={(e) => setPw(e.target.value)}
+            placeholder="확인을 위해 비밀번호 입력"
+            autoComplete="current-password"
+            className={inputCls}
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={busy || !pw}
+              className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              탈퇴하기
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setPw("");
+                setErr(null);
+              }}
+              className="rounded-lg px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+            >
+              취소
+            </button>
+          </div>
+        </form>
+      )}
+      {err && <Notice msg={err} kind="err" />}
+    </Card>
+  );
+}

--- a/ETF_RAG/frontend/src/components/NavBar.tsx
+++ b/ETF_RAG/frontend/src/components/NavBar.tsx
@@ -53,9 +53,18 @@ export default function NavBar({ onMenuClick }: { onMenuClick?: () => void } = {
         <div className="ml-auto flex shrink-0 items-center gap-2 pl-2">
           {loading ? null : user ? (
             <>
-              <span className="hidden text-xs text-gray-500 sm:inline">
-                {user.email}
-              </span>
+              <Link
+                href="/account"
+                title="계정 설정"
+                className={[
+                  "shrink-0 rounded-lg px-2 py-1.5 text-xs font-medium",
+                  pathname === "/account"
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-700 hover:bg-gray-100",
+                ].join(" ")}
+              >
+                ⚙️ {user.nickname}
+              </Link>
               <button
                 type="button"
                 onClick={logout}

--- a/ETF_RAG/frontend/src/lib/AuthContext.tsx
+++ b/ETF_RAG/frontend/src/lib/AuthContext.tsx
@@ -22,6 +22,7 @@ interface AuthState {
   login: (email: string, password: string) => Promise<void>;
   signup: (email: string, password: string) => Promise<void>;
   logout: () => void;
+  refresh: () => Promise<void>; // 닉네임 변경 등 후 user 재동기화
 }
 
 const AuthCtx = createContext<AuthState | null>(null);
@@ -62,8 +63,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   };
 
+  const refresh = async () => {
+    setUser(await fetchMe());
+  };
+
   return (
-    <AuthCtx.Provider value={{ user, loading, login, signup, logout }}>
+    <AuthCtx.Provider value={{ user, loading, login, signup, logout, refresh }}>
       {children}
     </AuthCtx.Provider>
   );

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -24,6 +24,7 @@ export function authHeader(): Record<string, string> {
 export interface AuthUser {
   id: number;
   email: string;
+  nickname: string; // 미설정 시 백엔드가 이메일 앞부분으로 채워 보냄
 }
 
 async function postAuth(
@@ -61,6 +62,46 @@ export async function fetchMe(): Promise<AuthUser | null> {
   });
   if (!res.ok) return null;
   return (await res.json()) as AuthUser;
+}
+
+// ── 계정 관리 (비번 변경 / 닉네임 / 탈퇴) ────────────────
+async function readDetail(res: Response): Promise<string> {
+  const d = await res.json().catch(() => ({}));
+  return d.detail || `요청 실패 (${res.status})`;
+}
+
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string,
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/auth/password`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({
+      current_password: currentPassword,
+      new_password: newPassword,
+    }),
+  });
+  if (!res.ok) throw new Error(await readDetail(res));
+}
+
+export async function updateNickname(nickname: string): Promise<AuthUser> {
+  const res = await fetch(`${API_BASE}/auth/profile`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ nickname }),
+  });
+  if (!res.ok) throw new Error(await readDetail(res));
+  return (await res.json()) as AuthUser;
+}
+
+export async function deleteAccount(password: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/auth/me`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ password }),
+  });
+  if (!res.ok) throw new Error(await readDetail(res));
 }
 
 // ── 유저별 저장 (로그인 시) ──────────────────────────────

--- a/ETF_RAG/tests/test_auth.py
+++ b/ETF_RAG/tests/test_auth.py
@@ -80,6 +80,8 @@ def test_signup_login_me_happy_path(client):
     body = r3.json()
     assert body["email"] == "a@b.com"
     assert isinstance(body["id"], int)
+    # 닉네임 미설정 → 이메일 local-part로 fallback
+    assert body["nickname"] == "a"
 
 
 def test_signup_duplicate_email_400(client):
@@ -117,3 +119,133 @@ def test_signup_short_password_422(client):
 def test_signup_invalid_email_422(client):
     r = client.post("/auth/signup", json={"email": "notanemail", "password": "pw123456"})
     assert r.status_code == 422
+
+
+# ── 계정 관리: 비밀번호 변경 / 닉네임 / 탈퇴 (2026-06-18) ──
+
+def _token(client, email="a@b.com", pw="pw123456"):
+    _signup(client, email=email, pw=pw)
+    r = client.post("/auth/login", json={"email": email, "password": pw})
+    return r.json()["access_token"]
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_change_password_happy(client):
+    token = _token(client)
+    r = client.put(
+        "/auth/password",
+        json={"current_password": "pw123456", "new_password": "newpw7890"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 204
+    # 기존 비번 로그인 실패, 새 비번 로그인 성공
+    assert client.post("/auth/login",
+                       json={"email": "a@b.com", "password": "pw123456"}).status_code == 401
+    assert client.post("/auth/login",
+                       json={"email": "a@b.com", "password": "newpw7890"}).status_code == 200
+
+
+def test_change_password_wrong_current_400(client):
+    token = _token(client)
+    r = client.put(
+        "/auth/password",
+        json={"current_password": "WRONGpw1", "new_password": "newpw7890"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 400
+
+
+def test_change_password_same_as_current_400(client):
+    token = _token(client)
+    r = client.put(
+        "/auth/password",
+        json={"current_password": "pw123456", "new_password": "pw123456"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 400
+
+
+def test_change_password_requires_auth_401(client):
+    r = client.put(
+        "/auth/password",
+        json={"current_password": "pw123456", "new_password": "newpw7890"},
+    )
+    assert r.status_code == 401
+
+
+def test_change_password_short_new_422(client):
+    token = _token(client)
+    r = client.put(
+        "/auth/password",
+        json={"current_password": "pw123456", "new_password": "short"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 422  # min_length=8
+
+
+def test_update_nickname_happy(client):
+    token = _token(client)
+    r = client.put("/auth/profile", json={"nickname": "투자왕"}, headers=_auth(token))
+    assert r.status_code == 200
+    assert r.json()["nickname"] == "투자왕"
+    # me에도 반영
+    assert client.get("/auth/me", headers=_auth(token)).json()["nickname"] == "투자왕"
+
+
+def test_update_nickname_strips_whitespace(client):
+    token = _token(client)
+    r = client.put("/auth/profile", json={"nickname": "  태민  "}, headers=_auth(token))
+    assert r.status_code == 200
+    assert r.json()["nickname"] == "태민"
+
+
+def test_update_nickname_blank_400(client):
+    token = _token(client)
+    r = client.put("/auth/profile", json={"nickname": "   "}, headers=_auth(token))
+    assert r.status_code == 400
+
+
+def test_update_nickname_too_long_422(client):
+    token = _token(client)
+    r = client.put("/auth/profile", json={"nickname": "가" * 41}, headers=_auth(token))
+    assert r.status_code == 422  # max_length=40
+
+
+def test_delete_account_happy(client):
+    token = _token(client)
+    r = client.request(
+        "DELETE", "/auth/me", json={"password": "pw123456"}, headers=_auth(token)
+    )
+    assert r.status_code == 204
+    # 토큰 무효(유저 없음) + 같은 이메일 재가입 가능
+    assert client.get("/auth/me", headers=_auth(token)).status_code == 401
+    assert _signup(client).status_code == 201
+
+
+def test_delete_account_wrong_password_400(client):
+    token = _token(client)
+    r = client.request(
+        "DELETE", "/auth/me", json={"password": "WRONGpw1"}, headers=_auth(token)
+    )
+    assert r.status_code == 400
+    # 여전히 살아있음
+    assert client.get("/auth/me", headers=_auth(token)).status_code == 200
+
+
+def test_delete_account_purges_watchlist(client):
+    token = _token(client)
+    client.put("/me/watchlist/005930", headers=_auth(token))
+    assert "005930" in client.get("/me/watchlist", headers=_auth(token)).json()["tickers"]
+    # 탈퇴
+    client.request("DELETE", "/auth/me", json={"password": "pw123456"}, headers=_auth(token))
+    # 같은 이메일 재가입 → 관심종목이 비어 있어야(이전 유저 데이터 소거 확인)
+    token2 = _token(client)
+    assert client.get("/me/watchlist", headers=_auth(token2)).json()["tickers"] == []
+
+
+def test_delete_account_requires_auth_401(client):
+    r = client.request("DELETE", "/auth/me", json={"password": "pw123456"})
+    assert r.status_code == 401


### PR DESCRIPTION
## 배경
회원가입 후 계정 관리 기능이 없었음(가입/로그인/me만). 사용자 요청으로 비밀번호 변경·회원 탈퇴·표시용 닉네임 추가.

전제: **유저 DB 영구화 완료** — Railway에 PostgreSQL 플러그인 추가 + `DATABASE_URL=${{Postgres.DATABASE_URL}}` 연결(코드는 이미 지원). 그 전엔 재배포마다 회원 데이터가 소실됐음.

## 변경
### 백엔드
- `models_db.User`에 `nickname`(VARCHAR40, nullable) 추가
- `db.init_models`에 `_migrate_add_columns()` — `create_all`이 못 하는 기존 테이블 컬럼 추가를 inspector 기반 멱등 마이그레이션으로 보완 (Alembic 미도입 환경용)
- `auth.py`:
  - `PUT /auth/password` — 현재 비번 검증 + 기존과 동일 거부 → 204
  - `PUT /auth/profile` — 닉네임 strip + 공백 거부 → UserResponse
  - `DELETE /auth/me` — 비번 재확인 후 Watchlist/ChatHistory/PushSubscription 명시 삭제 + 계정 삭제 (FK cascade 미설정이라 자식 먼저)
  - `/auth/me`·`UserResponse`에 `nickname` (미설정 시 이메일 local-part fallback)
- 테스트 **13개 추가** (test_auth 8→21, 전체 통과)

### 프론트
- `lib/auth.ts`: `AuthUser.nickname` + `changePassword`/`updateNickname`/`deleteAccount`
- `AuthContext.refresh()` (닉네임 변경 후 user 재동기화)
- **`/account` 페이지 신설** (닉네임/비번변경/탈퇴 3섹션, 비로그인 시 로그인 안내)
- NavBar 우측: 이메일 → **⚙️ {nickname}** 클릭 시 `/account`

## 범위 밖 (의도)
- **ID 찾기**: 이메일=ID라 "이메일이 곧 아이디" 안내로 대체
- **비밀번호 찾기**(이메일 재설정 링크): 메일 발송 인프라(Resend 등)+도메인 필요 → 후속. 보안질문 방식은 보안 저하라 안 함.

## 테스트
- 백엔드 `tests/test_auth.py` 21개 통과 (로컬 fastapi/bcrypt/PyJWT 설치 후 검증)
- 프론트 `tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)