### PR TITLE
fix(price): 시세 정확성 — 시장구분(.KS/.KQ) + 기간 등락률 + 라벨

### DIFF
--- a/ETF_RAG/frontend/src/components/PriceCard.tsx
+++ b/ETF_RAG/frontend/src/components/PriceCard.tsx
@@ -112,31 +112,44 @@ export default function PriceCard({ ticker }: { ticker: string }) {
         ? { label: "🟡 15분 지연 (yfinance)", cls: "bg-yellow-50 text-yellow-700" }
         : { label: "종가", cls: "bg-gray-100 text-gray-500" };
 
+  // 현재가(장중)인지 종가(장외)인지에 따라 라벨 구분
+  const isLivePrice = data.source !== "close";
+  const headLabel = isLivePrice ? "현재 시세" : "최근 종가";
+
   return (
     <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-baseline gap-2">
-          <span className="text-xl font-bold tabular-nums text-gray-900">
-            {data.price.toLocaleString("ko-KR")}원
-          </span>
-          {data.change_pct != null && (
-            <span className={`text-sm font-medium tabular-nums ${color}`}>
-              {data.change != null
-                ? `${up ? "+" : ""}${data.change.toLocaleString("ko-KR")}원 `
-                : ""}
-              ({up ? "+" : ""}
-              {data.change_pct}%)
-            </span>
-          )}
-        </div>
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-[11px] font-medium text-gray-500">{headLabel}</span>
         <span
           className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] ${badge.cls} ${live ? "animate-pulse" : ""}`}
         >
           {badge.label}
         </span>
       </div>
+      <div className="mt-0.5 flex items-baseline gap-2">
+        <span className="text-xl font-bold tabular-nums text-gray-900">
+          {data.price.toLocaleString("ko-KR")}원
+        </span>
+        {data.change_pct != null && (
+          <span className={`text-sm font-medium tabular-nums ${color}`}>
+            {data.change != null
+              ? `${up ? "+" : ""}${data.change.toLocaleString("ko-KR")}원 `
+              : ""}
+            ({up ? "+" : ""}
+            {data.change_pct}%)
+          </span>
+        )}
+      </div>
+      {/* 등락 기준 명시 */}
+      {data.change_pct != null && (
+        <div className="mt-0.5 text-[11px] text-gray-400">
+          전일 종가 대비
+          {data.prev_close != null &&
+            ` (전일 ${data.prev_close.toLocaleString("ko-KR")}원)`}
+        </div>
+      )}
       <div className="mt-1 flex items-center gap-3 text-[11px] text-gray-400">
-        {data.volume != null && (
+        {data.volume != null && data.volume > 0 && (
           <span>거래량 {data.volume.toLocaleString("ko-KR")}주</span>
         )}
         {data.timestamp && <span>{data.timestamp}</span>}

--- a/ETF_RAG/scripts/backfill_market.py
+++ b/ETF_RAG/scripts/backfill_market.py
@@ -1,0 +1,77 @@
+"""instruments.market(KOSPI/KOSDAQ) 일회성 백필.
+
+기존 종목은 market이 비어 있어 yfinance .KS/.KQ 변환이 추측에 의존 →
+pykrx로 시장별 종목 목록을 받아 instruments.market을 채운다. (ETF는 KOSPI 고정)
+
+사용:
+    python -m scripts.backfill_market
+"""
+
+import logging
+import sys
+
+from pykrx import stock
+
+from src.data.database import init_db, DB_PATH
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def backfill() -> None:
+    # init_db가 _migrate를 호출 → instruments.market 컬럼 보장
+    conn = init_db(DB_PATH)
+    # 날짜: DB 최신 수집일(오늘이 영업일/장중이 아니면 pykrx가 빈 응답을 주므로)
+    row = conn.execute("SELECT MAX(date) FROM daily_prices").fetchone()
+    date = row[0] if row and row[0] else None
+    if not date:
+        logger.error("daily_prices가 비어 있어 기준일을 알 수 없습니다.")
+        return
+
+    # 1) 주식: 시장별 ticker 목록 (pykrx 빈 응답 잦아 재시도)
+    import time
+    updated = 0
+    for mkt in ("KOSPI", "KOSDAQ"):
+        tickers = []
+        for attempt in range(4):
+            try:
+                tickers = stock.get_market_ticker_list(date, market=mkt)
+                if tickers:
+                    break
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"{mkt} 시도{attempt + 1} 실패: {e}")
+            time.sleep(3)
+        if not tickers:
+            logger.warning(f"{mkt} 목록 비어있음 — 건너뜀(나중에 재실행 권장)")
+            continue
+        with conn:
+            cur = conn.executemany(
+                "UPDATE instruments SET market = ? WHERE ticker = ? AND type = 'stock'",
+                [(mkt, t) for t in tickers],
+            )
+        logger.info(f"{mkt}: {len(tickers)}종목 market 설정")
+        updated += len(tickers)
+
+    # 2) ETF: 모두 KOSPI
+    with conn:
+        conn.execute(
+            "UPDATE instruments SET market = 'KOSPI' "
+            "WHERE type = 'etf' AND (market IS NULL OR market = '')"
+        )
+
+    # 3) 결과 요약
+    rows = conn.execute(
+        "SELECT market, COUNT(*) c FROM instruments GROUP BY market ORDER BY c DESC"
+    ).fetchall()
+    logger.info("=== 백필 결과 (market별 종목 수) ===")
+    for r in rows:
+        logger.info(f"  {r[0] or '(빈값)'}: {r[1]}")
+    conn.close()
+
+
+if __name__ == "__main__":
+    try:
+        backfill()
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"백필 실패: {e}")
+        sys.exit(1)

--- a/ETF_RAG/src/data/database/__init__.py
+++ b/ETF_RAG/src/data/database/__init__.py
@@ -29,6 +29,7 @@ from src.data.database._read import (
     get_latest_stock_data,
     get_historical_prices,
     get_closes_batch,
+    get_market_map,
     get_low_history_tickers,
     search_instruments,
 )
@@ -54,7 +55,7 @@ __all__ = [
     "DB_PATH", "get_connection", "init_db",
     "upsert_daily_data", "upsert_stock_data",
     "get_latest_date", "get_latest_data", "get_latest_stock_data",
-    "get_historical_prices", "get_closes_batch", "get_low_history_tickers",
+    "get_historical_prices", "get_closes_batch", "get_market_map", "get_low_history_tickers",
     "search_instruments",
     "upsert_corp_codes", "get_corp_code", "get_all_corp_codes",
     "upsert_financial_data", "get_financial_data", "get_latest_financial_summary",

--- a/ETF_RAG/src/data/database/_read.py
+++ b/ETF_RAG/src/data/database/_read.py
@@ -202,6 +202,14 @@ def get_historical_prices(conn: sqlite3.Connection,
     return [dict(r) for r in rows]
 
 
+def get_market_map(conn: sqlite3.Connection) -> dict:
+    """{ticker: 'KOSPI'|'KOSDAQ'} 맵 (market 비어있는 종목 제외). yfinance .KS/.KQ 변환용."""
+    rows = conn.execute(
+        "SELECT ticker, market FROM instruments WHERE market IS NOT NULL AND market != ''"
+    ).fetchall()
+    return {r["ticker"]: r["market"] for r in rows}
+
+
 def get_low_history_tickers(conn: sqlite3.Connection,
                             min_days: int = 20) -> set:
     """시세 거래일 수가 min_days 미만인 종목 집합 (기술분석 불가 종목 제외용).

--- a/ETF_RAG/src/data/database/_schema.py
+++ b/ETF_RAG/src/data/database/_schema.py
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS instruments (
     name        TEXT NOT NULL,
     type        TEXT NOT NULL DEFAULT 'etf',
     sector      TEXT DEFAULT '',
+    market      TEXT DEFAULT '',   -- KOSPI | KOSDAQ (yfinance .KS/.KQ 정확 변환용)
     first_seen  TEXT NOT NULL,
     last_seen   TEXT NOT NULL,
     is_active   INTEGER NOT NULL DEFAULT 1
@@ -147,5 +148,9 @@ def _migrate(conn: sqlite3.Connection):
     if "sector" not in cols:
         conn.execute("ALTER TABLE instruments ADD COLUMN sector TEXT DEFAULT ''")
         logger.info("마이그레이션: instruments.sector 컬럼 추가")
+    # instruments.market 컬럼 추가 (v3) — yfinance .KS/.KQ 정확 변환용
+    if "market" not in cols:
+        conn.execute("ALTER TABLE instruments ADD COLUMN market TEXT DEFAULT ''")
+        logger.info("마이그레이션: instruments.market 컬럼 추가")
     # sector 인덱스 (컬럼 존재 확인 후 생성)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_instruments_sector ON instruments(sector)")

--- a/ETF_RAG/src/data/database/_write.py
+++ b/ETF_RAG/src/data/database/_write.py
@@ -28,12 +28,14 @@ def upsert_daily_data(conn: sqlite3.Connection, data: dict) -> int:
     date = meta.get("collection_date", "")
 
     with conn:
-        # 1) instruments
+        # 1) instruments (ETF는 모두 KOSPI 상장 → market='KOSPI')
         conn.executemany("""
-            INSERT INTO instruments (ticker, name, type, first_seen, last_seen)
-            VALUES (?, ?, 'etf', ?, ?)
+            INSERT INTO instruments (ticker, name, type, market, first_seen, last_seen)
+            VALUES (?, ?, 'etf', 'KOSPI', ?, ?)
             ON CONFLICT(ticker) DO UPDATE SET
                 name = excluded.name,
+                market = CASE WHEN instruments.market = '' THEN 'KOSPI'
+                              ELSE instruments.market END,
                 last_seen = excluded.last_seen,
                 is_active = 1
         """, [(e["ticker"], e["name"], date, date) for e in etfs])
@@ -129,17 +131,19 @@ def upsert_stock_data(conn: sqlite3.Connection, data: dict) -> int:
     date = meta.get("collection_date", "")
 
     with conn:
-        # 1) instruments (type='stock', sector 포함)
+        # 1) instruments (type='stock', sector·market 포함)
         conn.executemany("""
-            INSERT INTO instruments (ticker, name, type, sector, first_seen, last_seen)
-            VALUES (?, ?, 'stock', ?, ?, ?)
+            INSERT INTO instruments (ticker, name, type, sector, market, first_seen, last_seen)
+            VALUES (?, ?, 'stock', ?, ?, ?, ?)
             ON CONFLICT(ticker) DO UPDATE SET
                 name = excluded.name,
                 sector = CASE WHEN excluded.sector != '' THEN excluded.sector
                               ELSE instruments.sector END,
+                market = CASE WHEN excluded.market != '' THEN excluded.market
+                              ELSE instruments.market END,
                 last_seen = excluded.last_seen,
                 is_active = 1
-        """, [(s["ticker"], s["name"], s.get("sector", ""), date, date)
+        """, [(s["ticker"], s["name"], s.get("sector", ""), s.get("market", ""), date, date)
               for s in stocks])
 
         # 2) daily_prices (주식은 nav/base_index/deviation/tracking_error 없음)

--- a/ETF_RAG/src/data/realtime.py
+++ b/ETF_RAG/src/data/realtime.py
@@ -20,6 +20,30 @@ _cache: dict = {}
 # 티커 마켓 매핑 캐시: {krx_ticker: "KS" | "KQ"}
 _market_suffix_cache: dict = {}
 
+# DB instruments.market 맵 (lazy 1회 로드): {ticker: "KOSPI"|"KOSDAQ"}
+_db_market_map: Optional[dict] = None
+
+
+def _market_suffix_from_db(ticker: str) -> Optional[str]:
+    """DB 시장구분으로 정확한 yfinance suffix. 추측 없는 정공법(전 종목 동일 기준)."""
+    global _db_market_map
+    if _db_market_map is None:
+        try:
+            from src.data.database import get_connection, get_market_map, DB_PATH
+            conn = get_connection(DB_PATH)
+            try:
+                _db_market_map = get_market_map(conn)
+            finally:
+                conn.close()
+        except Exception:  # noqa: BLE001 — DB 없으면 빈 맵(아래 yfinance fallback)
+            _db_market_map = {}
+    mkt = _db_market_map.get(ticker, "")
+    if mkt == "KOSPI":
+        return "KS"
+    if mkt == "KOSDAQ":
+        return "KQ"
+    return None
+
 
 def is_market_open(now: Optional[datetime] = None) -> bool:
     """KST 기준 장 운영 시간 판단 (평일 09:00~15:30)"""
@@ -45,18 +69,38 @@ def krx_to_yfinance(ticker: str, asset_type: str = "etf") -> str:
         _market_suffix_cache[ticker] = "KS"
         return f"{ticker}.KS"
 
-    # 주식: KS 먼저 시도, 실패하면 KQ
+    # 주식: 1순위 DB 시장구분(정확, 전 종목 동일 기준). 없으면 yfinance 거래량 검증.
+    db_suffix = _market_suffix_from_db(ticker)
+    if db_suffix:
+        _market_suffix_cache[ticker] = db_suffix
+        return f"{ticker}.{db_suffix}"
+
+    # 2순위: KS/KQ 둘 다 확인 후 '거래량이 있는' 쪽 선택.
+    # ⚠️ 같은 6자리 코드가 KOSPI·KOSDAQ 양쪽에 last_price를 반환할 수 있어
+    # (예: 코스닥 039440 에스티아이를 .KS로 조회하면 엉뚱한 값+volume 0),
+    # last_price만 보면 잘못된 시장을 고른다 → 거래량(volume>0)까지 검증.
     try:
         import yfinance as yf
+        candidates = []  # (suffix, has_volume)
         for suffix in ("KS", "KQ"):
             yf_ticker = f"{ticker}.{suffix}"
             try:
                 info = yf.Ticker(yf_ticker).fast_info
-                if info and getattr(info, "last_price", None):
-                    _market_suffix_cache[ticker] = suffix
-                    return yf_ticker
+                if not info or not getattr(info, "last_price", None):
+                    continue
+                # last_volume만 본다 — ten_day_average_volume은 양 시장이 같은 값을
+                # 줘서(엉뚱한 시장도 통과) 변별력 없음. 당일 실거래(last_volume>0)가
+                # 있는 시장이 진짜 상장 시장.
+                vol = getattr(info, "last_volume", None)
+                candidates.append((suffix, bool(vol)))
             except Exception:
                 continue
+        # 거래량 있는 시장 우선, 없으면 last_price라도 있는 첫 시장
+        for want_vol in (True, False):
+            for suffix, has_vol in candidates:
+                if has_vol == want_vol:
+                    _market_suffix_cache[ticker] = suffix
+                    return f"{ticker}.{suffix}"
     except ImportError:
         logger.warning("yfinance 패키지가 설치되지 않았습니다.")
 

--- a/ETF_RAG/src/data/stock_collector.py
+++ b/ETF_RAG/src/data/stock_collector.py
@@ -276,8 +276,12 @@ def collect_all(date: str, market: str = "ALL", max_stocks: int = 0) -> dict:
     logger.info(f"주식 목록 수집 중... (기준일: {date}, 시장: {market})")
     markets = ["KOSPI", "KOSDAQ"] if market == "ALL" else [market]
     tickers = []
+    ticker_market = {}  # {ticker: "KOSPI"|"KOSDAQ"} — yfinance .KS/.KQ 정확 변환용
     for mkt in markets:
-        tickers.extend(stock.get_market_ticker_list(date, market=mkt))
+        mkt_tickers = stock.get_market_ticker_list(date, market=mkt)
+        tickers.extend(mkt_tickers)
+        for t in mkt_tickers:
+            ticker_market[t] = mkt
 
     name_map = {}
     for t in tickers:
@@ -315,6 +319,7 @@ def collect_all(date: str, market: str = "ALL", max_stocks: int = 0) -> dict:
             "name": name_map.get(ticker, ""),
             "date": date,
             "sector": bulk_sector.get(ticker, ""),
+            "market": ticker_market.get(ticker, ""),
             "ohlcv": ohlcv,
             "market_cap": cap.get("market_cap", 0),
             "shares_outstanding": cap.get("shares_outstanding", 0),

--- a/ETF_RAG/src/data/technical/_summary.py
+++ b/ETF_RAG/src/data/technical/_summary.py
@@ -80,13 +80,17 @@ def get_technical_summary(ticker: str, days: int = 250) -> Optional[dict]:
     obv = calc_obv(closes, volumes)
     atr = calc_atr(highs, lows, closes)
 
+    # 기간 시작점: 지표 계산용으로 fetch는 250일 이상 당기지만, '기간 대비 등락률'은
+    # 사용자가 고른 days 기준이어야 한다(아니면 6개월=1년 first_close가 같아짐).
+    # 최근 days개 중 첫 항목을 시작점으로(데이터가 days보다 적으면 가장 오래된 것).
+    period_start = ohlcv[-days] if len(ohlcv) >= days else ohlcv[0]
     return {
         "ticker": ticker,
         "date": latest["date"],
         "close": latest["close"],
-        "first_close": ohlcv[0]["close"],  # 조회 기간 첫 종가(기간 대비 등락률용)
+        "first_close": period_start["close"],  # 선택 기간 시작 종가(기간 대비 등락률용)
         "data_days": len(ohlcv),
-        "first_date": ohlcv[0]["date"],
+        "first_date": period_start["date"],
         "last_date": latest["date"],
         "ma": {
             "ma5": round(ma5) if ma5 else None,


### PR DESCRIPTION
## 심각 버그 2건 (사용자 발견)

### 1. 시세 오조회 — 다른 종목 가격 표시
- **에스티아이(코스닥 039440)가 30,750원으로 표시(실제 26,000원)**. 원인: `krx_to_yfinance`가 `.KS`(코스피)를 먼저 시도하고 `last_price`만 검증 → 같은 코드 코스피 종목(거래량 0)이 잡힘. 프로덕션은 KIS env 없어 yfinance fallback이라 노출.
- **근본 해결(사용자 요청 "모든 종목 동일 기준")**: `instruments.market`(KOSPI/KOSDAQ) 컬럼 추가(스키마+멱등 마이그레이션) → 수집 시 저장(ETF=KOSPI/주식=시장별) → `krx_to_yfinance`가 **DB market 우선** 사용(추측 제거).
- **fallback**: DB에 market 없는 종목은 yfinance `last_volume>0` 검증으로 `.KS/.KQ` 판별(`ten_day_average_volume`은 양 시장 동일값이라 변별력 없어 제외). 이중 안전망.
- `scripts/backfill_market.py`(기존 종목 백필, pykrx 재시도).

### 2. 기간 대비 등락률이 6개월=1년=3년 동일
- `first_close`/`first_date`가 지표계산용으로 fetch한 250일 기준이라 기간 무관 동일. → 사용자가 고른 `days` 기준(`ohlcv[-days]`)으로 분리.

## UX
- `PriceCard`에 **'현재 시세/최근 종가' 라벨** + **'전일 종가 대비(전일 N원)'** 명시.

## 테스트/검증
- 153 통과(realtime/technical/api_tabs). 에스티아이 → `039440.KQ`(26,100) 라이브 검증. 삼성전자 기간별 등락률 모두 다름 확인.
- ⚠️ KOSDAQ 백필은 pykrx 일시 빈응답으로 보류 — 일일수집 upsert + fallback이 자동 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)