### PR TITLE
feat: 기간 대비 등락률 + 사이드바 전체검색·관심탭

### DIFF
--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -157,6 +157,32 @@ export default function TechnicalPage() {
           {/* 실시간 시세 (KIS 우선 → yfinance, 장 외엔 종가) */}
           <PriceCard ticker={data.ticker} />
 
+          {/* 선택 기간 대비 등락률 (종가 기준) */}
+          {(() => {
+            const cur = Number(s.close);
+            const base = Number(s.first_close);
+            const fd = String(s.first_date ?? "");
+            if (!cur || !base || base <= 0) return null;
+            const pct = ((cur - base) / base) * 100;
+            const label = PERIODS.find((p) => p.days === days)?.label ?? "기간";
+            const color =
+              pct > 0 ? "text-red-600" : pct < 0 ? "text-blue-600" : "text-gray-500";
+            const fdFmt =
+              fd.length === 8 ? `${fd.slice(0, 4)}.${fd.slice(4, 6)}.${fd.slice(6, 8)}` : fd;
+            return (
+              <p className="mt-2 text-xs text-gray-500">
+                {label} 전({fdFmt}) 대비{" "}
+                <span className={`font-semibold ${color}`}>
+                  {pct > 0 ? "+" : ""}
+                  {pct.toFixed(2)}%
+                </span>{" "}
+                <span className="text-gray-400">
+                  ({base.toLocaleString("ko-KR")} → {cur.toLocaleString("ko-KR")}원)
+                </span>
+              </p>
+            );
+          })()}
+
           {/* 호가 10단계 (KIS 전용, 장중에만 표시) */}
           <div className="mt-3">
             <OrderbookCard ticker={data.ticker} />

--- a/ETF_RAG/frontend/src/components/Sidebar.tsx
+++ b/ETF_RAG/frontend/src/components/Sidebar.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getOverview, getVisitor } from "@/lib/api";
+import { getOverview, getVisitor, searchTickers } from "@/lib/api";
 import PushToggle from "@/components/PushToggle";
+import WatchlistStar from "@/components/WatchlistStar";
+import { useWatchlist } from "@/lib/useWatchlist";
 import type {
   InstrumentItem,
   OverviewResponse,
   VisitorResponse,
 } from "@/lib/types";
