### PR TITLE
fix: 코드 점검 라운드(PR #69~#91) — 실버그 2건

### DIFF
--- a/ETF_RAG/api/paper.py
+++ b/ETF_RAG/api/paper.py
@@ -338,7 +338,12 @@ def dividend(
     items.sort(key=lambda x: x.amount, reverse=True)
 
     # 라운드당 1회 가드: 이미 이 라운드에서 정산했으면 지급 안 함(미리보기만)
-    already = acc.last_dividend_at is not None and acc.last_dividend_at >= acc.started_at
+    # started_at이 None인 경우(마이그레이션 직후 등) None 비교 TypeError 방어
+    already = (
+        acc.last_dividend_at is not None
+        and acc.started_at is not None
+        and acc.last_dividend_at >= acc.started_at
+    )
     if already:
         return DividendResponse(
             ok=True, paid=False, total=total, cash=acc.cash, items=items,

--- a/ETF_RAG/app.py
+++ b/ETF_RAG/app.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import streamlit as st
 import streamlit.components.v1
 
-from config import is_langsmith_enabled
+from config import is_langsmith_enabled, DB_PATH
 from src.data.db_downloader import ensure_db
 from src.data.loader import (
     load_etf_data as _load_etf_data,
@@ -54,8 +54,9 @@ def _get_deploy_data_version() -> str:
 @st.cache_resource(show_spinner="데이터베이스 준비 중... (최초 실행 시 1~2분)")
 def download_db():
     """Streamlit Cloud 시작 시 GitHub Release에서 DB 다운로드 (1회)."""
-    db_path = Path(__file__).parent / "src" / "data" / "etf_rag.db"
-    result = ensure_db(db_path)
+    # config.DB_PATH 사용 — ETF_DATA_DIR(영속 볼륨) 설정 시 그 경로로 일관 처리.
+    # (하드코딩 경로는 ETF_DATA_DIR을 무시해 _schema/deps와 불일치했음)
+    result = ensure_db(DB_PATH)
     logger.info(f"DB 다운로드 결과: {'성공' if result else '실패/스킵'}")
     return result
 


### PR DESCRIPTION
## 배경
ToDo 10번 — PR #69~#91(가상투자·시세·DB 누적분) 코드 점검. Explore 3개 병렬(가상투자 / 시세·티커 / DB·마이그레이션) → **보고 항목을 직접 재검증**(6-04/6-25 LLM 오판 교훈대로 실코드 검증분만 채택).

## 채택 2건

### 1) dividend `started_at` None 비교 방어 (paper.py)
- `/dividend` 라운드당 1회 가드 `last_dividend_at >= acc.started_at`에서 `started_at`이 None이면 `TypeError`(datetime vs NoneType) — 마이그레이션 직후 등 엣지케이스
- `acc.started_at is not None` 가드 추가. (직접 `datetime >= None` TypeError 재현 확인)

### 2) app.py DB 경로 정합성 (app.py)
- `download_db`가 하드코딩 경로(`src/data/etf_rag.db`)로 `ensure_db` 호출 → `config.DB_PATH`(ETF_DATA_DIR 영속볼륨 반영)와 불일치
- `config.DB_PATH` 사용으로 통일 (`_schema`/`deps`와 일관)

## 기각 (직접 재검증)
- **avg_loss 음수**: 의도된 표시(모델 주석 `(음수)`·테스트로 명시) — 버그 아님
- **시세/티커 정규화**: 전부 정상 — `.lower()` 일관 적용(#74), days 전달(#83), KOSPI/KOSDAQ volume 검증, KIS fallback source 정상
- **DB/마이그레이션/배치쿼리**: 무결성검사·멱등·IN절 바인딩 정상
- 동시성 race: 단일 워커라 발생 불가

## 검증
- 전체 **851 통과**(회귀 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)