### PR TITLE
feat(paper): 가상투자 수익률 추이 차트 (일별 스냅샷)

### DIFF
--- a/.github/workflows/daily-collect.yml
+++ b/.github/workflows/daily-collect.yml
@@ -180,6 +180,23 @@ jobs:
             -H "X-Cron-Token: $CRON_TOKEN" \
             --max-time 120 || echo "알림 트리거 실패(무시)"
 
+      # ── 가상투자 일별 평가액 스냅샷 트리거 (Railway 백엔드 호출) ──
+      # 거래 안 한 날도 시세 변동을 수익률 추이에 반영. 미설정 시 자동 skip(무해).
+      - name: Trigger paper-trading daily snapshot
+        continue-on-error: true
+        env:
+          PAPER_SNAPSHOT_URL: ${{ secrets.PAPER_SNAPSHOT_URL }}
+          CRON_TOKEN: ${{ secrets.CRON_TOKEN }}
+        run: |
+          if [ -z "$PAPER_SNAPSHOT_URL" ] || [ -z "$CRON_TOKEN" ]; then
+            echo "PAPER_SNAPSHOT_URL/CRON_TOKEN 미설정 — 스냅샷 트리거 skip"
+            exit 0
+          fi
+          echo "가상투자 스냅샷 트리거: $PAPER_SNAPSHOT_URL"
+          curl -fsS -X POST "$PAPER_SNAPSHOT_URL" \
+            -H "X-Cron-Token: $CRON_TOKEN" \
+            --max-time 120 || echo "스냅샷 트리거 실패(무시)"
+
   # ── 실패 시 GitHub Issue 자동 생성 ──────────────────────
   notify-failure:
     runs-on: ubuntu-latest

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -151,6 +151,23 @@ class RankingResponse(BaseModel):
     total_players: int
 
 
+class PaperHistoryPoint(BaseModel):
+    date: str          # YYYYMMDD
+    total_value: int
+    pnl_pct: float     # 초기자본 대비 수익률 %
+
+
+class PaperHistoryResponse(BaseModel):
+    points: List[PaperHistoryPoint]
+    chart_b64: Optional[str] = None  # 수익률 추이 라인 차트
+
+
+class SnapshotAllResponse(BaseModel):
+    ok: bool
+    users_snapshotted: int
+    date: str
+
+
 # ── 유저별 저장 (관심종목 / 대화이력) ──────────────────────
 class WatchlistResponse(BaseModel):
     tickers: List[str]

--- a/ETF_RAG/api/paper.py
+++ b/ETF_RAG/api/paper.py
@@ -8,8 +8,7 @@
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.concurrency import run_in_threadpool
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -17,18 +16,23 @@ from api.auth import get_current_user, _display_nickname
 from api.db import get_db
 from api.models import (
     HoldingItem,
+    PaperHistoryPoint,
+    PaperHistoryResponse,
     PortfolioResponse,
     RankingItem,
     RankingResponse,
+    SnapshotAllResponse,
     TradeHistoryItem,
     TradeHistoryResponse,
     TradeRequest,
     TradeResult,
 )
+from src.data.chart_generator import generate_paper_trend_chart
 from api.models_db import (
     INITIAL_CASH,
     PaperAccount,
     PaperHolding,
+    PaperSnapshot,
     PaperTrade,
     User,
 )
@@ -98,8 +102,51 @@ def _build_portfolio(db: Session, user_id: int) -> PortfolioResponse:
     )
 
 
