### PR TITLE
fix(technical): 페이지 내 사이드바 종목 클릭 시 종목 안 바뀌던 버그

### DIFF
--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { getTechnical, getIntraday } from "@/lib/api";
 import type { TechnicalResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
@@ -29,7 +30,8 @@ function str(v: unknown): string {
   return v == null || v === "" ? "-" : String(v);
 }
 
-export default function TechnicalPage() {
+function TechnicalInner() {
+  const searchParams = useSearchParams();
   const [days, setDays] = useState(120);
   const [data, setData] = useState<TechnicalResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -75,15 +77,19 @@ export default function TechnicalPage() {
     }
   };
 
-  // 관심종목 칩 등에서 /technical?ticker=005930 로 진입 시 자동 조회 (mount 1회)
+  // 사이드바/관심종목에서 /technical?ticker=X 진입 시 자동 조회.
+  // useSearchParams로 쿼리 변화를 감지 — 이미 이 페이지에 있을 때 다른 종목을
+  // 클릭하면 URL만 바뀌고 리마운트가 안 돼(mount 1회 useEffect는 안 돎) 종목이
+  // 안 바뀌던 버그 수정.
+  const queryTicker = searchParams.get("ticker");
   useEffect(() => {
-    const t = new URLSearchParams(window.location.search).get("ticker");
-    if (t) {
-      setSelected({ name: t, ticker: t });
-      run(t, 120);
+    if (queryTicker) {
+      setSelected({ name: queryTicker, ticker: queryTicker });
+      run(queryTicker, 120);
+      setDays(120);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [queryTicker]);
 
   const onPeriod = (d: number) => {
     setDays(d);
@@ -274,6 +280,15 @@ export default function TechnicalPage() {
       </p>
       <DataRangeNote />
     </main>
+  );
+}
+
+// useSearchParams는 Suspense 경계 필요(Next.js CSR bailout) → 래핑.
+export default function TechnicalPage() {
+  return (
+    <Suspense fallback={<main className="mx-auto w-full max-w-3xl px-3 py-5" />}>
+      <TechnicalInner />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## 버그 (사용자 발견)
"왼쪽에서 주식 개별종목 클릭해도 안 넘어감". 정확히는 — **기술분석 페이지에 이미 있을 때** 사이드바/검색에서 다른 종목 클릭하면 안 바뀜.

## 원인
URL은 `?ticker=Y`로 바뀌지만 Next.js는 같은 페이지 내 쿼리 변경 시 리마운트 안 함. ticker를 읽는 `useEffect`가 **mount 1회**(`[]`)라 안 돌아 종목이 그대로.

## 수정
- `useSearchParams`로 ticker 쿼리 변화 감지 → 바뀌면 재조회(`[queryTicker]`).
- `useSearchParams`는 Suspense 경계 필요(Next CSR bailout) → 본문을 `TechnicalInner`로 분리하고 페이지를 `<Suspense>`로 래핑.
- **`next build` 통과** 확인(빌드 에러 없음), tsc 통과.

## 참고 (별개 이슈)
기술분석 기간 가격이 6개월=1년=3년 동일한 건 코드 아닌 **프로덕션 DB 과거 high/low 결측**(또는 yfinance fallback 1년 제한)으로 별도 조사 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)