### PR TITLE
fix(db): 주가 DB 무결성 검사 — malformed 자동 복구

### DIFF
--- a/ETF_RAG/src/data/db_downloader.py
+++ b/ETF_RAG/src/data/db_downloader.py
@@ -18,18 +18,50 @@ DB_RELEASE_URL = (
 DOWNLOAD_TIMEOUT = 300  # 5분
 
 
+def _is_valid_sqlite(db_path: Path) -> bool:
+    """SQLite 파일이 열리고 손상되지 않았는지 빠르게 검증.
+
+    PRAGMA quick_check는 integrity_check보다 빠르며(인덱스 무결성 생략) 대용량에서
+    충분. 다운로드/압축해제가 중간에 끊긴 'malformed' 파일을 잡아낸다.
+    """
+    import sqlite3
+
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = con.execute("PRAGMA quick_check").fetchone()
+            ok = bool(row) and row[0] == "ok"
+            if ok:
+                # 핵심 테이블 존재 + 최소 행 확인 (빈 껍데기 파일 방어)
+                cnt = con.execute("SELECT COUNT(*) FROM daily_prices").fetchone()[0]
+                ok = cnt > 0
+            return ok
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001 — 손상 파일은 어떤 예외든 무효 처리
+        logger.warning(f"SQLite 무결성 검사 실패(손상으로 간주): {e}")
+        return False
+
+
 def ensure_db(db_path: Path) -> bool:
-    """DB가 없으면 GitHub Release에서 다운로드. 성공 시 True, 실패/스킵 시 False."""
+    """DB가 없으면 GitHub Release에서 다운로드. 성공 시 True, 실패/스킵 시 False.
+
+    이미 존재하더라도 무결성을 검사해 손상 파일(malformed)이면 지우고 재다운로드한다
+    — 과거 다운로드/해제 중단으로 깨진 파일이 남아 매 부팅 재사용되던 문제 방지.
+    """
     if db_path.exists():
-        size_mb = db_path.stat().st_size / (1024 * 1024)
-        logger.info(f"DB 이미 존재: {db_path} ({size_mb:.0f}MB)")
-        return True
+        if _is_valid_sqlite(db_path):
+            size_mb = db_path.stat().st_size / (1024 * 1024)
+            logger.info(f"DB 이미 존재(무결성 OK): {db_path} ({size_mb:.0f}MB)")
+            return True
+        logger.warning("기존 DB 손상 감지 — 삭제 후 재다운로드")
+        db_path.unlink(missing_ok=True)
 
     logger.info("DB 없음 — GitHub Release에서 다운로드 시작")
     zst_path = db_path.parent / "etf_rag.db.zst"
 
     try:
-        # 1. 다운로드
+        # 1. 다운로드 (크기 검증 포함)
         _download(DB_RELEASE_URL, zst_path)
 
         # 2. zstd 해제
@@ -38,13 +70,17 @@ def ensure_db(db_path: Path) -> bool:
         # 3. 압축 파일 정리
         zst_path.unlink(missing_ok=True)
 
+        # 4. 해제된 DB 무결성 검사 — 깨졌으면 실패로 처리(다음 부팅 재시도)
+        if not _is_valid_sqlite(db_path):
+            raise RuntimeError("다운로드한 DB 무결성 검사 실패 (malformed)")
+
         size_mb = db_path.stat().st_size / (1024 * 1024)
-        logger.info(f"DB 다운로드 완료: {size_mb:.0f}MB")
+        logger.info(f"DB 다운로드 완료(무결성 OK): {size_mb:.0f}MB")
         return True
 
     except Exception as e:
         logger.warning(f"DB 다운로드 실패 (deploy/ JSON fallback 사용): {e}")
-        # 불완전 파일 정리
+        # 불완전/손상 파일 정리 — 다음 부팅이 깨끗하게 재시도하도록
         zst_path.unlink(missing_ok=True)
         db_path.unlink(missing_ok=True)
         return False
@@ -74,6 +110,12 @@ def _download(url: str, dest: Path) -> None:
                 if downloaded % (50 * 1024 * 1024) < chunk_size:
                     logger.info(f"다운로드 진행: {downloaded / (1024*1024):.0f}/{total_mb:.0f}MB")
 
+    # 다운로드 크기 검증 — Content-Length와 다르면 중간에 끊긴 것
+    if total and downloaded != total:
+        raise IOError(
+            f"다운로드 불완전: {downloaded}/{total} bytes "
+            f"(연결 중단 추정)"
+        )
     logger.info(f"다운로드 완료: {downloaded / (1024*1024):.0f}MB")
 
 

--- a/ETF_RAG/tests/test_db_downloader.py
+++ b/ETF_RAG/tests/test_db_downloader.py
@@ -1,0 +1,101 @@
+"""db_downloader 무결성 검사 테스트 (2026-06-19).
+
+Railway에서 'database disk image is malformed'로 주가 DB 로드가 실패하던 문제 →
+ensure_db가 파일 존재만 보고 손상 파일을 재사용하던 것이 원인. 무결성 검사 추가분 검증.
+실제 네트워크 다운로드는 mock(여기선 무결성 로직만 검증).
+"""
+
+import sqlite3
+from pathlib import Path
+
+from src.data.db_downloader import _is_valid_sqlite, ensure_db
+
+
+def _make_valid_db(path: Path) -> None:
+    """daily_prices 테이블 + 1행을 가진 최소 정상 SQLite 생성."""
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE daily_prices (ticker TEXT, date TEXT, close INTEGER)")
+    con.execute("INSERT INTO daily_prices VALUES ('005930', '20260618', 70000)")
+    con.commit()
+    con.close()
+
+
+def test_valid_sqlite_passes(tmp_path):
+    db = tmp_path / "ok.db"
+    _make_valid_db(db)
+    assert _is_valid_sqlite(db) is True
+
+
+def test_corrupt_file_fails(tmp_path):
+    db = tmp_path / "bad.db"
+    db.write_bytes(b"SQLite format 3\x00" + b"\xde\xad\xbe\xef" * 500)
+    assert _is_valid_sqlite(db) is False
+
+
+def test_empty_file_fails(tmp_path):
+    db = tmp_path / "empty.db"
+    db.write_bytes(b"")
+    assert _is_valid_sqlite(db) is False
+
+
+def test_missing_file_fails(tmp_path):
+    assert _is_valid_sqlite(tmp_path / "nope.db") is False
+
+
+def test_valid_sqlite_without_daily_prices_fails(tmp_path):
+    """SQLite로는 멀쩡하나 핵심 테이블이 없으면(빈 껍데기) 무효."""
+    db = tmp_path / "shell.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE other (x INTEGER)")
+    con.commit()
+    con.close()
+    assert _is_valid_sqlite(db) is False
+
+
+def test_ensure_db_skips_when_valid_exists(tmp_path, monkeypatch):
+    """이미 정상 DB가 있으면 다운로드 없이 True."""
+    db = tmp_path / "etf_rag.db"
+    _make_valid_db(db)
+
+    called = {"download": False}
+
+    def _fake_download(url, dest):
+        called["download"] = True
+
+    monkeypatch.setattr("src.data.db_downloader._download", _fake_download)
+    assert ensure_db(db) is True
+    assert called["download"] is False  # 재다운로드 안 함
+
+
+def test_ensure_db_redownloads_when_corrupt(tmp_path, monkeypatch):
+    """기존 파일이 손상이면 삭제 후 재다운로드 경로를 탄다."""
+    db = tmp_path / "etf_rag.db"
+    db.write_bytes(b"SQLite format 3\x00garbage")  # 손상
+
+    attempted = {"download": False}
+
+    def _fake_download(url, dest):
+        attempted["download"] = True
+        raise IOError("network down")  # 다운로드 자체는 실패시킴(무결성 분기만 확인)
+
+    monkeypatch.setattr("src.data.db_downloader._download", _fake_download)
+    result = ensure_db(db)
+    assert attempted["download"] is True  # 손상 감지 → 재다운로드 시도함
+    assert result is False  # 다운로드 실패 → JSON fallback
+    assert not db.exists()  # 손상 파일 정리됨
+
+
+def test_ensure_db_fails_if_downloaded_db_corrupt(tmp_path, monkeypatch):
+    """다운로드/해제는 됐지만 결과가 손상이면 False + 파일 정리."""
+    db = tmp_path / "etf_rag.db"
+
+    def _fake_download(url, dest):
+        Path(dest).write_bytes(b"compressed")  # 더미 zst
+
+    def _fake_decompress(src, dest):
+        Path(dest).write_bytes(b"SQLite format 3\x00broken")  # 손상된 결과물
+
+    monkeypatch.setattr("src.data.db_downloader._download", _fake_download)
+    monkeypatch.setattr("src.data.db_downloader._decompress_zstd", _fake_decompress)
+    assert ensure_db(db) is False
+    assert not db.exists()