-def _today() -> str:
-    return datetime.now(timezone.utc).strftime("%Y%m%d")
+def _today_kst() -> str:
+    """KST 기준 YYYYMMDD (수집/거래일 기준 통일)."""
+    from datetime import timedelta
+    return (datetime.now(timezone.utc) + timedelta(hours=9)).strftime("%Y%m%d")
+
+
+def _user_total_value(db: Session, user_id: int, price_fn) -> int:
+    """유저의 현재 총자산(현금+보유 평가액). price_fn(ticker)->float|None로 현재가 조회."""
+    acc = _get_or_create_account(db, user_id)
+    value = acc.cash
+    for h in _holdings(db, user_id):
+        cur = price_fn(h.ticker)
+        if cur:
+            value += int(round(cur * h.qty))
+    return value
+
+
+def _record_snapshot(db: Session, user_id: int, total_value: int) -> None:
+    """오늘(KST) 스냅샷 upsert — 같은 날 여러 번이면 최신값으로 갱신. commit 안 함."""
+    today = _today_kst()
+    snap = db.scalar(select(PaperSnapshot).where(
+        PaperSnapshot.user_id == user_id, PaperSnapshot.date == today))
+    if snap is None:
+        db.add(PaperSnapshot(user_id=user_id, date=today, total_value=total_value))
+    else:
+        snap.total_value = total_value
+
+
+def _price_simple(ticker: str):
+    """현재가만 (실패 시 None) — 스냅샷/랭킹용 경량 조회."""
+    try:
+        return float(_resolve_price(ticker)["price"])
+    except HTTPException:
+        return None
+
+
+def _snapshot_after_trade(db: Session, user_id: int) -> None:
+    """거래 직후 당일 스냅샷 갱신 — 실패해도 거래 자체는 영향 없게 예외 삼킴."""
+    try:
+        value = _user_total_value(db, user_id, _price_simple)
+        _record_snapshot(db, user_id, value)
+        db.commit()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"거래 후 스냅샷 기록 실패(무시): {e}")
+        db.rollback()
 
 
 # ── 엔드포인트 ──────────────────────────────────────────
