### PR TITLE
feat(paper): 가상투자 고도화 — 비중 파이차트 + 거래 통계 + 배당 정산

### DIFF
--- a/ETF_RAG/api/db.py
+++ b/ETF_RAG/api/db.py
@@ -64,6 +64,12 @@ def _migrate_add_columns() -> None:
                     "WHERE started_at IS NULL"
                 ))
             logger.info("마이그레이션: paper_accounts.started_at 컬럼 추가")
+        if "last_dividend_at" not in pa_cols:
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "ALTER TABLE paper_accounts ADD COLUMN last_dividend_at TIMESTAMP"
+                ))
+            logger.info("마이그레이션: paper_accounts.last_dividend_at 컬럼 추가")
 
 
 def get_db() -> Iterator[Session]:

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -191,6 +191,40 @@ class PaperRoundsResponse(BaseModel):
     rounds: List[PaperRoundItem]  # 최신 라운드부터
 
 
+class TradeStatsResponse(BaseModel):
+    """현재 라운드 거래 통계(실현 기준). 매도 체결만 손익 판정에 사용."""
+    total_trades: int          # 전체 체결 수(매수+매도)
+    buy_count: int
+    sell_count: int            # 청산(손익 확정) 횟수
+    win_count: int             # 이익 실현 매도 수
+    loss_count: int            # 손실 실현 매도 수
+    win_rate: float            # 승률 % = win/sell (매도 없으면 0)
+    realized_pnl: int          # 실현손익 합(매도 realized_pnl)
+    avg_win: int               # 이익 매도 평균 실현손익
+    avg_loss: int              # 손실 매도 평균 실현손익(음수)
+    profit_factor: Optional[float] = None  # 총이익/총손실 절댓값(손실 0이면 None)
+    best_trade: Optional[int] = None       # 최대 단일 실현이익
+    worst_trade: Optional[int] = None      # 최대 단일 실현손실
+
+
+class DividendItem(BaseModel):
+    ticker: str
+    name: str
+    qty: int
+    dps: float          # 주당 연간 배당금(TTM)
+    amount: int         # dps × qty (지급액)
+
+
+class DividendResponse(BaseModel):
+    """배당 정산 결과. 데이터 한계로 '예상 연간 배당금'을 라운드당 1회 현금 지급."""
+    ok: bool
+    paid: bool          # 이번 호출에서 실제 지급했는지(이미 정산했으면 False)
+    total: int          # 지급(예정) 총액
+    cash: int           # 정산 후 현금
+    items: List[DividendItem]
+    message: str
+
+
 class ResetRequest(BaseModel):
     # 실수 방지 — 클라이언트에서 "초기화" 확인 입력. 서버도 재검증.
     confirm: str = Field(..., min_length=1)

--- a/ETF_RAG/api/models_db.py
+++ b/ETF_RAG/api/models_db.py
@@ -116,6 +116,10 @@ class PaperAccount(Base):
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, server_default=func.now()
     )
+    # 현재 라운드에서 마지막으로 배당 정산한 시각 (라운드당 1회 제한). None=미정산
+    last_dividend_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
 
 class PaperHolding(Base):

--- a/ETF_RAG/api/paper.py
+++ b/ETF_RAG/api/paper.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import Session
 from api.auth import get_current_user, _display_nickname
 from api.db import get_db
 from api.models import (
+    DividendItem,
+    DividendResponse,
     HoldingItem,
     PaperHistoryPoint,
     PaperHistoryResponse,
@@ -29,6 +31,7 @@ from api.models import (
     SnapshotAllResponse,
     TradeHistoryItem,
     TradeHistoryResponse,
+    TradeStatsResponse,
     TradeRequest,
     TradeResult,
 )
@@ -256,6 +259,107 @@ def trades(
     ])
 
 
