### PR TITLE
feat(financial): 재무제표 탭 — 주식만 검색 + 10년 + 직접설정

### DIFF
--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -255,8 +255,9 @@ async def sector(sector: Optional[str] = Query(None)):
 async def tickers(
     q: Optional[str] = Query(None),
     limit: int = Query(30, ge=1, le=200),
+    asset_type: Optional[str] = Query(None, pattern="^(stock|etf)$"),
 ):
-    options = await run_in_threadpool(get_available_tickers)
+    options = await run_in_threadpool(get_available_tickers, asset_type)
     if q:
         ql = q.lower()
         options = [o for o in options if ql in o.lower()]

--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -16,13 +16,15 @@ function pct(v: number | null | undefined): string {
   return typeof v === "number" ? `${v.toFixed(1)}%` : "-";
 }
 
-// 조회 기간 옵션 (분기 수 ↔ 라벨)
+// 조회 기간 옵션 (분기 수 ↔ 라벨). 1년=4분기.
 const RANGES = [
   { quarters: 4, label: "1년" },
   { quarters: 8, label: "2년" },
   { quarters: 12, label: "3년" },
   { quarters: 20, label: "5년" },
+  { quarters: 40, label: "10년" },
 ];
+const MAX_YEARS = 12; // 데이터 보존 한계(2015~)에 맞춘 상한
 
 export default function FinancialPage() {
   const [data, setData] = useState<FinancialResponse | null>(null);
@@ -30,6 +32,7 @@ export default function FinancialPage() {
   const [error, setError] = useState<string | null>(null);
   const [ticker, setTicker] = useState<string | null>(null);
   const [quarters, setQuarters] = useState(12);
+  const [customYears, setCustomYears] = useState(""); // 직접설정(년) 입력값
 
   const fetchFin = async (tk: string, q: number) => {
     setLoading(true);
@@ -52,6 +55,18 @@ export default function FinancialPage() {
 
   const onRange = (q: number) => {
     setQuarters(q);
+    setCustomYears("");
+    if (ticker) fetchFin(ticker, q);
+  };
+
+  // 직접설정: 연 수 입력 → 분기(년×4)로 환산. 1~MAX_YEARS로 clamp.
+  const applyCustom = () => {
+    const years = Math.round(Number(customYears));
+    if (!years || years < 1) return;
+    const clamped = Math.min(years, MAX_YEARS);
+    if (clamped !== years) setCustomYears(String(clamped));
+    const q = clamped * 4;
+    setQuarters(q);
     if (ticker) fetchFin(ticker, q);
   };
 
@@ -60,23 +75,53 @@ export default function FinancialPage() {
       <h1 className="mb-1 text-lg font-bold text-gray-900">📑 재무제표</h1>
       <p className="mb-4 text-xs text-gray-500">분기별 매출·영업이익·순이익·마진</p>
 
-      <TickerSearch onSelect={onSelect} placeholder="종목명 또는 종목코드 (주식만)" />
+      <TickerSearch
+        onSelect={onSelect}
+        assetType="stock"
+        placeholder="종목명 또는 종목코드 (주식만)"
+      />
 
       {/* 조회 기간 선택 */}
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        {RANGES.map((r) => (
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        {RANGES.map((r) => {
+          const active = quarters === r.quarters && customYears === "";
+          return (
+            <button
+              key={r.quarters}
+              onClick={() => onRange(r.quarters)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+                active
+                  ? "bg-gray-900 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
+            >
+              {r.label}
+            </button>
+          );
+        })}
+        {/* 직접 설정 (년) */}
+        <span className="ml-1 flex items-center gap-1">
+          <input
+            type="number"
+            min={1}
+            max={MAX_YEARS}
+            value={customYears}
+            onChange={(e) => setCustomYears(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") applyCustom();
+            }}
+            placeholder="직접"
+            className="w-16 rounded-full border border-gray-300 px-2.5 py-1 text-xs focus:border-blue-500 focus:outline-none"
+          />
+          <span className="text-xs text-gray-500">년</span>
           <button
-            key={r.quarters}
-            onClick={() => onRange(r.quarters)}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition ${
-              quarters === r.quarters
-                ? "bg-gray-900 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
+            onClick={applyCustom}
+            disabled={!customYears}
+            className="rounded-full bg-blue-600 px-2.5 py-1 text-xs font-medium text-white disabled:opacity-40"
           >
-            {r.label}
+            적용
           </button>
-        ))}
+        </span>
       </div>
 
       {loading && <p className="mt-6 text-center text-sm text-gray-400">조회 중…</p>}

--- a/ETF_RAG/frontend/src/components/TickerSearch.tsx
+++ b/ETF_RAG/frontend/src/components/TickerSearch.tsx
@@ -13,9 +13,11 @@ function parseOption(opt: string): { name: string; ticker: string } {
 export default function TickerSearch({
   onSelect,
   placeholder = "종목명 또는 종목코드 검색…",
+  assetType,
 }: {
   onSelect: (sel: { name: string; ticker: string; raw: string }) => void;
   placeholder?: string;
+  assetType?: "stock" | "etf"; // 지정 시 해당 자산만 자동완성 (재무제표=주식)
 }) {
   const [query, setQuery] = useState("");
   const [options, setOptions] = useState<string[]>([]);
@@ -30,12 +32,12 @@ export default function TickerSearch({
       return;
     }
     const timer = setTimeout(async () => {
-      const opts = await searchTickers(q, 20);
+      const opts = await searchTickers(q, 20, assetType);
       setOptions(opts);
       setOpen(true);
     }, 250);
     return () => clearTimeout(timer);
-  }, [query]);
+  }, [query, assetType]);
 
   // 바깥 클릭 시 닫기
   useEffect(() => {

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -119,14 +119,17 @@ export function streamChat(
 
 // ── 탭 API ──────────────────────────────────────────────
 
-/** 종목 자동완성 ("이름 (티커)" 옵션 리스트) */
+/** 종목 자동완성 ("이름 (종목코드)" 옵션 리스트).
+ * assetType="stock"이면 주식만, "etf"면 ETF만 (재무제표 탭처럼 주식 전용 화면용). */
 export async function searchTickers(
   q: string,
   limit = 20,
+  assetType?: "stock" | "etf",
 ): Promise<string[]> {
   const url = new URL(`${API_BASE}/tabs/tickers`);
   if (q) url.searchParams.set("q", q);
   url.searchParams.set("limit", String(limit));
+  if (assetType) url.searchParams.set("asset_type", assetType);
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) return [];
   const body = (await res.json()) as TickerSearchResponse;

--- a/ETF_RAG/src/llm/tools/_state.py
+++ b/ETF_RAG/src/llm/tools/_state.py
@@ -6,6 +6,7 @@ app.py에서 set_retriever()로 초기화한 뒤,
 """
 
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -114,11 +115,21 @@ def set_retriever(retriever, documents=None, stock_retriever=None,
         _data_initialized = True
 
 
-def get_available_tickers() -> list[str]:
-    """자동완성용 종목 옵션 리스트 반환 — 'name (ticker)' 형식, 정렬됨"""
+def get_available_tickers(asset_type: Optional[str] = None) -> list[str]:
+    """자동완성용 종목 옵션 리스트 반환 — 'name (ticker)' 형식, 정렬됨.
+
+    asset_type: "stock"이면 주식만, "etf"면 ETF만, None이면 전체.
+    (재무제표 탭처럼 주식만 의미 있는 화면에서 ETF를 자동완성에서 빼기 위함)
+    """
+    if asset_type == "stock":
+        indices = (_stock_data_index,)
+    elif asset_type == "etf":
+        indices = (_etf_data_index,)
+    else:
+        indices = (_etf_data_index, _stock_data_index)
     seen = set()
     options = []
-    for index in (_etf_data_index, _stock_data_index):
+    for index in indices:
         for _key, data in index.items():
             ticker = data.get("ticker", "")
             name = data.get("name", "")

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -204,6 +204,20 @@ def test_tickers_filters_and_caps(client):
     assert all("삼성" in o for o in body["options"])
 
 
+def test_tickers_asset_type_passed_through(client):
+    """asset_type 쿼리가 get_available_tickers에 그대로 전달돼야 한다(재무제표=주식)."""
+    with patch("api.tabs.get_available_tickers", return_value=["삼성전자 (005930)"]) as m:
+        r = client.get("/tabs/tickers", params={"asset_type": "stock"})
+    assert r.status_code == 200
+    # run_in_threadpool(get_available_tickers, asset_type) → 첫 위치인자로 전달
+    assert m.call_args.args[0] == "stock"
+
+
+def test_tickers_asset_type_invalid_422(client):
+    r = client.get("/tabs/tickers", params={"asset_type": "bond"})
+    assert r.status_code == 422  # pattern ^(stock|etf)$
+
+
 def test_tickers_resolve_404(client):
     with patch("api.tabs._find_structured_data", return_value=None):
         r = client.get("/tabs/tickers/resolve", params={"q": "ZZZ"})


### PR DESCRIPTION
## 변경 (사용자 요청 #2)
재무제표는 상장 주식만 제공되는데 자동완성에 ETF도 떠서 혼란 → 개선.

- **주식만 검색**: `get_available_tickers(asset_type)` 추가(stock/etf/전체). `/tabs/tickers`에 `asset_type` 쿼리(pattern `^(stock|etf)$`). 프론트 `searchTickers(q, limit, assetType)` + `TickerSearch` `assetType` prop. 재무제표 탭은 `assetType="stock"`.
- **10년 추가**: 기간 버튼에 10년(40분기).
- **직접설정**: 년 입력 → 분기 환산(년×4), 1~12년 clamp(데이터 보존 한계).

## 테스트
- `test_api_tabs.py` 2개 추가 (asset_type 전달 / 잘못된 값 422) — 31개 통과
- 프론트 `tsc` 통과, `get_available_tickers` 필터 단위 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)