### PR TITLE
refactor(ui): '티커' → '종목코드' 용어 교체

### DIFF
--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -60,7 +60,7 @@ export default function FinancialPage() {
       <h1 className="mb-1 text-lg font-bold text-gray-900">📑 재무제표</h1>
       <p className="mb-4 text-xs text-gray-500">분기별 매출·영업이익·순이익·마진</p>
 
-      <TickerSearch onSelect={onSelect} placeholder="종목명 또는 티커 (주식만)" />
+      <TickerSearch onSelect={onSelect} placeholder="종목명 또는 종목코드 (주식만)" />
 
       {/* 조회 기간 선택 */}
       <div className="mt-3 flex flex-wrap gap-1.5">

--- a/ETF_RAG/frontend/src/components/TickerSearch.tsx
+++ b/ETF_RAG/frontend/src/components/TickerSearch.tsx
@@ -12,7 +12,7 @@ function parseOption(opt: string): { name: string; ticker: string } {
 
 export default function TickerSearch({
   onSelect,
-  placeholder = "종목명 또는 티커 검색…",
+  placeholder = "종목명 또는 종목코드 검색…",
 }: {
   onSelect: (sel: { name: string; ticker: string; raw: string }) => void;
   placeholder?: string;

--- a/ETF_RAG/src/ui/tabs.py
+++ b/ETF_RAG/src/ui/tabs.py
@@ -95,7 +95,7 @@ def _resolve_ticker(name_or_ticker: str) -> Optional[dict]:
     return None
 
 
-def _ticker_input(label: str, key: str, placeholder: str = "종목명 또는 티커 입력") -> str:
+def _ticker_input(label: str, key: str, placeholder: str = "종목명 또는 종목코드 입력") -> str:
     """종목 입력 위젯 — text_input + selectbox 자동완성."""
     # 다른 탭에서 종목명을 넘겨받은 경우 prefill
     prefill = st.session_state.pop("_prefill_ticker", None)
@@ -169,7 +169,7 @@ def _ticker_input(label: str, key: str, placeholder: str = "종목명 또는 티
 def render_technical_tab():
     """기술적 분석 탭: 종목 입력 → 11개 지표 + 차트"""
     st.markdown("##### 📊 기술적 분석")
-    st.caption("종목명 또는 티커를 입력하면 11개 기술적 지표와 차트를 바로 확인합니다.")
+    st.caption("종목명 또는 종목코드를 입력하면 11개 기술적 지표와 차트를 바로 확인합니다.")
 
     col1, col2, col3 = st.columns([3, 1.5, 1])
     with col1:


### PR DESCRIPTION
## 배경
'티커(ticker)'가 일반 사용자에게 낯선 전문 용어라 '종목코드'로 변경.

## 변경 (화면에 보이는 문구만)
- 프론트: `TickerSearch` 기본 placeholder, 재무제표 탭 placeholder
- Streamlit: `_ticker_input` placeholder, 기술분석 탭 caption

컴포넌트명(`TickerSearch`)·변수명(`ticker`) 등 코드 식별자는 그대로 유지.

## 테스트
- 프론트 `tsc --noEmit` 통과 / Streamlit `py_compile` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)