### PR TITLE
feat(frontend): 관심종목 ⭐ 재무/전망/비교 탭 확대

### DIFF
--- a/.claude/CLAUDE.local.md
+++ b/.claude/CLAUDE.local.md
@@ -2376,8 +2376,8 @@ PR #50~#56(~972줄, KIS REST/WS + 푸시) 점검. **실버그 1건 발견·수�
 
 **사용자 액션(로컬 모델 켜기)**: requirements의 transformers/torch 주석 해제·설치 → 자동 로컬 분류(첫 호출 ~400MB 다운로드). 안 하면 기존 GPT. (Railway 배포 시 메모리·이미지 부담 고려 — 무료 티어는 GPT 유지 권장.)
 
-### 다음
-- **유료 전환**(구독 결제) 또는 블로그 9편. Railway env 등록(KIS/VAPID/CRON, 사용자). 로컬 감성 쓰려면 torch 설치.
+### 실배포 검토 결론 — GPT fallback 유지 (2026-06-26, ToDo 6)
+**결정: 프로덕션은 GPT-4o-mini 유지, torch/transformers 미설치.** 근거: 백엔드가 이미 full DB 1.8GB + FAISS 인덱스로 메모리가 큰데, KR-FinBert-SC(BERT-base ~420MB 모델)는 CPU 추론 시 +1~1.5GB RSS → Railway Hobby에서 OOM 위험·비용 상승. 뉴스 감성은 건당 극소액 GPT로 충분(요약/키워드도 어차피 GPT 하이브리드). 코드는 그대로 두고(선택적 설치 경로 유지), 로컬 개발에서만 필요 시 활성화. **추가 코드 작업 없음 — 검토만 완료.**
 
 ---
 

--- a/ETF_RAG/frontend/src/app/comparison/page.tsx
+++ b/ETF_RAG/frontend/src/app/comparison/page.tsx
@@ -12,6 +12,7 @@ import TickerSearch from "@/components/TickerSearch";
 import ChartImage from "@/components/ChartImage";
 import ComparisonTable from "@/components/ComparisonTable";
 import DataRangeNote from "@/components/DataRangeNote";
+import WatchlistStar from "@/components/WatchlistStar";
 
 // 상대 수익률 차트 기간 (1주=5거래일, 1개월=20, 3개월=60 ...)
 const PERIODS: { label: string; days: number }[] = [
@@ -156,6 +157,17 @@ export default function ComparisonPage() {
 
       {data && !loading && (
         <div className="mt-5">
+          {(t1 || t2) && (
+            <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1">
+              {[t1, t2].filter(Boolean).map((t) => (
+                <span key={t!.ticker} className="flex items-center gap-1">
+                  <span className="text-sm font-semibold">{t!.name}</span>
+                  <span className="text-xs text-gray-400">{t!.ticker}</span>
+                  <WatchlistStar ticker={t!.ticker} />
+                </span>
+              ))}
+            </div>
+          )}
           <ComparisonTable items={data.items as ComparisonItem[]} />
           <ChartImage b64={data.comparison_chart_b64} alt="상대 수익률 추이" />
           <ChartImage b64={data.valuation_chart_b64} alt="밸류에이션 비교" />

--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -6,6 +6,7 @@ import type { FinancialResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import ChartImage from "@/components/ChartImage";
 import DataRangeNote from "@/components/DataRangeNote";
+import WatchlistStar from "@/components/WatchlistStar";
 
 // 억원 단위
 function eok(v: number | null | undefined): string {
@@ -129,9 +130,11 @@ export default function FinancialPage() {
 
       {data && !loading && (
         <div className="mt-5">
-          <h2 className="mb-3 text-base font-semibold">
-            {data.name} <span className="text-xs text-gray-400">{data.ticker}</span>
-          </h2>
+          <div className="mb-3 flex items-center gap-2">
+            <h2 className="text-base font-semibold">{data.name}</h2>
+            <span className="text-xs text-gray-400">{data.ticker}</span>
+            <WatchlistStar ticker={data.ticker} />
+          </div>
 
           <div className="overflow-x-auto">
             <table className="comparison-table text-xs">

--- a/ETF_RAG/frontend/src/app/outlook/page.tsx
+++ b/ETF_RAG/frontend/src/app/outlook/page.tsx
@@ -5,6 +5,7 @@ import { getOutlook } from "@/lib/api";
 import type { OutlookResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import DataRangeNote from "@/components/DataRangeNote";
+import WatchlistStar from "@/components/WatchlistStar";
 
 const HORIZONS = ["1m", "3m", "6m", "1y"];
 
@@ -43,7 +44,7 @@ function forecastView(axis: Record<string, unknown> | undefined) {
 
 export default function OutlookPage() {
   const [horizon, setHorizon] = useState("1m");
-  const [selected, setSelected] = useState<{ ticker: string } | null>(null);
+  const [selected, setSelected] = useState<{ ticker: string; name?: string } | null>(null);
   const [data, setData] = useState<OutlookResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +63,7 @@ export default function OutlookPage() {
     }
   };
 
-  const onSelect = (sel: { ticker: string }) => {
+  const onSelect = (sel: { ticker: string; name: string }) => {
     setSelected(sel);
     run(sel.ticker, horizon);
   };
@@ -107,6 +108,13 @@ export default function OutlookPage() {
 
       {data && !loading && (
         <div className="mt-5 space-y-4">
+          {selected && (
+            <div className="flex items-center gap-2">
+              <h2 className="text-base font-semibold">{selected.name ?? selected.ticker}</h2>
+              <span className="text-xs text-gray-400">{selected.ticker}</span>
+              <WatchlistStar ticker={selected.ticker} />
+            </div>
+          )}
           <div className="flex flex-wrap gap-2">
             <Metric label="종합 점수" value={str(data.composite_score)} />
             <Metric label="신뢰 등급" value={str(data.confidence_grade)} />


### PR DESCRIPTION
## 배경
ToDo 7번 — 관심종목 ⭐ 토글이 기술분석 탭·사이드바에만 있어, 재무/전망/비교 탭으로 확대.

## 변경
종목 결과 헤더 옆에 기존 `WatchlistStar` 컴포넌트 배치:
- **financial**: 종목 헤더를 flex로 바꿔 ⭐ 추가
- **outlook**: `selected`에 name 저장 + 결과 상단 종목 헤더+⭐ 신설(기존엔 헤더 없었음)
- **comparison**: 두 종목 각각 헤더+⭐ (결과 상단)

`WatchlistStar`는 로그인 시에만 표시(기존 동작 유지), 관심종목은 Postgres watchlists 재사용 → 계정별 영구 누적.

## 검증
- `tsc --noEmit` 통과(에러 0)
- `next build` 통과(13 라우트)

## 추가
docs: F-3 로컬 감성 실배포 검토 결론(GPT fallback 유지) CLAUDE.local.md 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)