### PR TITLE
fix(tools): 영문 대문자 포함 티커 조회 실패 (0162Z0 등)

### DIFF
--- a/ETF_RAG/src/llm/tools/_helpers.py
+++ b/ETF_RAG/src/llm/tools/_helpers.py
@@ -60,10 +60,11 @@ def _fallback_deploy_lookup(key: str) -> Optional[dict]:
                 raw = json.load(f)
             items = raw.get("stocks", raw.get("etfs", []))
 
-            # 1단계: 정확 매칭 (이름 또는 티커)
+            # 1단계: 정확 매칭 (이름 또는 티커). key는 소문자이므로 티커도 소문자로
+            # 비교 — 일부 ETF 티커는 영문 대문자 포함(0162Z0 등).
             for item in items:
                 name = item.get("name", "").lower()
-                ticker = item.get("ticker", "")
+                ticker = item.get("ticker", "").lower()
                 if key == name or key == ticker:
                     return _normalize_deploy_item(item)
 

--- a/ETF_RAG/src/llm/tools/_state.py
+++ b/ETF_RAG/src/llm/tools/_state.py
@@ -28,7 +28,12 @@ _sector_index = {}             # {sector_name: [{name, ticker, per, pbr, market_
 
 
 def _build_data_index(data_list):
-    """데이터 리스트에서 이름/티커 → dict 인덱스 구축"""
+    """데이터 리스트에서 이름/티커 → dict 인덱스 구축.
+
+    조회(_find_structured_data)가 query를 .lower()로 찾으므로 키도 소문자로 통일한다.
+    일부 신형 ETF 티커는 영문 대문자 포함(예: 0162Z0, 0192L0) — 소문자화 안 하면
+    티커로 조회 시 매칭 실패('0162z0' != '0162Z0').
+    """
     index = {}
     for item in data_list:
         name = item.get("name", "")
@@ -36,7 +41,7 @@ def _build_data_index(data_list):
         if name:
             index[name.lower()] = item
         if ticker:
-            index[ticker] = item
+            index[ticker.lower()] = item
     return index
 
 

--- a/ETF_RAG/tests/test_find_structured_data.py
+++ b/ETF_RAG/tests/test_find_structured_data.py
@@ -1,0 +1,55 @@
+"""_find_structured_data 종목 해석 테스트 (2026-06-24).
+
+실버그: 일부 신형 ETF 티커는 영문 대문자 포함(0162Z0, 0192L0)인데, 인덱스는
+티커를 원본 대소문자로 키에 넣고 조회는 .lower()로 해서 대문자 티커 조회가
+None이 되던 문제(기술분석/전망 "데이터 없음"의 원인). 인덱스 키도 .lower() 통일로 수정.
+"""
+
+from src.llm.tools import _find_structured_data, set_retriever
+
+_ETF = [
+    {"name": "KODEX 200", "ticker": "069500", "close": 80800, "nav": 80647},
+    {"name": "RISE 삼성전자SK하이닉스채권혼합50", "ticker": "0162Z0",
+     "close": 10765, "nav": 10760},
+]
+_STOCK = [
+    {"name": "삼성전자", "ticker": "005930", "close": 70000},
+]
+
+
+def _setup():
+    set_retriever(None, [], etf_data=_ETF, stock_data=_STOCK)
+
+
+def test_lookup_by_uppercase_ticker():
+    """영문 대문자 포함 티커도 조회돼야 한다(버그 케이스)."""
+    _setup()
+    d = _find_structured_data("0162Z0")
+    assert d is not None
+    assert d["ticker"] == "0162Z0"
+
+
+def test_lookup_by_lowercase_ticker_input():
+    """사용자가 소문자로 입력해도 동일하게 조회."""
+    _setup()
+    d = _find_structured_data("0162z0")
+    assert d is not None and d["ticker"] == "0162Z0"
+
+
+def test_lookup_by_numeric_ticker_still_works():
+    """기존 숫자 티커 회귀 없음."""
+    _setup()
+    assert _find_structured_data("069500")["ticker"] == "069500"
+    assert _find_structured_data("005930")["ticker"] == "005930"
+
+
+def test_lookup_by_name():
+    """이름 조회 회귀 없음."""
+    _setup()
+    assert _find_structured_data("삼성전자")["ticker"] == "005930"
+    assert _find_structured_data("RISE 삼성전자SK하이닉스채권혼합50")["ticker"] == "0162Z0"
+
+
+def test_lookup_unknown_returns_none():
+    _setup()
+    assert _find_structured_data("ZZZZ999") is None


### PR DESCRIPTION
## 배경
사용자 발견: **RISE 삼성전자SK하이닉스채권혼합50(0162Z0)**이 자동완성엔 떠도 기술 분석 "데이터 없음". 시세 부족(#72) 케이스인 줄 알았으나 — **이 종목은 시세 82행으로 충분**(`get_technical_summary`는 OK 반환). 진짜 원인은 **종목 해석 버그**.

## 원인 (진짜 버그)
- 일부 신형 ETF 티커에 **영문 대문자** 포함(`0162Z0`, `0192L0`)
- `_build_data_index`가 티커를 **원본 대소문자**로 키에 저장(`index[ticker]`)하는데, `_find_structured_data`는 query를 `.lower()`로 조회 → `'0162z0' != '0162Z0'`
- 정확 매칭·부분 매칭 모두 실패 → None → "데이터 없음"
- 이름으로는 조회됐으나, 자동완성은 **티커를 넘겨서** 실패. 숫자만인 일반 티커는 무영향이라 그간 안 드러남.

## 수정
- `_build_data_index`: `index[ticker.lower()] = item` (이름은 이미 `.lower()`)
- `_helpers._fallback_deploy_lookup`: 티커 비교도 `.lower()` (인덱스 미초기화 복구 경로, 일관성)
- 회귀 테스트 5개 (대문자/소문자 티커, 숫자 티커, 이름, 미존재). 전체 **833**.

## 영향
기술분석·전망·비교·가상투자 등 **티커로 종목을 해석하는 모든 경로**에서 대문자 포함 티커가 이제 정상 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)