### PR DESCRIPTION
## 배경
Railway 백엔드 로그에 `주식 DB 로드 실패: database disk image is malformed` → 주가 SQLite(1.8GB)가 깨져 JSON fallback으로 동작 중(차트/과거시세 제한).

## 원인 (조사 완료)
- **GitHub Release 파일 자체는 정상**: 로컬에서 받아 압축해제 → `PRAGMA integrity_check: ok`, 8,847,510행, 최신 20260618 확인.
- **진짜 원인**: `ensure_db`가 `db_path.exists()`만 보고 무결성 검사를 안 함 → 다운로드/해제가 중간에 끊겨 생긴 손상 파일을 매 부팅 재사용. (`Killed`=OOM 로그도 동반)

## 수정
- `_is_valid_sqlite()`: `PRAGMA quick_check` + `daily_prices` 행수 확인(빈 껍데기 방어)
- `ensure_db`: **기존 파일도 무결성 검사** → 손상이면 삭제 후 재다운로드. 다운로드/해제 결과도 재검사, 깨지면 정리 후 False(다음 부팅 재시도)
- `_download`: Content-Length vs 수신 바이트 검증(연결 중단 즉시 감지)
- 테스트 8개 추가 (정상/손상/빈/없음/껍데기 + ensure_db 스킵·재다운로드·해제실패 경로)

## 배포 후
사용자가 Railway 백엔드 재배포 → 손상 파일 감지·재다운로드 → 무결성 OK 시 주가 DB 정상 동작 복구 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)