+
+// "삼성전자 (005930)" → {name, ticker}
+function parseOption(opt: string): { name: string; ticker: string } {
+  const m = opt.match(/^(.*)\s+\(([^)]+)\)\s*$/);
+  return m ? { name: m[1], ticker: m[2] } : { name: opt, ticker: opt };
+}
 
 function fmtDate(s: string | null): string {
   if (!s) return "-";
@@ -29,27 +37,59 @@ function changeColor(v: number): string {
 function ItemRow({
   it,
   onClick,
+  showStar = false,
 }: {
   it: InstrumentItem;
   onClick: () => void;
+  showStar?: boolean;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex w-full items-center justify-between gap-2 rounded px-2 py-1.5 text-left hover:bg-gray-100"
-    >
-      <span className="truncate text-xs text-gray-800">{it.name}</span>
-      <span className="flex shrink-0 items-center gap-2">
-        <span className="text-xs tabular-nums text-gray-500">
-          {it.close.toLocaleString("ko-KR")}
+    <div className="flex w-full items-center gap-1 rounded px-2 py-1.5 hover:bg-gray-100">
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex flex-1 items-center justify-between gap-2 text-left"
+      >
+        <span className="truncate text-xs text-gray-800">{it.name}</span>
+        <span className="flex shrink-0 items-center gap-2">
+          <span className="text-xs tabular-nums text-gray-500">
+            {it.close.toLocaleString("ko-KR")}
+          </span>
+          <span className={`text-xs tabular-nums ${changeColor(it.change_pct)}`}>
+            {it.change_pct > 0 ? "+" : ""}
+            {it.change_pct}%
+          </span>
         </span>
-        <span className={`text-xs tabular-nums ${changeColor(it.change_pct)}`}>
-          {it.change_pct > 0 ? "+" : ""}
-          {it.change_pct}%
-        </span>
-      </span>
-    </button>
+      </button>
+      {showStar && <WatchlistStar ticker={it.ticker} />}
+    </div>
+  );
+}
+
+// 전체 검색 결과 행 (가격 없이 이름+⭐+클릭이동만 — searchTickers는 가격 미제공)
+function SearchRow({
+  name,
+  ticker,
+  onClick,
+  showStar,
+}: {
+  name: string;
+  ticker: string;
+  onClick: () => void;
+  showStar: boolean;
+}) {
+  return (
+    <div className="flex w-full items-center gap-1 rounded px-2 py-1.5 hover:bg-gray-100">
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex flex-1 items-center justify-between gap-2 text-left"
+      >
+        <span className="truncate text-xs text-gray-800">{name}</span>
+        <span className="shrink-0 text-[10px] tabular-nums text-gray-400">{ticker}</span>
+      </button>
+      {showStar && <WatchlistStar ticker={ticker} />}
+    </div>
   );
 }
 
@@ -61,12 +101,15 @@ export default function Sidebar({
   onClose?: () => void;
 } = {}) {
   const router = useRouter();
+  const watch = useWatchlist();
   const [data, setData] = useState<OverviewResponse | null>(null);
   const [visitor, setVisitor] = useState<VisitorResponse | null>(null);
-  const [tab, setTab] = useState<"etf" | "stock">("etf");
+  const [tab, setTab] = useState<"etf" | "stock" | "watch">("etf");
   const [q, setQ] = useState("");
   const [sector, setSector] = useState(""); // "" = 전체
   const [sectorStocks, setSectorStocks] = useState<InstrumentItem[] | null>(null);
+  // 전체 종목 검색 결과 ("이름 (코드)" 문자열). 검색어 있을 때만 채움.
+  const [searchHits, setSearchHits] = useState<string[]>([]);
 
   useEffect(() => {
     getOverview(20).then(setData);
@@ -95,20 +138,29 @@ export default function Sidebar({
     setSectorStocks(null); // 새 선택 로딩 표시(전체면 그대로 null → 기본 목록 사용)
   };
 
+  // 전체 종목 검색(디바운스 250ms) — 검색어 있으면 자동완성 API로 전 종목 조회.
+  // 관심 탭은 검색 대신 관심종목 목록만 보여주므로 제외.
+  useEffect(() => {
+    const ql = q.trim();
+    if (!ql || tab === "watch") {
+      setSearchHits([]);
+      return;
+    }
+    const assetType = tab === "etf" ? "etf" : "stock";
+    const timer = setTimeout(() => {
+      searchTickers(ql, 30, assetType).then(setSearchHits);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [q, tab]);
+
   const stockList = sector ? sectorStocks ?? [] : data?.top_stocks ?? [];
   const list = data ? (tab === "etf" ? data.top_etfs : stockList) : [];
-  const filtered = useMemo(() => {
-    const ql = q.trim().toLowerCase();
-    if (!ql) return list;
-    return list.filter(
-      (it) => it.name.toLowerCase().includes(ql) || it.ticker.includes(ql),
-    );
-  }, [list, q]);
 
-  const go = (it: InstrumentItem) => {
-    router.push(`/technical?ticker=${encodeURIComponent(it.ticker)}`);
+  const goTicker = (ticker: string) => {
+    router.push(`/technical?ticker=${encodeURIComponent(ticker)}`);
     onClose?.(); // 모바일 드로워에서 종목 선택 시 닫기
   };
+  const go = (it: InstrumentItem) => goTicker(it.ticker);
 
   const content = (
     <>
@@ -136,9 +188,9 @@ export default function Sidebar({
         )}
       </div>
 
-      {/* ETF / 주식 탭 */}
+      {/* ETF / 주식 / 관심 탭 */}
       <div className="mb-2 flex gap-1">
-        {(["etf", "stock"] as const).map((t) => (
+        {(["etf", "stock", "watch"] as const).map((t) => (
           <button
             key={t}
             type="button"
@@ -148,13 +200,13 @@ export default function Sidebar({
               tab === t ? "bg-blue-600 text-white" : "text-gray-600 hover:bg-gray-100",
             ].join(" ")}
           >
-            {t === "etf" ? "📊 ETF" : "📈 주식"}
+            {t === "etf" ? "📊 ETF" : t === "stock" ? "📈 주식" : "⭐ 관심"}
           </button>
         ))}
       </div>
 
-      {/* 업종 필터 (주식 탭에서만) */}
-      {tab === "stock" && data && data.sectors.length > 0 && (
+      {/* 업종 필터 (주식 탭, 검색 안 할 때만) */}
+      {tab === "stock" && !q.trim() && data && data.sectors.length > 0 && (
         <select
           value={sector}
           onChange={(e) => onSectorChange(e.target.value)}
@@ -169,24 +221,65 @@ export default function Sidebar({
         </select>
       )}
 
-      {/* 검색 */}
-      <input
-        value={q}
-        onChange={(e) => setQ(e.target.value)}
-        placeholder="종목 검색…"
-        className="mb-2 w-full rounded-lg border border-gray-300 px-3 py-1.5 text-xs focus:border-blue-500 focus:outline-none"
-      />
+      {/* 검색 (관심 탭 제외 — 전체 종목 검색) */}
+      {tab !== "watch" && (
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder={`${tab === "etf" ? "ETF" : "주식"} 전체 검색…`}
+          className="mb-2 w-full rounded-lg border border-gray-300 px-3 py-1.5 text-xs focus:border-blue-500 focus:outline-none"
+        />
+      )}
 
-      {/* 목록 (거래대금 TOP) */}
+      {/* 목록 — 검색 중이면 전체 검색결과 / 관심 탭이면 관심종목 / 기본은 거래대금 TOP */}
       <div className="space-y-0.5">
-        {filtered.length === 0 ? (
+        {tab === "watch" ? (
+          !watch.enabled ? (
+            <div className="px-2 py-3 text-center text-xs text-gray-400">
+              로그인하면 관심종목을 저장할 수 있어요.
+            </div>
+          ) : watch.tickers.length === 0 ? (
+            <div className="px-2 py-3 text-center text-xs text-gray-400">
+              관심종목이 없어요. ETF·주식 탭에서 ⭐로 추가하세요.
+            </div>
+          ) : (
+            watch.tickers.map((tk) => (
+              <SearchRow
+                key={tk}
+                name={tk}
+                ticker={tk}
+                onClick={() => goTicker(tk)}
+                showStar
+              />
+            ))
+          )
+        ) : q.trim() ? (
+          searchHits.length === 0 ? (
+            <div className="px-2 py-3 text-center text-xs text-gray-400">…</div>
+          ) : (
+            searchHits.map((opt) => {
+              const { name, ticker } = parseOption(opt);
+              return (
+                <SearchRow
+                  key={ticker}
+                  name={name}
+                  ticker={ticker}
+                  onClick={() => goTicker(ticker)}
+                  showStar={watch.enabled}
+                />
+              );
+            })
+          )
+        ) : list.length === 0 ? (
           <div className="px-2 py-3 text-center text-xs text-gray-400">
             {!data || (tab === "stock" && sector && sectorStocks === null)
               ? "…"
               : "결과 없음"}
           </div>
         ) : (
-          filtered.map((it) => <ItemRow key={it.ticker} it={it} onClick={() => go(it)} />)
+          list.map((it) => (
+            <ItemRow key={it.ticker} it={it} onClick={() => go(it)} showStar={watch.enabled} />
+          ))
         )}
       </div>
 

--- a/ETF_RAG/src/data/technical/_summary.py
+++ b/ETF_RAG/src/data/technical/_summary.py
@@ -84,6 +84,7 @@ def get_technical_summary(ticker: str, days: int = 250) -> Optional[dict]:
         "ticker": ticker,
         "date": latest["date"],
         "close": latest["close"],
+        "first_close": ohlcv[0]["close"],  # 조회 기간 첫 종가(기간 대비 등락률용)
         "data_days": len(ohlcv),
         "first_date": ohlcv[0]["date"],
         "last_date": latest["date"],


### PR DESCRIPTION
## 변경 (사용자 요청)

### 기술 분석 — 기간 대비 등락률
- 현재가 카드 아래 **선택 기간 대비 등락률** 표시(전일 대비는 유지 — 둘 다).
- summary에 `first_close`(조회 기간 첫 종가) 1필드 추가 → `(close-first_close)/first_close`.
- "N 전(날짜) 대비 +X% (시작가→현재가)" 형태. 기간 버튼(6개월~10년)과 연동.

### 사이드바
- **전체 종목 검색**: 거래대금 TOP20 내 필터 → `searchTickers`(자동완성 API)로 전 종목 검색. 결과 클릭 시 기술분석 이동. 탭(ETF/주식)에 따라 asset_type 필터.
- **검색·목록 행에 ⭐**(WatchlistStar) — 로그인 시 바로 관심 추가.
- **"⭐ 관심" 탭** 신설(ETF/주식 옆) — 관심종목 목록(클릭 이동), 비로그인 안내.
- 관심종목은 **기존 Postgres `watchlists` 테이블에 영구 누적**(계정별, 재사용).

## 테스트
- 전체 **833** 통과(백엔드 summary first_close 추가가 기존 안 깸), 프론트 tsc 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)