@@ -142,6 +189,7 @@ def buy(
     db.add(PaperTrade(user_id=user.id, ticker=ticker, name=name,
                       side="buy", qty=req.qty, price=price, amount=amount))
     db.commit()
+    _snapshot_after_trade(db, user.id)  # 당일 평가액 스냅샷 갱신
     return TradeResult(
         ok=True, side="buy", ticker=ticker, name=name, qty=req.qty,
         price=price, amount=amount, cash=acc.cash,
@@ -176,6 +224,7 @@ def sell(
                       side="sell", qty=req.qty, price=price, amount=amount,
                       realized_pnl=realized))
     db.commit()
+    _snapshot_after_trade(db, user.id)  # 당일 평가액 스냅샷 갱신
     return TradeResult(
         ok=True, side="sell", ticker=ticker, name=name, qty=req.qty,
         price=price, amount=amount, cash=acc.cash, realized_pnl=realized,
@@ -205,12 +254,15 @@ def trades(
 def reset(
     user: User = Depends(get_current_user), db: Session = Depends(get_db)
 ) -> PortfolioResponse:
-    """계좌 초기화 — 보유/내역 삭제 + 현금 1억으로 복구."""
+    """계좌 초기화 — 보유/내역/스냅샷 삭제 + 현금 1억으로 복구."""
     from sqlalchemy import delete
     db.execute(delete(PaperHolding).where(PaperHolding.user_id == user.id))
     db.execute(delete(PaperTrade).where(PaperTrade.user_id == user.id))
+    db.execute(delete(PaperSnapshot).where(PaperSnapshot.user_id == user.id))
     acc = _get_or_create_account(db, user.id)
     acc.cash = INITIAL_CASH
+    db.commit()
+    _record_snapshot(db, user.id, INITIAL_CASH)  # 초기화 시점 스냅샷(1억)
     db.commit()
     return _build_portfolio(db, user.id)
 
@@ -261,4 +313,59 @@ def ranking(
             ))
     return RankingResponse(
         rankings=items, my_rank=my_rank, total_players=len(rows),
+    )
+
+
+@router.get("/history", response_model=PaperHistoryResponse)
+def history(
+    user: User = Depends(get_current_user), db: Session = Depends(get_db)
+) -> PaperHistoryResponse:
+    """일별 평가액 스냅샷 → 수익률 추이. 스냅샷 2개 미만이면 차트 없음."""
+    snaps = list(db.scalars(
+        select(PaperSnapshot).where(PaperSnapshot.user_id == user.id)
+        .order_by(PaperSnapshot.date)
+    ))
+    points = [
+        PaperHistoryPoint(
+            date=s.date, total_value=s.total_value,
+            pnl_pct=round((s.total_value - INITIAL_CASH) / INITIAL_CASH * 100.0, 2),
+        ) for s in snaps
+    ]
+    chart = None
+    if len(points) >= 2:
+        chart = generate_paper_trend_chart(
+            [p.date for p in points], [p.pnl_pct for p in points],
+        )
+    return PaperHistoryResponse(points=points, chart_b64=chart)
+
+
+@router.post("/snapshot-all", response_model=SnapshotAllResponse)
+def snapshot_all(
+    x_cron_token: str = Header(None, alias="X-Cron-Token"),
+    db: Session = Depends(get_db),
+) -> SnapshotAllResponse:
+    """전 유저 당일 평가액 스냅샷 기록 (GitHub Actions 수집 후 호출). X-Cron-Token 보호.
+
+    거래 안 한 날도 시세 변동을 추이에 반영하기 위함. 종목별 현재가는 1회만 조회(캐시).
+    """
+    from config import CRON_TOKEN
+    if not CRON_TOKEN:
+        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
+    if x_cron_token != CRON_TOKEN:
+        raise HTTPException(403, "잘못된 토큰")
+
+    price_cache: dict = {}
+
+    def _cached(tk: str):
+        if tk not in price_cache:
+            price_cache[tk] = _price_simple(tk)
+        return price_cache[tk]
+
+    accounts = list(db.scalars(select(PaperAccount)))
+    for acc in accounts:
+        value = _user_total_value(db, acc.user_id, _cached)
+        _record_snapshot(db, acc.user_id, value)
+    db.commit()
+    return SnapshotAllResponse(
+        ok=True, users_snapshotted=len(accounts), date=_today_kst(),
     )

--- a/ETF_RAG/frontend/src/app/invest/page.tsx
+++ b/ETF_RAG/frontend/src/app/invest/page.tsx
@@ -7,6 +7,7 @@ import {
   getPortfolio,
   getTradeHistory,
   getRanking,
+  getPaperHistory,
   buyStock,
   sellStock,
   resetPaper,
@@ -15,8 +16,10 @@ import type {
   PaperPortfolio,
   PaperTradeHistoryItem,
   PaperRanking,
+  PaperHistory,
 } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
+import ChartImage from "@/components/ChartImage";
 
 const won = (v: number) => `${Math.round(v).toLocaleString("ko-KR")}원`;
 function signColor(v: number): string {
@@ -31,6 +34,7 @@ export default function InvestPage() {
   const [pf, setPf] = useState<PaperPortfolio | null>(null);
   const [trades, setTrades] = useState<PaperTradeHistoryItem[]>([]);
   const [ranking, setRanking] = useState<PaperRanking | null>(null);
+  const [hist, setHist] = useState<PaperHistory | null>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ k: "ok" | "err"; t: string } | null>(null);
 
@@ -40,14 +44,16 @@ export default function InvestPage() {
   const [qty, setQty] = useState("");
 
   const refresh = useCallback(async () => {
-    const [p, t, r] = await Promise.all([
+    const [p, t, r, hh] = await Promise.all([
       getPortfolio(),
       getTradeHistory(),
       getRanking(),
+      getPaperHistory(),
     ]);
     setPf(p);
     setTrades(t);
     setRanking(r);
+    setHist(hh);
   }, []);
 
   useEffect(() => {
@@ -133,6 +139,13 @@ export default function InvestPage() {
             color={signColor(pf.total_pnl)}
           />
           <Stat label="현금" value={won(pf.cash)} />
+        </div>
+      )}
+
+      {/* 수익률 추이 차트 (스냅샷 2일+ 누적 시) */}
+      {hist?.chart_b64 && (
+        <div className="mb-4">
+          <ChartImage b64={hist.chart_b64} alt="가상투자 수익률 추이" />
         </div>
       )}
 

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -184,6 +184,7 @@ import type {
   PaperTradeResult,
   PaperTradeHistoryItem,
   PaperRanking,
+  PaperHistory,
 } from "./types";
 
 async function paperGet<T>(path: string): Promise<T | null> {
@@ -206,6 +207,10 @@ export async function getTradeHistory(): Promise<PaperTradeHistoryItem[]> {
 
 export function getRanking(): Promise<PaperRanking | null> {
   return paperGet<PaperRanking>("/ranking");
+}
+
+export function getPaperHistory(): Promise<PaperHistory | null> {
+  return paperGet<PaperHistory>("/history");
 }
 
 /** 매수/매도 — 실패 시 detail 메시지로 throw(잔고부족 등 사용자에게 표시). */

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -294,3 +294,13 @@ export interface PaperRanking {
   my_rank: number | null;
   total_players: number;
 }
+
+export interface PaperHistoryPoint {
+  date: string;
+  total_value: number;
+  pnl_pct: number;
+}
+export interface PaperHistory {
+  points: PaperHistoryPoint[];
+  chart_b64: string | null;
+}

--- a/ETF_RAG/src/data/chart_generator/__init__.py
+++ b/ETF_RAG/src/data/chart_generator/__init__.py
@@ -18,6 +18,7 @@ from src.data.chart_generator.financial import (
     generate_financial_chart,
     generate_valuation_chart,
     generate_portfolio_chart,
+    generate_paper_trend_chart,
 )
 from src.data.chart_generator.sector import (
     generate_sector_overview_chart,
@@ -32,6 +33,7 @@ __all__ = [
     "generate_financial_chart",
     "generate_valuation_chart",
     "generate_portfolio_chart",
+    "generate_paper_trend_chart",
     "generate_sector_overview_chart",
     "generate_sector_detail_chart",
     "generate_sector_trend_chart",

--- a/ETF_RAG/src/data/chart_generator/financial.py
+++ b/ETF_RAG/src/data/chart_generator/financial.py
@@ -233,3 +233,52 @@ def generate_portfolio_chart(
     except Exception as e:
         logger.error(f"포트폴리오 차트 생성 실패: {e}")
         return None
+
+
+def generate_paper_trend_chart(
+    dates: list,
+    pnl_pcts: list,
+) -> Optional[str]:
+    """가상투자 수익률 추이 라인 차트(0%=원금) → base64 PNG.
+
+    dates: ["YYYYMMDD", ...] 오름차순, pnl_pcts: 동일 길이 수익률(%) 시계열.
+    """
+    if not dates or len(dates) < 2 or len(dates) != len(pnl_pcts):
+        return None
+
+    setup_font()
+    try:
+        x = list(range(len(dates)))
+        last = pnl_pcts[-1]
+        color = "#E8453C" if last >= 0 else "#1A73E8"
+
+        fig, ax = plt.subplots(figsize=(11, 4), facecolor=BG_COLOR)
+        ax.set_facecolor(BG_COLOR)
+        ax.plot(x, pnl_pcts, color=color, linewidth=1.8, zorder=3)
+        ax.fill_between(x, 0.0, pnl_pcts, color=color, alpha=0.08, zorder=2)
+        ax.axhline(0.0, color=TEXT_COLOR, linewidth=0.6, alpha=0.4, zorder=1)
+
+        fp = font_kw()
+        n = len(dates)
+        step = max(1, n // 8)
+        ticks = list(range(0, n, step))
+        if ticks and ticks[-1] != n - 1:
+            ticks.append(n - 1)
+
+        def _fmt(d: str) -> str:
+            return f"{d[4:6]}.{d[6:8]}" if len(d) == 8 else d
+
+        ax.set_xticks(ticks)
+        ax.set_xticklabels([_fmt(dates[i]) for i in ticks],
+                           fontsize=7, color=TEXT_COLOR, **fp)
+        ax.set_ylabel("수익률 (%)", fontsize=8, color=TEXT_COLOR, **fp)
+        ax.grid(True, alpha=0.3, color=GRID_COLOR, zorder=0)
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+        ax.set_title(f"가상투자 수익률 추이 (현재 {last:+.2f}%)",
+                     fontsize=12, fontweight="bold", color=TEXT_COLOR, **fp)
+        fig.subplots_adjust(left=0.08, right=0.97, top=0.90, bottom=0.12)
+        return to_base64_tight(fig)
+    except Exception as e:
+        logger.error(f"가상투자 추이 차트 생성 실패: {e}")
+        return None

--- a/ETF_RAG/tests/test_paper.py
+++ b/ETF_RAG/tests/test_paper.py
@@ -216,3 +216,62 @@ def test_ranking_excludes_users_without_account(client):
     client.get("/me/paper/portfolio", headers=a)  # a만 계좌 생성
     rk = client.get("/me/paper/ranking", headers=a).json()
     assert rk["total_players"] == 1
+
+
+# ── 수익률 추이 스냅샷 ──────────────────────────────────
+def test_history_empty_no_chart(client):
+    auth = _auth(client)
+    client.get("/me/paper/portfolio", headers=auth)  # 계좌 생성(스냅샷 없음)
+    h = client.get("/me/paper/history", headers=auth).json()
+    assert h["points"] == []
+    assert h["chart_b64"] is None
+
+
+def test_buy_records_snapshot(client):
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 10}, headers=auth)
+        h = client.get("/me/paper/history", headers=auth).json()
+    # 거래로 당일 스냅샷 1개 생성 — 총자산은 1억 그대로(현금-1000 + 평가1000)
+    assert len(h["points"]) == 1
+    assert h["points"][0]["total_value"] == INITIAL_CASH
+    assert h["points"][0]["pnl_pct"] == 0.0
+
+
+def test_reset_clears_snapshots(client):
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 10}, headers=auth)
+    client.post("/me/paper/reset", headers=auth)
+    h = client.get("/me/paper/history", headers=auth).json()
+    # 리셋 후 1억 스냅샷 1개만(초기화 시점)
+    assert len(h["points"]) == 1
+    assert h["points"][0]["total_value"] == INITIAL_CASH
+
+
+def test_snapshot_all_requires_cron_token(client):
+    from unittest.mock import patch
+    # 토큰 미설정 → 403
+    with patch("config.CRON_TOKEN", ""):
+        assert client.post("/me/paper/snapshot-all").status_code == 403
+    # 잘못된 토큰 → 403
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.post("/me/paper/snapshot-all", headers={"X-Cron-Token": "wrong"})
+        assert r.status_code == 403
+
+
+def test_snapshot_all_records_all_accounts(client):
+    from unittest.mock import patch
+    a = _auth(client, "a@b.com")
+    b = _auth(client, "b@b.com")
+    client.get("/me/paper/portfolio", headers=a)  # 계좌 생성
+    client.get("/me/paper/portfolio", headers=b)
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.post("/me/paper/snapshot-all", headers={"X-Cron-Token": "secret"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["users_snapshotted"] == 2
+    # 각 유저 history에 스냅샷 1개(현금만이라 1억)
+    h = client.get("/me/paper/history", headers=a).json()
+    assert len(h["points"]) == 1 and h["points"][0]["total_value"] == INITIAL_CASH


### PR DESCRIPTION
## 기능
가상투자 평가액을 **일별 스냅샷**으로 누적 → **수익률 추이 라인 차트**.

## 스냅샷 기록 2경로
1. **거래 직후**(`_snapshot_after_trade`) — 당일 스냅샷 즉시 갱신(실패해도 거래 무영향)
2. **`POST /me/paper/snapshot-all`**(X-Cron-Token) — 전 유저 일별 기록. **거래 안 한 날도 시세 변동 반영.** `daily-collect.yml`에 트리거 스텝 추가(`PAPER_SNAPSHOT_URL`/`CRON_TOKEN` secret, 미설정 시 skip — 관심종목 알림과 동일 패턴)

## 그 외
- `PaperSnapshot(user_id, date, total_value)` upsert(같은 날 최신값)
- `GET /me/paper/history` — 본인 시계열 + `generate_paper_trend_chart`(0%=원금 기준 수익률 라인)
- reset 시 스냅샷도 삭제 후 1억 시점 재기록
- 프론트 `/invest`: 자산 요약 아래 추이 차트(스냅샷 2일+ 누적 시)

## 테스트
- +5 (history 빈/거래시 기록/reset 초기화/cron 토큰 403/snapshot-all 전유저) — 전체 **821 통과**, tsc 통과

## 사용자 후속(선택)
- Railway env `CRON_TOKEN` + GHA secret `PAPER_SNAPSHOT_URL`(=`{백엔드}/me/paper/snapshot-all`) 설정 시 매일 자동 스냅샷. 미설정이어도 **거래 시점 스냅샷은 쌓임**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)