### PR TITLE
feat(deploy): 영속 볼륨 지원 (ETF_DATA_DIR)

### DIFF
--- a/ETF_RAG/DEPLOY.md
+++ b/ETF_RAG/DEPLOY.md
@@ -51,18 +51,20 @@ HTTP로만 결합된 **독립 2서비스**다. 기존 Streamlit 앱은 그대로
 
 프론트 URL 열기 → health 게이트 통과 확인 → 채팅 한 번 → 데이터 탭(기술/재무/섹터) 확인.
 
-## 영속(권장 후속) — DB/FAISS 콜드스타트 제거
+## 영속 볼륨 — DB/FAISS 콜드스타트 제거 (코드 구현 완료)
 
-현재 영속 볼륨 **미구현**. 그대로 두면 컨테이너 재생성(콜드스타트)마다 DB 재다운로드(3~5분) +
-FAISS 재임베딩(~90s, ~$0.005). 한 번 띄우면 유지되지만, 재배포 때마다 반복.
+영속 볼륨이 없으면 재배포(콜드스타트)마다 DB 재다운로드(3~5분, 1.8GB) + FAISS
+재임베딩(~90s)이 반복된다. **코드는 `ETF_DATA_DIR` 환경변수를 지원**하도록 구현됨:
+- `config.PERSIST_DIR = ETF_DATA_DIR`(미설정 시 기존 `src/data`) → DB_PATH·FAISS·BM25
+  캐시가 모두 이 경로 기준(`_schema.py`/`api/deps.py`/`vectorstore.py`/`retriever.py` 통일).
+- 미설정 시 동작 무변경(로컬·기존 배포 안전).
 
-**권장 후속 편집** (별도 작업):
-1. `config.py`: `DATA_DIR`를 `ETF_DATA_DIR` 환경변수로 오버라이드 가능하게.
-   (DB_PATH, FAISS/BM25 캐시 경로가 DATA_DIR 기준이 되도록 — vectorstore/retriever도 확인.)
-2. `api/deps.py`: 하드코딩된 `_DB_PATH`도 `ETF_DATA_DIR` 반영.
-3. Railway: 볼륨을 **`/data`에 마운트**(❌ `src/data` 금지 — 소스 패키지/`deploy/` fallback을 가림),
-   `ETF_DATA_DIR=/data` 설정.
-→ DB와 FAISS가 `/data`에 영속되어 콜드스타트 1회로 끝남.
+**Railway 설정 (사용자 1회):**
+1. `etf-backend`(AI_agent) 서비스 → 우클릭/메뉴 → **Add Volume**
+2. Mount path = **`/data`** (❌ `/app/src/data` 금지 — 소스 패키지/deploy fallback을 가림)
+3. Variables에 **`ETF_DATA_DIR=/data`** 추가 → 재배포
+→ 첫 부팅에 DB가 `/data`에 1회 저장되고, 이후 재배포는 그걸 재사용해 즉시 부팅.
+   (deploy/ JSON·하드코딩 샘플은 소스(`src/data`)에 그대로 — 볼륨과 분리.)
 
 ## Render 대안 (비권장)
 

--- a/ETF_RAG/api/deps.py
+++ b/ETF_RAG/api/deps.py
@@ -9,7 +9,6 @@ run_agent/stream_agent가 투명하게 읽는다. AppState에는 init 상태만 
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional
 
 from fastapi import HTTPException, Request
@@ -28,8 +27,9 @@ from src.llm.tools import set_retriever
 
 logger = logging.getLogger(__name__)
 
-# ETF_RAG/src/data/etf_rag.db (app.py의 download_db와 동일 경로)
-_DB_PATH = Path(__file__).resolve().parent.parent / "src" / "data" / "etf_rag.db"
+# DB 경로는 config.DB_PATH 단일 출처 사용(ETF_DATA_DIR 볼륨 반영). 과거 하드코딩은
+# config·_schema와 어긋날 수 있어 통일.
+from config import DB_PATH as _DB_PATH  # noqa: E402
 
 
 @dataclass

--- a/ETF_RAG/config.py
+++ b/ETF_RAG/config.py
@@ -15,11 +15,18 @@ def is_langsmith_enabled() -> bool:
     )
 
 # Data paths
+# DATA_DIR: 소스 동봉 데이터(git 추적) — deploy/ JSON, 하드코딩 샘플. 항상 소스 경로.
 DATA_DIR = PROJECT_ROOT / "src" / "data"
 ETF_DATA_PATH = DATA_DIR / "etf_data.json"  # 하드코딩 샘플 (fallback)
 COLLECTED_DIR = DATA_DIR / "collected"       # 수집 데이터 디렉토리
 DEPLOY_DIR = DATA_DIR / "deploy"             # 배포용 데이터 (Git 추적)
