### PR TITLE
fix(outlook): 시세 60일 미만 신규 종목 전망 자동완성 제외

### DIFF
--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -351,23 +351,23 @@ async def sector(
 
 # ── 종목 자동완성 / 해석 ────────────────────────────────────────────
 # 시세 부족(min_days 미만) 제외 종목 집합 캐시 — 자동완성 매 호출 DB 조회 회피.
-_low_hist_cache: dict = {"set": None, "min_days": None, "at": 0.0}
+# min_days별로 분리 캐시(기술탭 20 / 전망탭 60 병행 시 상호 무효화 방지).
+_low_hist_cache: dict = {}  # {min_days: (set, ts)}
 _LOW_HIST_TTL = 300  # 5분
 
 
 def _low_history_set(min_days: int) -> set:
     import time
     now = time.time()
-    c = _low_hist_cache
-    if (c["set"] is not None and c["min_days"] == min_days
-            and now - c["at"] < _LOW_HIST_TTL):
-        return c["set"]
+    cached = _low_hist_cache.get(min_days)
+    if cached and now - cached[1] < _LOW_HIST_TTL:
+        return cached[0]
     conn = get_connection(DB_PATH)
     try:
         s = get_low_history_tickers(conn, min_days)
     finally:
         conn.close()
-    c.update(set=s, min_days=min_days, at=now)
+    _low_hist_cache[min_days] = (s, now)
     return s
 
 

--- a/ETF_RAG/frontend/src/app/outlook/page.tsx
+++ b/ETF_RAG/frontend/src/app/outlook/page.tsx
@@ -80,7 +80,7 @@ export default function OutlookPage() {
         기술적·펀더멘털·통계·Prophet 4축 종합 + 시나리오
       </p>
 
-      <TickerSearch onSelect={onSelect} />
+      <TickerSearch onSelect={onSelect} minDays={60} />
 
       {selected && (
         <div className="mt-3 flex flex-wrap gap-2">
@@ -155,6 +155,10 @@ export default function OutlookPage() {
         </div>
       )}
 
+      <p className="mt-4 text-[11px] leading-relaxed text-gray-400">
+        ℹ️ 가격 전망은 회귀·Prophet 등 모델 학습에 충분한 과거 시세가 필요해, 상장
+        직후라 시세가 60거래일 미만인 신규 종목은 검색에서 자동 제외됩니다.
+      </p>
       <DataRangeNote />
     </main>
   );

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -274,6 +274,28 @@ def test_tickers_min_days_zero_keeps_all(client):
     low.assert_not_called()
 
 
+def test_low_history_cache_separates_by_min_days():
+    """min_days별 캐시 분리 — 20과 60이 서로 무효화하지 않는다(전망탭60/기술탭20 병행)."""
+    import api.tabs as tabs
+    calls = []
+
+    def fake_get(conn, md):
+        calls.append(md)
+        return {f"under{md}"}
+
+    tabs._low_hist_cache.clear()
+    with patch("api.tabs.get_low_history_tickers", side_effect=fake_get), patch(
+        "api.tabs.get_connection"
+    ):
+        assert tabs._low_history_set(20) == {"under20"}
+        assert tabs._low_history_set(60) == {"under60"}
+        # 캐시 적중 — DB 재조회 없음
+        assert tabs._low_history_set(20) == {"under20"}
+        assert tabs._low_history_set(60) == {"under60"}
+    assert calls == [20, 60]  # 각 1회씩만
+    tabs._low_hist_cache.clear()
+
+
 def test_tickers_resolve_404(client):
     with patch("api.tabs._find_structured_data", return_value=None):
         r = client.get("/tabs/tickers/resolve", params={"q": "ZZZ"})


### PR DESCRIPTION
## 배경
PR #72 후속 — 사용자가 전망 탭에서도 0192L0(RISE SK하이닉스레버리지)이 "전망을 생성할 수 없어요" 확인. 같은 원인이나 **임계값이 다름**: predictor 통계 예측이 `min_required = max(60, horizon+60)`거래일 요구(`predictor.py:346`) → 시세 19일은 미달.

## 변경
- 전망 탭 `TickerSearch minDays={60}` + 안내문(기술탭 20 / 전망 60)
- `_low_history_set` 캐시를 **min_days별 분리**(`{min_days: (set, ts)}`) — 기술탭(20)·전망탭(60) 병행 호출 시 상호 무효화 방지
- 백엔드 `min_days` 필터는 PR #72에서 이미 임의 값 지원 → 프론트 + 캐시 구조만 수정
- 테스트 +1(캐시 분리 검증). 전체 828. tsc 통과. 60일 필터로 0192L0 제외(82개)·삼성전자 유지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)