### PR TITLE
fix(auth): 회원 탈퇴 시 가상투자 데이터 cascade 삭제 누락 수정

### DIFF
--- a/ETF_RAG/api/auth.py
+++ b/ETF_RAG/api/auth.py
@@ -26,7 +26,17 @@ from api.models import (
     TokenResponse,
     UserResponse,
 )
-from api.models_db import ChatHistory, PushSubscription, User, Watchlist
+from api.models_db import (
+    ChatHistory,
+    PaperAccount,
+    PaperHolding,
+    PaperRound,
+    PaperSnapshot,
+    PaperTrade,
+    PushSubscription,
+    User,
+    Watchlist,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -165,6 +175,12 @@ def delete_account(
     db.execute(delete(Watchlist).where(Watchlist.user_id == uid))
     db.execute(delete(ChatHistory).where(ChatHistory.user_id == uid))
     db.execute(delete(PushSubscription).where(PushSubscription.user_id == uid))
+    # 가상투자(Phase F #69~71) — user_id FK를 가지나 모델 cascade 미설정이므로 명시 삭제.
+    db.execute(delete(PaperTrade).where(PaperTrade.user_id == uid))
+    db.execute(delete(PaperHolding).where(PaperHolding.user_id == uid))
+    db.execute(delete(PaperSnapshot).where(PaperSnapshot.user_id == uid))
+    db.execute(delete(PaperRound).where(PaperRound.user_id == uid))
+    db.execute(delete(PaperAccount).where(PaperAccount.user_id == uid))
     db.delete(user)
     db.commit()
 

--- a/ETF_RAG/tests/test_auth.py
+++ b/ETF_RAG/tests/test_auth.py
@@ -249,3 +249,30 @@ def test_delete_account_purges_watchlist(client):
 def test_delete_account_requires_auth_401(client):
     r = client.request("DELETE", "/auth/me", json={"password": "pw123456"})
     assert r.status_code == 401
+
+
+def test_delete_account_purges_paper_trading(client):
+    """탈퇴 시 가상투자(PaperAccount/Holding/Trade/...) 데이터도 소거되어야 한다.
+
+    회귀: 탈퇴 cascade에 Watchlist/ChatHistory/Push만 있고 Paper* 5개가 누락돼
+    탈퇴 후 재가입 시 옛 보유종목/평가액이 남던 버그(2026-06-24 발견)."""
+    from unittest.mock import patch
+
+    token = _token(client)
+    with patch("api.paper._resolve_price",
+               return_value={"ticker": "005930", "name": "삼성전자", "price": 70000}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 10},
+                    headers=_auth(token))
+        pf = client.get("/me/paper/portfolio", headers=_auth(token)).json()
+    assert any(h["ticker"] == "005930" for h in pf["holdings"])
+
+    # 탈퇴
+    assert client.request(
+        "DELETE", "/auth/me", json={"password": "pw123456"}, headers=_auth(token)
+    ).status_code == 204
+
+    # 같은 이메일 재가입 → 가상투자가 1억 새 계좌로 초기화(이전 보유종목 없음)
+    token2 = _token(client)
+    pf2 = client.get("/me/paper/portfolio", headers=_auth(token2)).json()
+    assert pf2["holdings"] == []
+    assert pf2["cash"] == 100_000_000


### PR DESCRIPTION
## 버그
프로덕션 점검 중 발견. `DELETE /auth/me`(회원 탈퇴)가 연관 데이터 중 Watchlist/ChatHistory/PushSubscription 3개만 삭제하고, 나중에 추가된 가상투자(#69~71) 5개 테이블을 cascade 목록에서 누락.

→ 탈퇴해도 PaperAccount/Holding/Trade/Snapshot/Round가 DB에 고아로 남고, 같은 이메일로 재가입 시 옛 보유종목/평가액이 그대로 노출됨.

## 수정
- `auth.py`: 탈퇴 시 Paper* 5개 테이블 명시 삭제 추가 (모델에 FK cascade 미설정이라 기존 패턴대로 명시 삭제)
- 회귀 테스트: 매수 → 탈퇴 → 같은 이메일 재가입 시 `holdings == []`, `cash == 1억` 검증
- 테스트 auth+paper 44개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
