### PR TITLE
feat(comparison): 비교 분석 1주/1개월/3개월 추가

### DIFF
--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -40,7 +40,7 @@ class VisitorResponse(BaseModel):
 
 class ComparisonRequest(BaseModel):
     tickers: List[str] = Field(..., min_length=2, max_length=2)
-    days: int = Field(120, ge=20, le=2500)
+    days: int = Field(120, ge=5, le=2500)  # 1주(5거래일)~10년
 
 
 # ── 인증 ────────────────────────────────────────────────

--- a/ETF_RAG/frontend/src/app/comparison/page.tsx
+++ b/ETF_RAG/frontend/src/app/comparison/page.tsx
@@ -13,8 +13,11 @@ import ChartImage from "@/components/ChartImage";
 import ComparisonTable from "@/components/ComparisonTable";
 import DataRangeNote from "@/components/DataRangeNote";
 
-// 상대 수익률 차트 기간 (기술 분석 탭과 동일 옵션)
+// 상대 수익률 차트 기간 (1주=5거래일, 1개월=20, 3개월=60 ...)
 const PERIODS: { label: string; days: number }[] = [
+  { label: "1주", days: 5 },
+  { label: "1개월", days: 20 },
+  { label: "3개월", days: 60 },
   { label: "6개월", days: 120 },
   { label: "1년", days: 250 },
   { label: "3년", days: 750 },


### PR DESCRIPTION
비교 분석 상대 수익률 기간에 1주(5거래일)/1개월(20)/3개월(60) 추가. ComparisonRequest days 하한 20→5. tsc·비교 테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)