+@router.get("/stats", response_model=TradeStatsResponse)
+def stats(
+    user: User = Depends(get_current_user), db: Session = Depends(get_db)
+) -> TradeStatsResponse:
+    """현재 라운드 거래 통계 — 매도(청산) 실현손익 기준 승률·평균손익·손익비."""
+    rows = list(db.scalars(
+        select(PaperTrade).where(PaperTrade.user_id == user.id)
+    ))
+    buys = [t for t in rows if t.side == "buy"]
+    sells = [t for t in rows if t.side == "sell"]
+    pnls = [t.realized_pnl for t in sells if t.realized_pnl is not None]
+    wins = [p for p in pnls if p > 0]
+    losses = [p for p in pnls if p < 0]
+    gross_profit = sum(wins)
+    gross_loss = abs(sum(losses))
+    return TradeStatsResponse(
+        total_trades=len(rows),
+        buy_count=len(buys),
+        sell_count=len(sells),
+        win_count=len(wins),
+        loss_count=len(losses),
+        win_rate=round(len(wins) / len(sells) * 100.0, 1) if sells else 0.0,
+        realized_pnl=sum(pnls),
+        avg_win=int(round(gross_profit / len(wins))) if wins else 0,
+        avg_loss=int(round(sum(losses) / len(losses))) if losses else 0,
+        profit_factor=round(gross_profit / gross_loss, 2) if gross_loss > 0 else None,
+        best_trade=max(pnls) if pnls else None,
+        worst_trade=min(pnls) if pnls else None,
+    )
+
+
+def _holding_dps(tickers: list) -> dict:
+    """보유 종목별 최신 DPS(주당 연간 배당금) 조회. {ticker: dps}."""
+    if not tickers:
+        return {}
+    from src.data.database import get_connection, get_latest_dps, DB_PATH
+    if not DB_PATH.exists():
+        return {}
+    conn = get_connection(DB_PATH)
+    try:
+        return {t: get_latest_dps(conn, t) for t in tickers}
+    finally:
+        conn.close()
+
+
+@router.post("/dividend", response_model=DividendResponse)
+def dividend(
+    user: User = Depends(get_current_user), db: Session = Depends(get_db)
+) -> DividendResponse:
+    """배당 정산 — 보유 종목의 연 DPS × 수량을 현금으로 1회 지급(라운드당 1회).
+
+    데이터 한계: pykrx DPS는 'TTM 연간 배당금'이라 정확한 배당락/지급일이 없음.
+    따라서 '예상 연간 배당금'을 라운드당 한 번 현금에 더하는 단순 모델.
+    """
+    acc = _get_or_create_account(db, user.id)
+    holdings = _holdings(db, user.id)
+    dps_map = _holding_dps([h.ticker for h in holdings])
+
+    items = []
+    total = 0
+    for h in holdings:
+        dps = dps_map.get(h.ticker, 0.0)
+        if dps <= 0:
+            continue
+        amount = int(round(dps * h.qty))
+        if amount <= 0:
+            continue
+        # 종목명: 현재가 조회 실패해도 ticker로 표기(정산은 진행)
+        try:
+            name = _resolve_price(h.ticker).get("name", h.ticker)
+        except HTTPException:
+            name = h.ticker
+        total += amount
+        items.append(DividendItem(
+            ticker=h.ticker, name=name, qty=h.qty, dps=round(dps, 2), amount=amount,
+        ))
+    items.sort(key=lambda x: x.amount, reverse=True)
+
+    # 라운드당 1회 가드: 이미 이 라운드에서 정산했으면 지급 안 함(미리보기만)
+    already = acc.last_dividend_at is not None and acc.last_dividend_at >= acc.started_at
+    if already:
+        return DividendResponse(
+            ok=True, paid=False, total=total, cash=acc.cash, items=items,
+            message="이번 라운드에서는 이미 배당을 정산했어요. 계좌 초기화 후 다시 받을 수 있어요.",
+        )
+    if total <= 0:
+        return DividendResponse(
+            ok=True, paid=False, total=0, cash=acc.cash, items=[],
+            message="배당을 지급하는 보유 종목이 없어요.",
+        )
+
+    acc.cash += total
+    acc.last_dividend_at = datetime.now(timezone.utc)
+    db.commit()
+    _snapshot_after_trade(db, user.id)
+    return DividendResponse(
+        ok=True, paid=True, total=total, cash=acc.cash, items=items,
+        message=f"예상 연간 배당금 {total:,}원을 현금으로 지급했어요. (라운드당 1회)",
+    )
+
+
 def _round_symbol_pnl(db: Session, user_id: int) -> list:
     """현재 라운드의 종목별 손익 = 실현(매도분 합) + 미실현(보유 평가손익).
     [{ticker,name,realized,unrealized,total}, ...] total 내림차순."""
