### PR TITLE
fix(technical): 과거 high/low 결측으로 기간 분석 잘리던 버그

### DIFF
--- a/ETF_RAG/src/data/technical/_data.py
+++ b/ETF_RAG/src/data/technical/_data.py
@@ -170,17 +170,25 @@ def _get_ohlcv(ticker: str, days: int = 250,
 
     use_conn = conn if conn is not None else _get_db_conn()
 
+    # close>0만 필수. 과거 데이터(yfinance 백필 등)는 high/low가 0/null일 수 있어
+    # high>0 AND low>0으로 거르면 과거가 통째로 잘려 기간 분석이 1년치로 제한됐음.
+    # high/low가 없으면 close로 대체(종가만 있는 날의 자연스러운 OHLC 근사).
     rows = use_conn.execute("""
         SELECT date, open, high, low, close, volume FROM daily_prices
-        WHERE ticker = ? AND close > 0 AND high > 0 AND low > 0
+        WHERE ticker = ? AND close > 0
         ORDER BY date DESC
         LIMIT ?
     """, (ticker, days)).fetchall()
 
-    result = [
-        {"date": r["date"], "open": r["open"], "high": r["high"],
-         "low": r["low"], "close": r["close"], "volume": r["volume"]}
-        for r in reversed(rows)
-    ]
+    result = []
+    for r in reversed(rows):
+        close = r["close"]
+        high = r["high"] if r["high"] and r["high"] > 0 else close
+        low = r["low"] if r["low"] and r["low"] > 0 else close
+        opn = r["open"] if r["open"] and r["open"] > 0 else close
+        result.append({
+            "date": r["date"], "open": opn, "high": high,
+            "low": low, "close": close, "volume": r["volume"] or 0,
+        })
     _ohlcv_cache_put(ticker, days, result)
     return result


### PR DESCRIPTION
## 버그 (#2 근본 원인)
기술분석 기간 가격이 6개월=1년=3년 동일. 코드(#77 ohlcv[-days])는 맞으나 **`_get_ohlcv`가 `WHERE high>0 AND low>0`로 걸러** 과거 high/low 결측분(yfinance 백필 등)이 통째로 잘려 **최근 1년치만** 남던 게 원인. (섹터 추이 차트는 close만 봐서 5년 정상 → DB 깊이 자체는 있었음.)

## 수정
- 필터를 **`close>0`만**으로 완화. `high`/`low`/`open`이 없으면 **close로 대체**(종가만 있는 날의 자연스러운 OHLC 근사). MA/RSI/MACD는 close 기반이라 무영향, 봉장차트만 일부.
- 로컬 검증: days=750→data_days 750, days=2500→2500. 기간별 first_close 모두 다름.
- 테스트 technical 92 / 전체 **835** 통과.

프로덕션은 결측분이 많아 효과가 더 큼(재배포 후 6개월/1년/3년 구분).

## 후속(B)
Release `db-latest`의 과거 high/low가 실제 비었는지는 별도 점검(완전 해결). 본 PR(A)로 표시 문제는 즉시 해소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)