### PR TITLE
feat(watchlist): 관심종목 종목명 표시

### DIFF
--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -201,6 +201,15 @@ class WatchlistResponse(BaseModel):
     tickers: List[str]
 
 
+class WatchlistDetailItem(BaseModel):
+    ticker: str
+    name: str  # 종목명(해석 실패 시 ticker로 fallback)
+
+
+class WatchlistDetailResponse(BaseModel):
+    items: List[WatchlistDetailItem]
+
+
 class ChatHistoryItemDB(BaseModel):
     role: Literal["user", "assistant"]
     content: str

--- a/ETF_RAG/api/user_data.py
+++ b/ETF_RAG/api/user_data.py
@@ -15,6 +15,8 @@ from api.models import (
     ChatHistoryAppend,
     ChatHistoryItemDB,
     ChatHistoryResponse,
+    WatchlistDetailItem,
+    WatchlistDetailResponse,
     WatchlistResponse,
 )
 from api.models_db import ChatHistory, User, Watchlist
@@ -34,6 +36,26 @@ def get_watchlist(
         .order_by(Watchlist.created_at)
     ).all()
     return WatchlistResponse(tickers=list(rows))
+
+
+@router.get("/watchlist/detail", response_model=WatchlistDetailResponse)
+def get_watchlist_detail(
+    user: User = Depends(get_current_user), db: Session = Depends(get_db)
+) -> WatchlistDetailResponse:
+    """관심종목 + 종목명 (관심 탭 가독성용). 종목명 해석 실패 시 ticker fallback."""
+    from src.llm.tools import _find_structured_data
+
+    rows = db.scalars(
+        select(Watchlist.ticker)
+        .where(Watchlist.user_id == user.id)
+        .order_by(Watchlist.created_at)
+    ).all()
+    items = []
+    for tk in rows:
+        data = _find_structured_data(tk)
+        name = (data.get("name") if data else None) or tk
+        items.append(WatchlistDetailItem(ticker=tk, name=name))
+    return WatchlistDetailResponse(items=items)
 
 
 @router.put("/watchlist/{ticker}", response_model=WatchlistResponse,

--- a/ETF_RAG/frontend/src/components/Sidebar.tsx
+++ b/ETF_RAG/frontend/src/components/Sidebar.tsx
@@ -6,10 +6,12 @@ import { getOverview, getVisitor, searchTickers } from "@/lib/api";
 import PushToggle from "@/components/PushToggle";
 import WatchlistStar from "@/components/WatchlistStar";
 import { useWatchlist } from "@/lib/useWatchlist";
+import { getWatchlistDetail } from "@/lib/auth";
 import type {
   InstrumentItem,
   OverviewResponse,
   VisitorResponse,
+  WatchlistDetailItem,
 } from "@/lib/types";
 
 // "삼성전자 (005930)" → {name, ticker}
@@ -110,6 +112,8 @@ export default function Sidebar({
   const [sectorStocks, setSectorStocks] = useState<InstrumentItem[] | null>(null);
   // 전체 종목 검색 결과 ("이름 (코드)" 문자열). 검색어 있을 때만 채움.
   const [searchHits, setSearchHits] = useState<string[]>([]);
+  // 관심종목 + 종목명 (관심 탭 표시용)
+  const [watchDetail, setWatchDetail] = useState<WatchlistDetailItem[]>([]);
 
   useEffect(() => {
     getOverview(20).then(setData);
@@ -152,6 +156,14 @@ export default function Sidebar({
     }, 250);
     return () => clearTimeout(timer);
   }, [q, tab]);
+
+  // 관심 탭 진입 또는 관심종목 변경 시 종목명 포함 상세 로드
+  useEffect(() => {
+    if (tab !== "watch" || !watch.enabled) {
+      return;
+    }
+    getWatchlistDetail().then(setWatchDetail);
+  }, [tab, watch.enabled, watch.tickers.length]);
 
   const stockList = sector ? sectorStocks ?? [] : data?.top_stocks ?? [];
   const list = data ? (tab === "etf" ? data.top_etfs : stockList) : [];
@@ -243,15 +255,18 @@ export default function Sidebar({
               관심종목이 없어요. ETF·주식 탭에서 ⭐로 추가하세요.
             </div>
           ) : (
-            watch.tickers.map((tk) => (
-              <SearchRow
-                key={tk}
-                name={tk}
-                ticker={tk}
-                onClick={() => goTicker(tk)}
-                showStar
-              />
-            ))
+            // 종목명 로드 전이면 ticker로, 로드 후엔 종목명 표시
+            (watchDetail.length ? watchDetail : watch.tickers.map((t) => ({ ticker: t, name: t }))).map(
+              (it) => (
+                <SearchRow
+                  key={it.ticker}
+                  name={it.name}
+                  ticker={it.ticker}
+                  onClick={() => goTicker(it.ticker)}
+                  showStar
+                />
+              ),
+            )
           )
         ) : q.trim() ? (
           searchHits.length === 0 ? (

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -158,6 +158,19 @@ export async function getWatchlist(): Promise<string[]> {
   return (data.tickers ?? []) as string[];
 }
 
+/** 관심종목 + 종목명 (관심 탭 가독성용). */
+export async function getWatchlistDetail(): Promise<
+  import("./types").WatchlistDetailItem[]
+> {
+  const res = await fetch(`${API_BASE}/me/watchlist/detail`, {
+    headers: authHeader(),
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.items ?? []) as import("./types").WatchlistDetailItem[];
+}
+
 export async function addWatchlist(ticker: string): Promise<string[]> {
   const res = await fetch(`${API_BASE}/me/watchlist/${ticker}`, {
     method: "PUT",

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -322,3 +322,8 @@ export interface PaperRound {
   trade_count: number;
   symbols: RoundSymbolPnl[];
 }
+
+export interface WatchlistDetailItem {
+  ticker: string;
+  name: string;
+}

--- a/ETF_RAG/tests/test_user_data.py
+++ b/ETF_RAG/tests/test_user_data.py
@@ -89,6 +89,26 @@ def test_watchlist_requires_auth(client):
     assert client.put("/me/watchlist/005930").status_code == 401
 
 
+def test_watchlist_detail_includes_name(client, auth):
+    from unittest.mock import patch
+    client.put("/me/watchlist/005930", headers=auth)
+    with patch("src.llm.tools._find_structured_data",
+               return_value={"ticker": "005930", "name": "삼성전자"}):
+        r = client.get("/me/watchlist/detail", headers=auth)
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert items == [{"ticker": "005930", "name": "삼성전자"}]
+
+
+def test_watchlist_detail_fallback_to_ticker(client, auth):
+    """종목명 해석 실패 시 ticker로 fallback."""
+    from unittest.mock import patch
+    client.put("/me/watchlist/999999", headers=auth)
+    with patch("src.llm.tools._find_structured_data", return_value=None):
+        r = client.get("/me/watchlist/detail", headers=auth)
+    assert r.json()["items"] == [{"ticker": "999999", "name": "999999"}]
+
+
 def test_watchlist_isolated_per_user(client):
     t1 = client.post("/auth/signup", json={"email": "a@b.com", "password": "pw123456"}).json()["access_token"]
     t2 = client.post("/auth/signup", json={"email": "b@b.com", "password": "pw123456"}).json()["access_token"]


### PR DESCRIPTION
## 변경 (사용자 요청)
관심 탭이 종목코드(티커)만 표시해 가독성이 낮던 것 → **종목명 표시 + 티커는 작게**.

- `GET /me/watchlist/detail` — ticker + 종목명(`_find_structured_data`, 해석 실패 시 ticker fallback). 기존 `/watchlist`(tickers)는 유지(useWatchlist 등 영향 없음).
- 사이드바 ⭐관심 탭: 종목명(+티커 작게) 표시. 로드 전이면 ticker로.
- `lib/auth.getWatchlistDetail` + `WatchlistDetailItem` 타입.
- 테스트 2개(종목명 포함 / ticker fallback). 전체 **835**, tsc 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)