### PR TITLE
fix(technical): days 미전달로 기간 무관 250일 고정 버그 (진짜 원인)

### DIFF
--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -94,7 +94,7 @@ def _technical_blocking(query: str, days: int) -> Optional[dict]:
         return None
     ticker = data.get("ticker") or query
     name = data.get("name") or query
-    summary = get_technical_summary(ticker)
+    summary = get_technical_summary(ticker, days=days)  # days 전달(미전달 시 항상 250 고정 버그)
     if summary is None:
         return None
     return {

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -45,6 +45,20 @@ def test_technical_returns_summary_and_chart(client):
     assert body["chart_b64"] == "BASE64PNG"
 
 
+def test_technical_passes_days_to_summary(client):
+    """days가 get_technical_summary에 그대로 전달돼야 한다.
+    (미전달 시 기본 250 고정 → 6개월=1년=3년 동일해지던 버그 회귀 방지)."""
+    structured = {"ticker": "005930", "name": "삼성전자"}
+    with patch("api.tabs._find_structured_data", return_value=structured), patch(
+        "api.tabs.get_technical_summary", return_value={"close": 70000}
+    ) as m, patch("api.tabs.generate_technical_chart", return_value="X"):
+        client.get("/tabs/technical", params={"ticker": "삼성전자", "days": 2500})
+    # get_technical_summary(ticker, days=2500)로 호출됐는지
+    assert m.call_args.kwargs.get("days") == 2500 or (
+        len(m.call_args.args) > 1 and m.call_args.args[1] == 2500
+    )
+
+
 def test_technical_404_when_unresolved(client):
     with patch("api.tabs._find_structured_data", return_value=None):
         r = client.get("/tabs/technical", params={"ticker": "ZZZ"})


### PR DESCRIPTION
## 진짜 원인 (#2 최종)
기술분석 6개월=1년=3년 가격 동일 — **`_technical_blocking`이 `get_technical_summary(ticker)`로 호출해 days를 안 넘김**. summary가 항상 기본값 `days=250`으로 계산돼 모든 기간이 1년치로 고정.

#77(ohlcv[-days])·#81(필터완화)·#82(DB깊이)는 다 정상이었으나 **이 호출부 한 줄이 days를 버려서** 전부 무용지물이었음.

## 진단 (Console로 프로덕션 직접 확인)
- DB: 880만행, 2014~, 1.8GB **정상** (얕은 DB 아니었음)
- `_get_ohlcv('005930', 2500)`: 2500행 반환 **정상**
- 그런데 API: 250 → **호출부 days 누락**이 범인

## 수정
- `get_technical_summary(ticker, days=days)`
- 회귀 테스트: days 전달 검증(기존 mock 테스트는 못 잡던 사각). 전체 **838**.

배포 후 6개월/1년/3년/5년/10년 각각 다른 시작가·등락률·그래프.

🤖 Generated with [Claude Code](https://claude.com/claude-code)