### PR TITLE
fix(technical): 시세 부족 신규 종목 기술분석 자동완성 제외

### DIFF
--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -44,6 +44,7 @@ from src.data.database import (
     get_connection,
     get_financial_data,
     get_closes_batch,
+    get_low_history_tickers,
     DB_PATH,
 )
 from src.llm.tools import (
@@ -349,13 +350,48 @@ async def sector(
 
 
 # ── 종목 자동완성 / 해석 ────────────────────────────────────────────
+# 시세 부족(min_days 미만) 제외 종목 집합 캐시 — 자동완성 매 호출 DB 조회 회피.
+_low_hist_cache: dict = {"set": None, "min_days": None, "at": 0.0}
+_LOW_HIST_TTL = 300  # 5분
+
+
+def _low_history_set(min_days: int) -> set:
+    import time
+    now = time.time()
+    c = _low_hist_cache
+    if (c["set"] is not None and c["min_days"] == min_days
+            and now - c["at"] < _LOW_HIST_TTL):
+        return c["set"]
+    conn = get_connection(DB_PATH)
+    try:
+        s = get_low_history_tickers(conn, min_days)
+    finally:
+        conn.close()
+    c.update(set=s, min_days=min_days, at=now)
+    return s
+
+
+def _extract_ticker(opt: str) -> str:
+    """'이름 (005930)' → '005930'."""
+    if opt.endswith(")") and " (" in opt:
+        return opt.rsplit(" (", 1)[1][:-1]
+    return opt
+
+
 @router.get("/tickers", response_model=TickerSearchResponse)
 async def tickers(
     q: Optional[str] = Query(None),
     limit: int = Query(30, ge=1, le=200),
     asset_type: Optional[str] = Query(None, pattern="^(stock|etf)$"),
+    min_days: int = Query(0, ge=0, le=250),
 ):
+    """종목 자동완성. min_days>0이면 시세 거래일이 그보다 적은 신규 종목 제외
+    (기술적 분석 탭처럼 과거 데이터가 필요한 화면용 — 기본 0=제외 안 함)."""
     options = await run_in_threadpool(get_available_tickers, asset_type)
+    if min_days > 0:
+        low = await run_in_threadpool(_low_history_set, min_days)
+        if low:
+            options = [o for o in options if _extract_ticker(o) not in low]
     if q:
         ql = q.lower()
         options = [o for o in options if ql in o.lower()]

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -119,7 +119,7 @@ export default function TechnicalPage() {
         이동평균·RSI·MACD·볼린저밴드 등 지표와 차트
       </p>
 
-      <TickerSearch onSelect={onSelect} />
+      <TickerSearch onSelect={onSelect} minDays={20} />
 
       {selected && (
         <div className="mt-3 flex flex-wrap gap-2">
@@ -242,6 +242,10 @@ export default function TechnicalPage() {
         </div>
       )}
 
+      <p className="mt-4 text-[11px] leading-relaxed text-gray-400">
+        ℹ️ 기술적 분석은 이동평균·RSI 등 계산에 충분한 과거 시세가 필요해, 상장 직후라
+        시세가 20거래일 미만인 신규 종목은 검색에서 자동 제외됩니다.
+      </p>
       <DataRangeNote />
     </main>
   );

--- a/ETF_RAG/frontend/src/components/TickerSearch.tsx
+++ b/ETF_RAG/frontend/src/components/TickerSearch.tsx
@@ -14,10 +14,12 @@ export default function TickerSearch({
   onSelect,
   placeholder = "종목명 또는 종목코드 검색…",
   assetType,
+  minDays,
 }: {
   onSelect: (sel: { name: string; ticker: string; raw: string }) => void;
   placeholder?: string;
   assetType?: "stock" | "etf"; // 지정 시 해당 자산만 자동완성 (재무제표=주식)
+  minDays?: number; // 시세 거래일이 이보다 적은 신규 종목 제외 (기술분석=20)
 }) {
   const [query, setQuery] = useState("");
   const [options, setOptions] = useState<string[]>([]);
@@ -32,12 +34,12 @@ export default function TickerSearch({
       return;
     }
     const timer = setTimeout(async () => {
-      const opts = await searchTickers(q, 20, assetType);
+      const opts = await searchTickers(q, 20, assetType, minDays);
       setOptions(opts);
       setOpen(true);
     }, 250);
     return () => clearTimeout(timer);
-  }, [query, assetType]);
+  }, [query, assetType, minDays]);
 
   // 바깥 클릭 시 닫기
   useEffect(() => {

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -125,11 +125,13 @@ export async function searchTickers(
   q: string,
   limit = 20,
   assetType?: "stock" | "etf",
+  minDays?: number,
 ): Promise<string[]> {
   const url = new URL(`${API_BASE}/tabs/tickers`);
   if (q) url.searchParams.set("q", q);
   url.searchParams.set("limit", String(limit));
   if (assetType) url.searchParams.set("asset_type", assetType);
+  if (minDays && minDays > 0) url.searchParams.set("min_days", String(minDays));
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) return [];
   const body = (await res.json()) as TickerSearchResponse;

--- a/ETF_RAG/src/data/database/__init__.py
+++ b/ETF_RAG/src/data/database/__init__.py
@@ -29,6 +29,7 @@ from src.data.database._read import (
     get_latest_stock_data,
     get_historical_prices,
     get_closes_batch,
+    get_low_history_tickers,
     search_instruments,
 )
 
@@ -53,7 +54,8 @@ __all__ = [
     "DB_PATH", "get_connection", "init_db",
     "upsert_daily_data", "upsert_stock_data",
     "get_latest_date", "get_latest_data", "get_latest_stock_data",
-    "get_historical_prices", "get_closes_batch", "search_instruments",
+    "get_historical_prices", "get_closes_batch", "get_low_history_tickers",
+    "search_instruments",
     "upsert_corp_codes", "get_corp_code", "get_all_corp_codes",
     "upsert_financial_data", "get_financial_data", "get_latest_financial_summary",
     "prune_old_data", "import_json_file", "get_db_stats",

--- a/ETF_RAG/src/data/database/_read.py
+++ b/ETF_RAG/src/data/database/_read.py
@@ -202,6 +202,34 @@ def get_historical_prices(conn: sqlite3.Connection,
     return [dict(r) for r in rows]
 
 
+def get_low_history_tickers(conn: sqlite3.Connection,
+                            min_days: int = 20) -> set:
+    """시세 거래일 수가 min_days 미만인 종목 집합 (기술분석 불가 종목 제외용).
+
+    880만 행 전체 GROUP BY는 느리므로(>10초), first_seen이 최근(min_days*2.5일)인
+    신규 상장 종목만 후보로 좁혀 그들의 거래일만 센다(~0.02초).
+    """
+    latest_row = conn.execute("SELECT MAX(date) FROM daily_prices").fetchone()
+    if not latest_row or not latest_row[0]:
+        return set()
+    latest = latest_row[0]
+    # 달력일 여유(min_days 거래일 ≈ min_days*1.5 달력일) + 버퍼
+    from datetime import datetime, timedelta
+    window = max(min_days * 3, 30)
+    cut = (datetime.strptime(latest, "%Y%m%d") - timedelta(days=window)).strftime("%Y%m%d")
+    cands = [r[0] for r in conn.execute(
+        "SELECT ticker FROM instruments WHERE first_seen >= ?", (cut,)).fetchall()]
+    if not cands:
+        return set()
+    placeholders = ",".join("?" * len(cands))
+    rows = conn.execute(
+        f"SELECT ticker, COUNT(*) c FROM daily_prices "
+        f"WHERE ticker IN ({placeholders}) GROUP BY ticker HAVING c < ?",
+        (*cands, min_days),
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
 def get_closes_batch(conn: sqlite3.Connection,
                      tickers: List[str],
                      start_date: str,

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -251,6 +251,29 @@ def test_tickers_asset_type_invalid_422(client):
     assert r.status_code == 422  # pattern ^(stock|etf)$
 
 
+def test_tickers_min_days_excludes_low_history(client):
+    """min_days>0이면 시세 부족 종목(_low_history_set)을 자동완성에서 제외."""
+    opts = ["삼성전자 (005930)", "신상ETF (0192L0)"]
+    with patch("api.tabs.get_available_tickers", return_value=opts), patch(
+        "api.tabs._low_history_set", return_value={"0192L0"}
+    ):
+        r = client.get("/tabs/tickers", params={"min_days": 20})
+    names = r.json()["options"]
+    assert "삼성전자 (005930)" in names
+    assert "신상ETF (0192L0)" not in names  # 제외됨
+
+
+def test_tickers_min_days_zero_keeps_all(client):
+    """min_days 미지정(0)이면 제외 안 함(_low_history_set 미호출)."""
+    opts = ["삼성전자 (005930)", "신상ETF (0192L0)"]
+    with patch("api.tabs.get_available_tickers", return_value=opts), patch(
+        "api.tabs._low_history_set", return_value={"0192L0"}
+    ) as low:
+        r = client.get("/tabs/tickers")
+    assert len(r.json()["options"]) == 2
+    low.assert_not_called()
+
+
 def test_tickers_resolve_404(client):
     with patch("api.tabs._find_structured_data", return_value=None):
         r = client.get("/tabs/tickers/resolve", params={"q": "ZZZ"})


### PR DESCRIPTION
## 배경
사용자 발견: **RISE SK하이닉스단일종목레버리지(0192L0)**가 자동완성엔 뜨는데 기술 분석은 "데이터를 찾을 수 없어요". 원인 조사 결과 — 이 ETF는 **상장 2026-05-27, 시세 19거래일**뿐이라, 기술 지표(MA/RSI/MACD/볼린저)는 최소 20거래일이 필요해(`_summary.py` `len<20 → None`) 계산 불가. **버그 아님, 데이터 한계.**

## 대응 (사용자 합의)
자동완성에서 숨기고 + 안내문 명시.

- `get_low_history_tickers(min_days)`: 880만행 전체 GROUP BY는 14.5초라, `first_seen` 최근 종목(신규 상장)만 후보로 좁혀 거래일 카운트 → **0.02초**(700배). 제외 대상 38개.
- `/tabs/tickers?min_days=` : 제외집합 5분 캐시. 기본 0(제외 안 함) — 다른 탭 영향 없음.
- 프론트: 기술 분석 탭 `TickerSearch minDays={20}` + "상장 직후 시세 20거래일 미만 신규 종목 자동 제외" 안내문.
- 전망/비교/재무 탭은 그대로(짧은 시세로도 일부 동작).

## 테스트
- +2 (min_days 제외/미제외). 전체 **827**, tsc 통과. `0192L0` 제외·삼성전자 유지 라이브 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)