### PR TITLE
chore(scripts): 프로덕션 env 진단 스크립트 (KIS/VAPID/CRON)

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2497,11 +2497,25 @@ PR #57 이후 머지된 변경(F-3 로컬 감성 #58 + RAG 품질 #61 + sector �
 ### Railway 유료 전환 완료 (2026-06-24, 사용자)
 trial($5 일회성) → **Hobby $5/월**(종량제, $5 포함+초과청구). 사용량 상한: **Compute Hard $15**(자동정지=폭주방어)/Email $8. **서비스 영구 유지**(친구 URL 계속 동작)+유저DB Postgres 영구보존. ⚠️백엔드 메모리 커서 $5 초과 가능 → Usage 탭 Current Usage 모니터링 권장. 라이브: 프론트 radiant-abundance-production-bdf0 / 백엔드 aiagent-production-75ca.
 
-### 다음
-- 후원("해줘" 시, BMC+토스 안내) → 블로그 9편 / 메일 인프라(비번찾기)
+### 프로덕션 점검 + 코드 점검 라운드 (2026-06-25)
+**① 프로덕션 라이브 점검 — 전부 정상.** 백엔드 health `ready:true`. **full DB 안착 확인**(삼성전자 /tabs/technical days=2500 → data_days=2500, first_date 2016-04-11, last_date 2026-06-23 — 영속볼륨 #84 살아있고 기간가격 버그 해결). 실시간시세 장외 종가 fallback 정상. **유저DB Postgres 영구화 라이브 검증**(curl 회원가입201→로그인→me200→탈퇴204→재로그인401, 테스트 계정 정리).
+
+**② 실버그 1건 발견·수정 (PR #86 머지).** 점검 중 `DELETE /auth/me`(회원 탈퇴)가 연관 데이터 중 Watchlist/ChatHistory/PushSubscription 3개만 삭제하고 **나중에 추가된 가상투자(#69~71) 5개 테이블(PaperAccount/Holding/Trade/Snapshot/Round)을 cascade 목록에서 누락** → 탈퇴 후 같은 이메일 재가입 시 옛 보유종목/평가액이 고아로 남던 버그. auth.py에 Paper* 5개 명시 삭제 추가 + 회귀 테스트(매수→탈퇴→재가입 시 holdings=[], cash=1억). 모델에 FK cascade 미설정이라 기존 패턴(명시 삭제)대로. **교훈: 유저 연관 테이블을 나중에 추가할 때 탈퇴 cascade 목록 갱신 필수.**
+
+**③ 코드 점검 라운드 — Explore 3개 병렬(가상투자/시세·시장구분/DB·볼륨·마이그레이션).** 에이전트가 "진짜 버그" 8건 보고 → **6-04 LLM 오판 교훈대로 직접 코드 재검증 → 치명 버그 0건.** 기각 내역:
+  - 매수/캐시/다층TTL 동시성 race 3건 → **단일 워커 전용**(Dockerfile CMD에 --workers 없음, 주석 "단일 워커 전용: set_retriever 프로세스 전역") → 발생 불가.
+  - `_migrate` commit 누락 → SQLite DDL 자동 커밋 + 조건부 멱등(if not in cols) + test_database 멱등 테스트 통과 → 기각.
+  - market trailing space → market은 하드코딩 리터럴 `["KOSPI","KOSDAQ"]`이라 구조적 불가 → 기각.
+  - yfinance candidates 빈 경우 .KS 고착 → last_volume>0 우선 로직 정상, 0원/None 방어됨 → 기각.
+  - **경미 개선 1건 채택**: `realtime._market_suffix_from_db`의 `_db_market_map`이 첫 로드 실패 시 `{}`로 영구 고착(`if _db_market_map is None` → `if not _db_market_map`로 변경, 영속볼륨 환경서 DB 늦게 준비될 때 시장구분 영구 누락 방지). **✅ PR #87 머지 완료**(2026-06-25): 수정 + `_market_suffix_from_db` 테스트 7개(매핑/1회로드/빈맵 재시도 회귀/예외 후 재시도) + 기존 krx_to_yfinance fallback 테스트 4개에 `_market_suffix_from_db` None patch 추가(로컬 DB가 yfinance fallback 경로를 가리던 사전 존재 격리 결함 보강). 전체 845 통과.
+  - Content-Length 누락 시 부분다운로드 미감지 → 이후 quick_check가 잡으므로 스킵.
+
+### 다음 (사용자 지시 2026-06-25: 후원/블로그는 요청 시까지 보류, 개발 우선)
+- ToDo 1~10 순차 진행 중: ①doc정리 ②MEMORY 다이어트 ③KIS env ④푸시/스냅샷 env ⑤KOSDAQ 백필 ⑥F-3 로컬감성 실배포 ⑦관심종목⭐ 확대 ⑧가상투자 고도화 ⑨RAGAS 잔존 ⑩코드점검(#69~#86)
 
 ---
 
-_Last Updated: 2026-06-24 (✅영속볼륨 적용·검증 완료 #84 — Railway 볼륨/data+ETF_DATA_DIR 설정 후 full DB(1.8GB) 안착, 콜드스타트 제거. 기간가격 정상(days=120/750/2500 다 다름). 직전: #2 days미전달 #83 + 종목클릭 #80 + 비교단기 #79 + 시세정확성 #77 + 가상투자 #69~71. 전체 838. 다음: 후원/블로그9편)_
+_Last Updated: 2026-06-25 (프로덕션 라이브 점검 전부 정상 + 코드 점검 라운드: 탈퇴 가상투자 cascade 누락 실버그 #86 수정 + realtime db_market_map 재시도 #87 머지(테스트 7개). 에이전트 보고 8건 중 7건 LLM 오판/단일워커로 기각. 전체 845. 사용자 지시로 후원/블로그 보류, ToDo 1~10 순차 개발 착수)_
+_2026-06-24 (✅영속볼륨 적용·검증 완료 #84 — Railway 볼륨/data+ETF_DATA_DIR 설정 후 full DB(1.8GB) 안착, 콜드스타트 제거. 기간가격 정상(days=120/750/2500 다 다름). 직전: #2 days미전달 #83 + 종목클릭 #80 + 비교단기 #79 + 시세정확성 #77 + 가상투자 #69~71. 전체 838. 다음: 후원/블로그9편)_
 _2026-06-16 (PR #50~#54 KIS + 모바일드로워 #51 + 웹푸시 #55·#56 + 코드점검 #57 + F-3 로컬감성 #58). 테스트 766_
 _운영 장애 2건 회복 + 데이터 완전성 복구 + 외부 공개 자료 완성 (2026-06-01) → Phase F SaaS 전환 착수 (2026-06-08)_

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -541,10 +541,12 @@ ETF_RAG/
 
 ---
 
-_Last Updated: 2026-06-24 (✅영속볼륨 적용·검증 완료 #84 — Railway 볼륨/data+ETF_DATA_DIR 설정 후 full DB(1.8GB) 안착, 콜드스타트 제거. 기간가격 정상(days=120/750/2500 다 다름). 직전: #2 days미전달 #83 + 종목클릭 #80 + 비교단기 #79 + 시세정확성 #77 + 가상투자 #69~71. 전체 838. 다음: 후원/블로그9편)_
+_Last Updated: 2026-06-25 (프로덕션 점검 + 코드 점검 라운드 — 탈퇴 가상투자 cascade #86 + realtime db_market_map 재시도 #87. 전체 845. 사용자 지시로 후원/블로그 보류, ToDo 1~10 순차 개발 착수. 직전: ✅영속볼륨 #84, 기간가격 #79~83, 시세정확성 #77, 가상투자 #69~71)_
 
 > ✅ **CI 액션 Node 24 대응 완료** (2026-06-08): `checkout@v4→v6`, `setup-python@v5→v6` (ci.yml + daily-collect.yml 4곳). CI green 확인. 2026-06-16 Node 24 강제 전환 대비.
 
 > 🔬 **임베딩 A/B 실험 (small 유지 결정, 2026-06-08)**: `eval/exp_embedding_ab.py` — `text-embedding-3-small`(현행) vs `-3-large` 격리 비교. **full 파이프라인은 둘 다 100%**(직접매칭+BM25+Rerank가 천장), 순수 dense-only로 격리하면 large가 Hit@1 0.45→0.79(+0.33)·MRR 0.47→0.80로 압도하나 인덱싱 5.6배 느림(19s→106s)·비용 2배. **결론: small 유지** — 하이브리드 검색 덕에 실서비스 체감 개선 0. PDF 투자설명서 등 비정형 문서 확대로 dense 의존도가 커지면 large 재검토.
 
 > 🚀 **Phase F 착수 — F-1 백엔드 골격 (2026-06-08)**: `api/` 패키지 (FastAPI). `/health`·`/chat`·`/stream`(SSE)으로 기존 agent를 Streamlit 없이 노출. 동기 `run_agent`/`stream_agent`는 threadpool 경유, init은 `app.py:init_all()`을 데코레이터 없이 복제(`api/deps.py`). 테스트 **655개**(+6). 단일 워커 전용. Streamlit 앱과 병행. 상세: CLAUDE.local.md.
+
+> 🩺 **프로덕션 점검 + 코드 점검 라운드 (2026-06-25)**: 라이브 점검 전부 정상(full DB 안착 days=2500, 유저DB Postgres 영구화 curl 검증). **실버그 1건 수정(PR #86)** — 회원 탈퇴 시 가상투자 Paper* 5개 테이블 cascade 삭제 누락. **코드 점검**: Explore 3개 병렬 → 보고 8건 중 7건 LLM 오판/단일워커로 기각, 치명버그 0. 경미개선(realtime db_market_map 재시도)은 미커밋. 상세: CLAUDE.local.md.

--- a/ETF_RAG/scripts/check_prod_env.py
+++ b/ETF_RAG/scripts/check_prod_env.py
@@ -1,0 +1,157 @@
+"""
+프로덕션 백엔드 env 설정 진단 스크립트
+
+Railway 백엔드에 KIS / VAPID / CRON_TOKEN / 가상투자 스냅샷 자동화 env가
+제대로 등록됐는지 라이브 엔드포인트로 점검한다. 보안상 백엔드가 비밀값을
+직접 노출하지 않으므로, 공개 신호(활성 플래그·HTTP 상태)로 추론한다.
+
+사용법:
+    python scripts/check_prod_env.py                       # 기본 URL(프로덕션)
+    python scripts/check_prod_env.py --base http://localhost:8000
+    python scripts/check_prod_env.py --cron-token <TOKEN>   # CRON 토큰 실제 검증
+    python scripts/check_prod_env.py --ticker 005930        # KIS 시세 source 확인
+
+종료 코드: 모든 점검 통과(또는 정보성)면 0, 점검 자체 실패 시 1.
+"""
+
+import sys
+import ssl
+import json
+import argparse
+import urllib.request
+import urllib.error
+
+DEFAULT_BASE = "https://aiagent-production-75ca.up.railway.app"
+TIMEOUT = 15
+
+# macOS 시스템 Python은 CA 미설치라 HTTPS 검증이 깨질 수 있음(뉴스 SSL 이슈와 동일)
+# → certifi 번들을 명시. certifi 없으면 시스템 기본 컨텍스트로 fallback.
+try:
+    import certifi
+    _SSL_CTX = ssl.create_default_context(cafile=certifi.where())
+except Exception:  # noqa: BLE001
+    _SSL_CTX = ssl.create_default_context()
+
+OK = "✅"
+NO = "❌"
+WARN = "⚠️ "
+INFO = "ℹ️ "
+
+
+def _get(base, path, method="GET", token=None):
+    """엔드포인트 호출 → (http_status, body_dict_or_text). 오류 시 status=None."""
+    url = base.rstrip("/") + path
+    headers = {}
+    if token:
+        headers["X-Cron-Token"] = token
+    req = urllib.request.Request(url, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            try:
+                return resp.status, json.loads(raw)
+            except json.JSONDecodeError:
+                return resp.status, raw
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return e.code, raw
+    except Exception as e:  # noqa: BLE001
+        return None, str(e)
+
+
+def check_health(base):
+    status, body = _get(base, "/health")
+    if status == 200 and isinstance(body, dict) and body.get("ready"):
+        print(f"{OK} 백엔드 health: ready")
+        return True
+    print(f"{NO} 백엔드 health 비정상: status={status}, body={body}")
+    return False
+
+
+def check_kis(base, ticker):
+    """장중에는 source=kis면 KIS 활성, 장외에는 추론 불가(close fallback 정상)."""
+    status, body = _get(base, f"/tabs/price?ticker={ticker}")
+    if status != 200 or not isinstance(body, dict):
+        print(f"{NO} KIS 시세 점검 실패: status={status}, body={body}")
+        return
+    src = body.get("source")
+    market_open = body.get("market_open")
+    if src == "kis":
+        print(f"{OK} KIS env 등록됨 — 실시간 시세 동작 (source=kis, {ticker})")
+    elif market_open:
+        print(f"{WARN}장중인데 source={src} — KIS env 미등록이거나 KIS 일시 오류 "
+              f"(yfinance/close fallback 중)")
+    else:
+        print(f"{INFO}장 마감 — source={src} (close fallback 정상). "
+              f"KIS 등록 여부는 장중(평일 09:00~15:30 KST)에 재실행해 확인")
+
+
+def check_vapid(base):
+    status, body = _get(base, "/push/vapid-public-key")
+    if status == 200 and isinstance(body, dict):
+        if body.get("enabled") and body.get("public_key"):
+            print(f"{OK} VAPID env 등록됨 — 웹 푸시 발송 가능")
+        else:
+            print(f"{NO} VAPID 미등록 (enabled=false) — 웹 푸시 발송 불가. "
+                  f"scripts/gen_vapid_keys.py로 키 생성 후 Railway env "
+                  f"VAPID_PUBLIC_KEY/PRIVATE_KEY/SUBJECT 등록 필요")
+    else:
+        print(f"{NO} VAPID 점검 실패: status={status}, body={body}")
+
+
+def check_cron(base, token):
+    """CRON 보호 엔드포인트. 토큰 미설정이면 401/403, 일치하면 200."""
+    if token:
+        status, body = _get(base, "/push/run-watchlist-alerts", method="POST", token=token)
+        if status == 200:
+            print(f"{OK} CRON_TOKEN 일치 — 관심종목 알림 트리거 동작 "
+                  f"(users_notified={body.get('users_notified') if isinstance(body, dict) else '?'})")
+        elif status in (401, 403):
+            print(f"{NO} CRON_TOKEN 불일치/미설정 (status={status}) — "
+                  f"Railway env CRON_TOKEN과 전달 토큰이 다름")
+        else:
+            print(f"{WARN}CRON 트리거 응답 status={status}, body={body}")
+    else:
+        status, _ = _get(base, "/push/run-watchlist-alerts", method="POST")
+        print(f"{INFO}CRON 보호 엔드포인트 status={status} (토큰 없이 호출 → 403 정상). "
+              f"실제 설정 여부는 --cron-token <값>으로 검증")
+
+
+def check_snapshot(base, token):
+    if token:
+        status, body = _get(base, "/me/paper/snapshot-all", method="POST", token=token)
+        if status == 200:
+            print(f"{OK} PAPER 스냅샷 트리거 동작 (CRON_TOKEN 일치)")
+        elif status in (401, 403):
+            print(f"{NO} PAPER 스냅샷 CRON_TOKEN 불일치/미설정 (status={status})")
+        else:
+            print(f"{WARN}PAPER 스냅샷 응답 status={status}, body={body}")
+    else:
+        status, _ = _get(base, "/me/paper/snapshot-all", method="POST")
+        print(f"{INFO}PAPER 스냅샷 엔드포인트 status={status} (토큰 없이 → 403 정상)")
+
+
+def main():
+    p = argparse.ArgumentParser(description="프로덕션 백엔드 env 설정 진단")
+    p.add_argument("--base", default=DEFAULT_BASE, help="백엔드 base URL")
+    p.add_argument("--cron-token", default=None, help="CRON_TOKEN 실제 검증용")
+    p.add_argument("--ticker", default="005930", help="KIS 시세 확인 종목코드")
+    args = p.parse_args()
+
+    print(f"=== 프로덕션 env 진단: {args.base} ===")
+    if not check_health(args.base):
+        print("백엔드가 준비되지 않아 나머지 점검을 건너뜁니다.")
+        sys.exit(1)
+    check_kis(args.base, args.ticker)
+    check_vapid(args.base)
+    check_cron(args.base, args.cron_token)
+    check_snapshot(args.base, args.cron_token)
+    print("\n※ 비밀값은 백엔드가 노출하지 않으므로 활성 플래그/HTTP 상태로 추론합니다.")
+    print("  env 등록은 Railway 대시보드 → 백엔드 서비스(AI_agent) → Variables 에서.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 배경
ToDo 3·4번 — 프로덕션 KIS / VAPID / CRON_TOKEN / 가상투자 스냅샷 자동화 env 등록 여부를 라이브로 진단. 실제 env 등록은 Railway 대시보드에서 사용자가 직접 하는 작업이라, 검증을 돕는 스크립트로 정리.

## 추가
`scripts/check_prod_env.py` — 표준 라이브러리(urllib)만으로 백엔드 엔드포인트 점검:
- `/health` ready
- `/tabs/price` source (장중 kis면 KIS 활성, 장외는 close fallback 정상)
- `/push/vapid-public-key` enabled (VAPID 등록 여부)
- `/push/run-watchlist-alerts`·`/me/paper/snapshot-all` CRON 보호 (403/200, `--cron-token`으로 실검증)
- macOS CERTIFICATE_VERIFY_FAILED 회피 위해 certifi 명시

## 현재 진단 결과 (2026-06-26 실행)
- ✅ 백엔드 ready / ℹ️ 장 마감 source=close / ❌ **VAPID 미등록** / ℹ️ CRON 403(토큰없이 정상)

## 사용자 액션 (Railway → 백엔드 AI_agent → Variables)
- **KIS**: 로컬 .env의 `KIS_APP_KEY/SECRET/ACCOUNT_NO/ENV` 등록 → 장중 실시간 시세
- **VAPID**: `python scripts/gen_vapid_keys.py` → `VAPID_PUBLIC_KEY/PRIVATE_KEY/SUBJECT`
- **CRON**: `CRON_TOKEN`(랜덤) + GHA secret `PUSH_ALERT_URL`/`PAPER_SNAPSHOT_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)