@@ -325,6 +429,7 @@ def reset(
     db.execute(delete(PaperSnapshot).where(PaperSnapshot.user_id == user.id))
     acc.cash = INITIAL_CASH
     acc.started_at = datetime.now(timezone.utc)  # 새 라운드 시작
+    acc.last_dividend_at = None  # 새 라운드는 배당 다시 받을 수 있게
     db.commit()
     _record_snapshot(db, user.id, INITIAL_CASH)  # 새 라운드 첫 스냅샷(1억)
     db.commit()

--- a/ETF_RAG/frontend/src/app/invest/page.tsx
+++ b/ETF_RAG/frontend/src/app/invest/page.tsx
@@ -8,10 +8,12 @@ import {
   getTradeHistory,
   getRanking,
   getPaperHistory,
+  getPaperStats,
   getPaperRounds,
   buyStock,
   sellStock,
   resetPaper,
+  collectDividend,
 } from "@/lib/auth";
 import { getPrice } from "@/lib/api";
 import type {
@@ -19,11 +21,13 @@ import type {
   PaperTradeHistoryItem,
   PaperRanking,
   PaperHistory,
+  PaperTradeStats,
   PaperRound,
   PriceData,
 } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import ChartImage from "@/components/ChartImage";
+import PortfolioPie from "@/components/PortfolioPie";
 
 const won = (v: number) => `${Math.round(v).toLocaleString("ko-KR")}원`;
 function signColor(v: number): string {
@@ -39,6 +43,7 @@ export default function InvestPage() {
   const [trades, setTrades] = useState<PaperTradeHistoryItem[]>([]);
   const [ranking, setRanking] = useState<PaperRanking | null>(null);
   const [hist, setHist] = useState<PaperHistory | null>(null);
+  const [stats, setStats] = useState<PaperTradeStats | null>(null);
   const [pastRounds, setPastRounds] = useState<PaperRound[]>([]);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ k: "ok" | "err"; t: string } | null>(null);
@@ -52,17 +57,19 @@ export default function InvestPage() {
   const [price, setPrice] = useState<PriceData | null>(null); // 선택 종목 현재가
 
   const refresh = useCallback(async () => {
-    const [p, t, r, hh, rd] = await Promise.all([
+    const [p, t, r, hh, st, rd] = await Promise.all([
       getPortfolio(),
       getTradeHistory(),
       getRanking(),
       getPaperHistory(),
+      getPaperStats(),
       getPaperRounds(),
     ]);
     setPf(p);
     setTrades(t);
     setRanking(r);
     setHist(hh);
+    setStats(st);
     setPastRounds(rd);
   }, []);
 
@@ -145,6 +152,20 @@ export default function InvestPage() {
       await refresh();
     } catch (e) {
       setMsg({ k: "err", t: e instanceof Error ? e.message : "초기화 실패" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doDividend = async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      const d = await collectDividend();
+      setMsg({ k: d.paid ? "ok" : "err", t: d.message });
+      await refresh();
+    } catch (e) {
+      setMsg({ k: "err", t: e instanceof Error ? e.message : "배당 정산 실패" });
     } finally {
       setBusy(false);
     }
@@ -264,8 +285,25 @@ export default function InvestPage() {
 
       {/* 보유 현황 */}
       <section className="mb-5">
-        <h2 className="mb-2 text-sm font-semibold text-gray-800">보유 종목</h2>
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-800">보유 종목</h2>
+          {pf && pf.holdings.length > 0 && (
+            <button
+              type="button"
+              onClick={doDividend}
+              disabled={busy}
+              title="보유 종목의 예상 연간 배당금을 현금으로 1회 지급(라운드당 1회)"
+              className="rounded-lg border border-emerald-300 px-2.5 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-50 disabled:opacity-40"
+            >
+              💰 배당 받기
+            </button>
+          )}
+        </div>
         {pf && pf.holdings.length > 0 ? (
+          <>
+          <div className="mb-3">
+            <PortfolioPie holdings={pf.holdings} cash={pf.cash} />
+          </div>
           <div className="overflow-x-auto">
             <table className="comparison-table text-xs">
               <thead>
@@ -296,6 +334,7 @@ export default function InvestPage() {
               </tbody>
             </table>
           </div>
+          </>
         ) : (
           <p className="text-xs text-gray-400">보유 종목이 없어요. 위에서 매수해 보세요.</p>
         )}
@@ -333,6 +372,42 @@ export default function InvestPage() {
                 ))}
               </tbody>
             </table>
+          </div>
+        </section>
+      )}
+
+      {/* 거래 통계 (청산 1건 이상일 때) */}
+      {stats && stats.sell_count > 0 && (
+        <section className="mb-5">
+          <h2 className="mb-2 text-sm font-semibold text-gray-800">거래 통계</h2>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <Stat label="승률" value={`${stats.win_rate}%`} sub={`${stats.win_count}승 ${stats.loss_count}패`} />
+            <Stat
+              label="실현손익"
+              value={`${stats.realized_pnl > 0 ? "+" : ""}${stats.realized_pnl.toLocaleString("ko-KR")}`}
+            />
+            <Stat
+              label="손익비"
+              value={stats.profit_factor == null ? "-" : `${stats.profit_factor}`}
+              sub="총이익/총손실"
+            />
+            <Stat label="청산 횟수" value={`${stats.sell_count}회`} sub={`매수 ${stats.buy_count}회`} />
+            <Stat
+              label="평균 이익"
+              value={`+${stats.avg_win.toLocaleString("ko-KR")}`}
+            />
+            <Stat
+              label="평균 손실"
+              value={`${stats.avg_loss.toLocaleString("ko-KR")}`}
+            />
+            <Stat
+              label="최고 거래"
+              value={stats.best_trade == null ? "-" : `+${stats.best_trade.toLocaleString("ko-KR")}`}
+            />
+            <Stat
+              label="최악 거래"
+              value={stats.worst_trade == null ? "-" : `${stats.worst_trade.toLocaleString("ko-KR")}`}
+            />
           </div>
         </section>
       )}
@@ -490,15 +565,18 @@ function Stat({
   label,
   value,
   color = "text-gray-900",
+  sub,
 }: {
   label: string;
   value: string;
   color?: string;
+  sub?: string;
 }) {
   return (
     <div className="rounded-xl border border-gray-200 px-3 py-2">
       <div className="text-[11px] text-gray-500">{label}</div>
       <div className={`text-sm font-semibold tabular-nums ${color}`}>{value}</div>
+      {sub ? <div className="text-[10px] text-gray-400">{sub}</div> : null}
     </div>
   );
 }

--- a/ETF_RAG/frontend/src/components/PortfolioPie.tsx
+++ b/ETF_RAG/frontend/src/components/PortfolioPie.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * 가상투자 자산 배분 도넛 차트 (외부 라이브러리 없이 SVG).
+ * 보유 종목 평가금액 + 현금을 비중으로 시각화.
+ */
+
+type Slice = { label: string; value: number };
+
+// 구분 잘 되는 팔레트(현금은 회색 고정, 종목은 순환)
+const COLORS = [
+  "#2563eb", "#e8453c", "#34a853", "#fbbc04", "#9333ea",
+  "#0891b2", "#db2777", "#65a30d", "#ea580c", "#4f46e5",
+];
+const CASH_COLOR = "#9ca3af";
+
+function polar(cx: number, cy: number, r: number, deg: number) {
+  const rad = ((deg - 90) * Math.PI) / 180;
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+function arcPath(cx: number, cy: number, r: number, start: number, end: number) {
+  // 단일 슬라이스가 100%면 SVG arc가 그려지지 않으므로 살짝 줄임
+  const e = end - start >= 360 ? start + 359.999 : end;
+  const s = polar(cx, cy, r, start);
+  const f = polar(cx, cy, r, e);
+  const large = e - start > 180 ? 1 : 0;
+  return `M ${cx} ${cy} L ${s.x} ${s.y} A ${r} ${r} 0 ${large} 1 ${f.x} ${f.y} Z`;
+}
+
+export default function PortfolioPie({
+  holdings,
+  cash,
+}: {
+  holdings: { name: string; eval_value: number }[];
+  cash: number;
+}) {
+  const slices: Slice[] = [
+    ...holdings.map((h) => ({ label: h.name, value: h.eval_value })),
+  ];
+  if (cash > 0) slices.push({ label: "현금", value: cash });
+  const total = slices.reduce((a, s) => a + s.value, 0);
+  if (total <= 0) return null;
+
+  const cx = 80, cy = 80, r = 76, hole = 46;
+  let acc = 0;
+  const arcs = slices.map((s, i) => {
+    const start = (acc / total) * 360;
+    acc += s.value;
+    const end = (acc / total) * 360;
+    const color = s.label === "현금" ? CASH_COLOR : COLORS[i % COLORS.length];
+    return { ...s, start, end, color, pct: (s.value / total) * 100 };
+  });
+
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <svg viewBox="0 0 160 160" width={160} height={160} role="img" aria-label="자산 배분">
+        {arcs.map((a) => (
+          <path key={a.label} d={arcPath(cx, cy, r, a.start, a.end)} fill={a.color} />
+        ))}
+        {/* 도넛 구멍 */}
+        <circle cx={cx} cy={cy} r={hole} fill="white" />
+      </svg>
+      <ul className="space-y-1 text-xs">
+        {arcs.map((a) => (
+          <li key={a.label} className="flex items-center gap-2">
+            <span className="inline-block h-3 w-3 shrink-0 rounded-sm" style={{ background: a.color }} />
+            <span className="text-gray-700">{a.label}</span>
+            <span className="ml-auto tabular-nums text-gray-500">{a.pct.toFixed(1)}%</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -198,6 +198,8 @@ import type {
   PaperTradeHistoryItem,
   PaperRanking,
   PaperHistory,
+  PaperTradeStats,
+  PaperDividend,
   PaperRound,
 } from "./types";
 
@@ -225,6 +227,10 @@ export function getRanking(): Promise<PaperRanking | null> {
 
 export function getPaperHistory(): Promise<PaperHistory | null> {
   return paperGet<PaperHistory>("/history");
+}
+
+export function getPaperStats(): Promise<PaperTradeStats | null> {
+  return paperGet<PaperTradeStats>("/stats");
 }
 
 /** 매수/매도 — 실패 시 detail 메시지로 throw(잔고부족 등 사용자에게 표시). */
@@ -262,6 +268,19 @@ export async function resetPaper(confirm: string): Promise<PaperPortfolio> {
     throw new Error(d.detail || `초기화 실패 (${res.status})`);
   }
   return (await res.json()) as PaperPortfolio;
+}
+
+/** 배당 정산 — 보유 종목 연 DPS×수량을 현금 지급(라운드당 1회). */
+export async function collectDividend(): Promise<PaperDividend> {
+  const res = await fetch(`${API_BASE}/me/paper/dividend`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+  });
+  if (!res.ok) {
+    const d = await res.json().catch(() => ({}));
+    throw new Error(d.detail || `배당 정산 실패 (${res.status})`);
+  }
+  return (await res.json()) as PaperDividend;
 }
 
 export async function getPaperRounds(): Promise<PaperRound[]> {

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -305,6 +305,37 @@ export interface PaperHistory {
   chart_b64: string | null;
 }
 
+export interface DividendItem {
+  ticker: string;
+  name: string;
+  qty: number;
+  dps: number;
+  amount: number;
+}
+export interface PaperDividend {
+  ok: boolean;
+  paid: boolean;
+  total: number;
+  cash: number;
+  items: DividendItem[];
+  message: string;
+}
+
+export interface PaperTradeStats {
+  total_trades: number;
+  buy_count: number;
+  sell_count: number;
+  win_count: number;
+  loss_count: number;
+  win_rate: number;
+  realized_pnl: number;
+  avg_win: number;
+  avg_loss: number;
+  profit_factor: number | null;
+  best_trade: number | null;
+  worst_trade: number | null;
+}
+
 export interface RoundSymbolPnl {
   ticker: string;
   name: string;

--- a/ETF_RAG/src/data/database/__init__.py
+++ b/ETF_RAG/src/data/database/__init__.py
@@ -30,6 +30,7 @@ from src.data.database._read import (
     get_historical_prices,
     get_closes_batch,
     get_market_map,
+    get_latest_dps,
     get_low_history_tickers,
     search_instruments,
 )
@@ -55,7 +56,7 @@ __all__ = [
     "DB_PATH", "get_connection", "init_db",
     "upsert_daily_data", "upsert_stock_data",
     "get_latest_date", "get_latest_data", "get_latest_stock_data",
-    "get_historical_prices", "get_closes_batch", "get_market_map", "get_low_history_tickers",
+    "get_historical_prices", "get_closes_batch", "get_market_map", "get_latest_dps", "get_low_history_tickers",
     "search_instruments",
     "upsert_corp_codes", "get_corp_code", "get_all_corp_codes",
     "upsert_financial_data", "get_financial_data", "get_latest_financial_summary",

--- a/ETF_RAG/src/data/database/_read.py
+++ b/ETF_RAG/src/data/database/_read.py
@@ -210,6 +210,21 @@ def get_market_map(conn: sqlite3.Connection) -> dict:
     return {r["ticker"]: r["market"] for r in rows}
 
 
+def get_latest_dps(conn: sqlite3.Connection, ticker: str) -> float:
+    """종목의 최신 주당 연간 배당금(DPS). 없으면 0.0.
+
+    pykrx DPS는 'TTM 연간 배당금'을 일별로 반복하는 값(배당락일/지급일 정보 없음).
+    가상투자의 '배당 정산'에서 보유 수량 × DPS로 1회 지급에 사용한다.
+    """
+    row = conn.execute(
+        "SELECT dps FROM stock_fundamentals "
+        "WHERE ticker = ? AND dps IS NOT NULL AND dps > 0 "
+        "ORDER BY date DESC LIMIT 1",
+        (ticker,),
+    ).fetchone()
+    return float(row["dps"]) if row and row["dps"] else 0.0
+
+
 def get_low_history_tickers(conn: sqlite3.Connection,
                             min_days: int = 20) -> set:
     """시세 거래일 수가 min_days 미만인 종목 집합 (기술분석 불가 종목 제외용).

--- a/ETF_RAG/tests/test_paper.py
+++ b/ETF_RAG/tests/test_paper.py
@@ -324,3 +324,90 @@ def test_snapshot_all_records_all_accounts(client):
     # 각 유저 history에 스냅샷 1개(현금만이라 1억)
     h = client.get("/me/paper/history", headers=a).json()
     assert len(h["points"]) == 1 and h["points"][0]["total_value"] == INITIAL_CASH
+
+
+def test_stats_empty_account(client):
+    auth = _auth(client)
+    client.get("/me/paper/portfolio", headers=auth)  # 계좌 생성
+    s = client.get("/me/paper/stats", headers=auth).json()
+    assert s["total_trades"] == 0 and s["sell_count"] == 0
+    assert s["win_rate"] == 0.0 and s["realized_pnl"] == 0
+    assert s["profit_factor"] is None and s["best_trade"] is None
+
+
+def test_stats_win_loss_and_winrate(client):
+    auth = _auth(client)
+    # 005930 이익 실현(+1500), 000660 손실 실현(-1000)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 100}, headers=auth)
+    with _price_patch({"000660": 200}):
+        client.post("/me/paper/buy", json={"ticker": "000660", "qty": 100}, headers=auth)
+    with _price_patch({"005930": 130}):
+        client.post("/me/paper/sell", json={"ticker": "005930", "qty": 50}, headers=auth)  # +1500
+    with _price_patch({"000660": 180}):
+        client.post("/me/paper/sell", json={"ticker": "000660", "qty": 50}, headers=auth)  # -1000
+    s = client.get("/me/paper/stats", headers=auth).json()
+    assert s["buy_count"] == 2 and s["sell_count"] == 2
+    assert s["win_count"] == 1 and s["loss_count"] == 1
+    assert s["win_rate"] == 50.0
+    assert s["realized_pnl"] == 500          # +1500 - 1000
+    assert s["avg_win"] == 1500 and s["avg_loss"] == -1000
+    assert s["best_trade"] == 1500 and s["worst_trade"] == -1000
+    assert s["profit_factor"] == 1.5         # 1500 / 1000
+
+
+def test_dividend_pays_dps_times_qty(client):
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 100}, headers=auth)
+    # 보유 100주 × DPS 30 = 3000원 지급
+    with _price_patch({"005930": 100}), \
+         patch("api.paper._holding_dps", return_value={"005930": 30.0}):
+        r = client.post("/me/paper/dividend", headers=auth)
+    b = r.json()
+    assert b["ok"] and b["paid"] is True
+    assert b["total"] == 3000
+    assert b["cash"] == INITIAL_CASH - 10000 + 3000
+    assert len(b["items"]) == 1 and b["items"][0]["amount"] == 3000
+
+
+def test_dividend_once_per_round(client):
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 100}, headers=auth)
+    with _price_patch({"005930": 100}), \
+         patch("api.paper._holding_dps", return_value={"005930": 30.0}):
+        client.post("/me/paper/dividend", headers=auth)  # 1차 지급
+        r2 = client.post("/me/paper/dividend", headers=auth)  # 2차는 미지급
+    b = r2.json()
+    assert b["paid"] is False
+    # 현금은 1회분만 증가
+    pf = client.get("/me/paper/portfolio", headers=auth).json()
+    assert pf["cash"] == INITIAL_CASH - 10000 + 3000
+
+
+def test_dividend_resets_after_round_reset(client):
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 100}, headers=auth)
+    with _price_patch({"005930": 100}), \
+         patch("api.paper._holding_dps", return_value={"005930": 30.0}):
+        client.post("/me/paper/dividend", headers=auth)
+    # 초기화 → 새 라운드
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/reset", json={"confirm": "초기화"}, headers=auth)
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 100}, headers=auth)
+    with _price_patch({"005930": 100}), \
+         patch("api.paper._holding_dps", return_value={"005930": 30.0}):
+        r = client.post("/me/paper/dividend", headers=auth)  # 새 라운드라 다시 지급
+    assert r.json()["paid"] is True
+
+
+def test_dividend_no_dps_holdings(client):
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 100}, headers=auth)
+    with patch("api.paper._holding_dps", return_value={"005930": 0.0}):
+        r = client.post("/me/paper/dividend", headers=auth)
+    b = r.json()
+    assert b["paid"] is False and b["total"] == 0


### PR DESCRIPTION
## 배경
ToDo 8번 — 가상투자 고도화. 사용자 선택 3종 구현.

## 1) 포트폴리오 비중 파이차트
- `PortfolioPie` (SVG 도넛, 외부 라이브러리 없음) — 보유 종목 평가금액 + 현금 비중 시각화
- 데이터는 기존 portfolio 응답 재사용, **프론트 전용**(백엔드 변경 0)

## 2) 거래 통계 (`GET /me/paper/stats`)
- 매도(청산) `realized_pnl` 기준: 승률, 실현손익, 평균이익/손실, 손익비(PF), 최고/최악 거래
- `/invest`에 통계 카드(청산 1건 이상일 때 표시)

## 3) 배당 정산 (`POST /me/paper/dividend`)
- 보유 종목 연 DPS × 수량을 현금 **1회 지급**(라운드당 1회)
- **데이터 한계 명시**: pykrx DPS는 'TTM 연간배당금'이라 정확한 배당락/지급일 없음 → '예상 연간 배당금' 수동 정산 모델
- `PaperAccount.last_dividend_at`(멱등 마이그레이션), reset 시 초기화 → 새 라운드 재수령
- `/invest` '💰 배당 받기' 버튼 + `get_latest_dps` DB 헬퍼

## 검증
- 테스트 +6 (stats 2 + dividend 4), 전체 **851 통과**
- `tsc` + `next build`(13 라우트) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)