### PR TITLE
fix(db): 얕은 DB(1년치) 감지 시 full Release 재다운로드

### DIFF
--- a/ETF_RAG/src/data/db_downloader.py
+++ b/ETF_RAG/src/data/db_downloader.py
@@ -43,19 +43,45 @@ def _is_valid_sqlite(db_path: Path) -> bool:
         return False
 
 
+# full DB(2014~, ~880만행)의 깊이 하한. 이보다 적으면 '얕은 DB'로 보고 재다운로드.
+# 일일수집만으로 빈 DB에 쌓인 1년치(~105만행)를 잡아 full Release로 교체하기 위함.
+# (full이 본 프로젝트 강점인 12년 시계열·재무제표를 담음 — 얕은 DB면 기간분석 불가)
+_MIN_FULL_ROWS = 3_000_000
+
+
+def _is_full_depth(db_path: Path) -> bool:
+    """daily_prices 행수가 full DB 수준인지(얕은 1년치 DB 감지)."""
+    import sqlite3
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            cnt = con.execute("SELECT COUNT(*) FROM daily_prices").fetchone()[0]
+            return cnt >= _MIN_FULL_ROWS
+        finally:
+            con.close()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def ensure_db(db_path: Path) -> bool:
     """DB가 없으면 GitHub Release에서 다운로드. 성공 시 True, 실패/스킵 시 False.
 
-    이미 존재하더라도 무결성을 검사해 손상 파일(malformed)이면 지우고 재다운로드한다
-    — 과거 다운로드/해제 중단으로 깨진 파일이 남아 매 부팅 재사용되던 문제 방지.
+    이미 존재하더라도 (1) 무결성 검사 — 손상(malformed)이면 재다운로드,
+    (2) 깊이 검사 — 일일수집만으로 쌓인 얕은 1년치 DB면 full Release로 교체.
     """
     if db_path.exists():
         if _is_valid_sqlite(db_path):
-            size_mb = db_path.stat().st_size / (1024 * 1024)
-            logger.info(f"DB 이미 존재(무결성 OK): {db_path} ({size_mb:.0f}MB)")
-            return True
-        logger.warning("기존 DB 손상 감지 — 삭제 후 재다운로드")
-        db_path.unlink(missing_ok=True)
+            if _is_full_depth(db_path):
+                size_mb = db_path.stat().st_size / (1024 * 1024)
+                logger.info(f"DB 이미 존재(무결성·깊이 OK): {db_path} ({size_mb:.0f}MB)")
+                return True
+            logger.warning(
+                "기존 DB가 얕음(full 미만, 일일수집 누적 추정) — full Release로 교체"
+            )
+            db_path.unlink(missing_ok=True)
+        else:
+            logger.warning("기존 DB 손상 감지 — 삭제 후 재다운로드")
+            db_path.unlink(missing_ok=True)
 
     logger.info("DB 없음 — GitHub Release에서 다운로드 시작")
     zst_path = db_path.parent / "etf_rag.db.zst"

--- a/ETF_RAG/tests/test_db_downloader.py
+++ b/ETF_RAG/tests/test_db_downloader.py
@@ -52,8 +52,8 @@ def test_valid_sqlite_without_daily_prices_fails(tmp_path):
     assert _is_valid_sqlite(db) is False
 
 
-def test_ensure_db_skips_when_valid_exists(tmp_path, monkeypatch):
-    """이미 정상 DB가 있으면 다운로드 없이 True."""
+def test_ensure_db_skips_when_valid_and_deep(tmp_path, monkeypatch):
+    """유효 + 깊이 충분(full)이면 다운로드 없이 True."""
     db = tmp_path / "etf_rag.db"
     _make_valid_db(db)
 
@@ -63,8 +63,36 @@ def test_ensure_db_skips_when_valid_exists(tmp_path, monkeypatch):
         called["download"] = True
 
     monkeypatch.setattr("src.data.db_downloader._download", _fake_download)
+    monkeypatch.setattr("src.data.db_downloader._is_full_depth", lambda p: True)
     assert ensure_db(db) is True
     assert called["download"] is False  # 재다운로드 안 함
+
+
+def test_ensure_db_redownloads_when_shallow(tmp_path, monkeypatch):
+    """유효하나 얕은 DB(일일수집 1년치)면 full Release로 재다운로드."""
+    db = tmp_path / "etf_rag.db"
+    _make_valid_db(db)  # 유효하지만 행수 적음 → _is_full_depth False
+
+    attempted = {"download": False}
+
+    def _fake_download(url, dest):
+        attempted["download"] = True
+        raise IOError("network down")  # 다운로드 분기 진입만 확인
+
+    monkeypatch.setattr("src.data.db_downloader._download", _fake_download)
+    # 실제 _is_full_depth로 검증(소수 행 DB는 얕음 판정)
+    result = ensure_db(db)
+    assert attempted["download"] is True  # 얕음 감지 → full 재다운로드 시도
+    assert result is False  # 다운로드 실패 → fallback
+    assert not db.exists()  # 얕은 DB 삭제됨
+
+
+def test_is_full_depth(tmp_path):
+    """행수 임계 미만이면 얕음(False)."""
+    from src.data.db_downloader import _is_full_depth
+    db = tmp_path / "shallow.db"
+    _make_valid_db(db)  # 1행
+    assert _is_full_depth(db) is False  # _MIN_FULL_ROWS 미만
 
 
 def test_ensure_db_redownloads_when_corrupt(tmp_path, monkeypatch):


### PR DESCRIPTION
## 근본 원인 (#2 진짜 원인)
기술분석 6개월=1년=3년 가격 동일 + 모든 종목 `first_date=20250613` 동일. 조사 결과 **프로덕션 daily_prices에 종목당 ~250일(1년)치만** 존재(로컬은 3062행 2014~). **full DB(2014~, 880만행)를 못 받고 일일수집이 빈 DB에 쌓은 1년치로 동작** — 이 프로젝트 핵심 강점(12년 시계열·재무제표)이 프로덕션에서 죽어 있었음.

`ensure_db`가 'DB 파일 존재'만 보고 스킵 → 일일수집이 만든 얕은 DB가 있으면 full을 영영 안 받던 게 원인.

## 수정
- `_is_full_depth()`: daily_prices 행수 < `_MIN_FULL_ROWS`(300만)면 얕음(full=880만/1년치≈105만).
- `ensure_db`: 유효하되 얕으면 삭제 후 **full Release 재다운로드**.
- 테스트 +2. 전체 **837**.

## 배포 후
사용자가 백엔드 재배포하면 ensure_db가 얕은 DB 감지 → full(1.7GB) 다운로드(3~5분) → 기간 가격/그래프 정상.

⚠️ **영구 볼륨 없으면 재배포마다 1.7GB 재다운로드** — DEPLOY.md 영속볼륨 설정 권장(후속, 콜드스타트 제거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)