### PR TITLE
fix(scripts): backfill_market KRX 로그인 추가 (KOSDAQ 빈응답 해결)

### DIFF
--- a/ETF_RAG/scripts/backfill_market.py
+++ b/ETF_RAG/scripts/backfill_market.py
@@ -10,6 +10,10 @@ pykrx로 시장별 종목 목록을 받아 instruments.market을 채운다. (ETF
 import logging
 import sys
 
+from dotenv import load_dotenv
+
+load_dotenv()  # KRX_ID/KRX_PW를 .env에서 로드 (로그인 필수)
+
 from pykrx import stock
 
 from src.data.database import init_db, DB_PATH
@@ -19,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 
 def backfill() -> None:
+    # KRX는 2026-02부터 로그인 필수 → 로그인 안 하면 종목 목록이 빈 응답으로
+    # 온다(과거 "pykrx 외부 장애"로 오인했던 KOSDAQ 백필 보류의 진짜 원인).
+    from src.data.collector import ensure_krx_login
+    ensure_krx_login()
+
     # init_db가 _migrate를 호출 → instruments.market 컬럼 보장
     conn = init_db(DB_PATH)
     # 날짜: DB 최신 수집일(오늘이 영업일/장중이 아니면 pykrx가 빈 응답을 주므로)


### PR DESCRIPTION
## 배경
ToDo 5번 — KOSDAQ market 백필이 "pykrx 외부 장애"로 보류돼 있던 건.

## 진짜 원인
`backfill_market.py`가 **KRX 로그인을 안 했던 것**. KRX는 2026-02부터 종목 목록 조회에도 로그인이 필수라, 로그인 없이는 KOSPI·KOSDAQ 둘 다 빈 응답(0종목)을 받는다. 과거 "KOSDAQ만 빈 응답하는 외부 장애"로 오인했으나, 실제론 KOSPI도 0이었고 로그인 후엔 둘 다 정상.

## 수정
- `ensure_krx_login()` 호출 추가 (collector의 기존 로그인 워크어라운드 재사용)
- `load_dotenv()` 추가 (`-m`으로 실행 시 KRX_ID/PW 로드)

## 실행 결과 (로컬 DB)
- KRX 로그인 성공 → KOSPI **2096** + KOSDAQ **1822** market 채움
- 빈값 797개는 전부 현재 시장 목록에 없는 **상장폐지 종목**(yfinance 조회 대상 아님 → 실서비스 무영향, `krx_to_yfinance`의 volume 검증 fallback이 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)