-DB_PATH = DATA_DIR / "etf_rag.db"           # SQLite 데이터베이스 (주가 데이터, read-only)
+
+# PERSIST_DIR: 재배포에도 살아남아야 하는 대용량 산출물(DB·FAISS·BM25 캐시).
+# ETF_DATA_DIR 환경변수(예: Railway 볼륨 /data)로 오버라이드 → 콜드스타트 제거.
+# 미설정 시 기존 동작(소스 내 src/data)과 동일 — 로컬/기존 배포 무영향.
+PERSIST_DIR = Path(os.getenv("ETF_DATA_DIR", str(DATA_DIR)))
+PERSIST_DIR.mkdir(parents=True, exist_ok=True)
+DB_PATH = PERSIST_DIR / "etf_rag.db"        # SQLite (주가 데이터). 볼륨에 영속.
 LOG_DIR = PROJECT_ROOT / "logs"
 
 # --- 인증 / 사용자 DB (Phase F-1 잔여) -------------------------------

--- a/ETF_RAG/src/data/database/_schema.py
+++ b/ETF_RAG/src/data/database/_schema.py
@@ -3,12 +3,17 @@ DB 스키마 + 초기화 — 테이블 정의, 연결, 마이그레이션
 """
 
 import logging
+import os
 import sqlite3
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-DB_PATH = Path(__file__).resolve().parent.parent / "etf_rag.db"
+# DB는 영속 볼륨(ETF_DATA_DIR, 예: Railway /data)에 두어 재배포 시 재다운로드를
+# 피한다. 미설정 시 기존 경로(src/data)와 동일 — config.PERSIST_DIR와 같은 규칙.
+# (config 직접 import는 순환 위험이라 env를 직접 읽어 동일 로직 유지.)
+_DEFAULT_DATA_DIR = Path(__file__).resolve().parent.parent  # src/data
+DB_PATH = Path(os.getenv("ETF_DATA_DIR", str(_DEFAULT_DATA_DIR))) / "etf_rag.db"
 
 _SCHEMA_SQL = """
 -- 종목 마스터 (ETF + 주식)

--- a/ETF_RAG/src/rag/retriever.py
+++ b/ETF_RAG/src/rag/retriever.py
@@ -22,7 +22,7 @@ from rank_bm25 import BM25Okapi
 from langchain_core.documents import Document
 from langchain_community.vectorstores import FAISS
 
-from config import SIMILARITY_THRESHOLD, TOP_K_RESULTS, HYBRID_SEARCH, RERANK, COHERE_API_KEY, DATA_DIR
+from config import SIMILARITY_THRESHOLD, TOP_K_RESULTS, HYBRID_SEARCH, RERANK, COHERE_API_KEY, PERSIST_DIR
 from src.rag.utils import compute_docs_hash as _compute_docs_hash
 
 logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ def tokenize_korean(text: str) -> List[str]:
 
 
 # BM25 캐시 디렉토리
-BM25_CACHE_DIR = DATA_DIR / "bm25_cache"
+BM25_CACHE_DIR = PERSIST_DIR / "bm25_cache"
 
 
 def _load_bm25_cache(docs_hash: str) -> Optional[Tuple[BM25Okapi, List[List[str]]]]:

--- a/ETF_RAG/src/rag/vectorstore.py
+++ b/ETF_RAG/src/rag/vectorstore.py
@@ -15,15 +15,15 @@ from langchain_openai import OpenAIEmbeddings
 from langchain_community.vectorstores import FAISS
 
 from config import (
-    EMBEDDING_MODEL, DATA_DIR,
+    EMBEDDING_MODEL, PERSIST_DIR,
     VECTOR_DB_BACKEND, PINECONE_API_KEY, PINECONE_INDEX_NAME,
 )
 from src.rag.utils import compute_docs_hash as _compute_docs_hash
 
 logger = logging.getLogger(__name__)
 
-# FAISS 인덱스 저장 디렉토리
-FAISS_INDEX_DIR = DATA_DIR / "faiss_index"
+# FAISS 인덱스 저장 디렉토리 — 영속 볼륨(PERSIST_DIR)에 두면 콜드스타트 재임베딩 제거.
+FAISS_INDEX_DIR = PERSIST_DIR / "faiss_index"
 
 
 def get_embeddings() -> OpenAIEmbeddings:


### PR DESCRIPTION
## 목적
재배포(콜드스타트)마다 DB 1.8GB 재다운로드 + FAISS 재임베딩(~90s)이 반복되던 것을 영속 볼륨으로 제거. #67·#82·#83에서 드러난 콜드스타트 계열의 근본 완화.

## 코드
- `config.PERSIST_DIR = os.getenv("ETF_DATA_DIR", src/data)` → `DB_PATH`·`FAISS_INDEX_DIR`·`BM25_CACHE_DIR` 전부 이 경로 기준 통일.
- `_schema.py DB_PATH`·`api/deps._DB_PATH`도 동일(과거 3곳 독립 하드코딩 통일. `_schema`는 순환 회피로 env 직접 read).
- `deploy/` JSON·하드코딩 샘플은 **소스(src/data) 유지**(볼륨과 분리 — 볼륨이 소스 패키지를 가리지 않게).
- **미설정 시 동작 무변경**(로컬·기존 배포 안전). 전체 **838** 통과. env override 라이브 검증.

## Railway 설정 (사용자 1회)
1. 백엔드(AI_agent) → Add Volume, Mount path **`/data`** (❌ /app/src/data 금지)
2. Variables에 **`ETF_DATA_DIR=/data`** → 재배포
→ 첫 부팅 1회만 DB 다운로드, 이후 재배포는 즉시 부팅. DEPLOY.md 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)