### PR TITLE
feat(paper): 보유기간 + 거래내역 CSV 내보내기 + 실현손익 컬럼

### DIFF
--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -97,6 +97,8 @@ class HoldingItem(BaseModel):
     pnl: int                  # 평가손익 = eval - cost
     pnl_pct: float            # 평가수익률 %
     price_source: str         # "kis"|"yfinance"|"close"
+    since: Optional[str] = None       # 현재 보유 시작일 YYYY-MM-DD (재진입 시 마지막 진입일)
+    holding_days: Optional[int] = None  # 보유 일수(since~오늘)
 
 
 class PortfolioResponse(BaseModel):

--- a/ETF_RAG/api/paper.py
+++ b/ETF_RAG/api/paper.py
@@ -7,7 +7,9 @@
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+
+KST = timezone(timedelta(hours=9))
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import delete, func as safunc, select
@@ -77,8 +79,36 @@ def _holdings(db: Session, user_id: int):
     ))
 
 
+def _holding_since_map(db: Session, user_id: int) -> dict:
+    """종목별 '현재 보유 구간의 진입일' {ticker: date(KST)}.
+
+    거래를 시간순으로 누적 수량을 따라가다가, 수량이 0→양수가 되는 마지막
+    시점이 현재 보유의 시작이다(전량 매도 후 재매수 시 재진입일 반영).
+    """
+    since: dict = {}
+    running: dict = {}
+    rows = db.scalars(
+        select(PaperTrade).where(PaperTrade.user_id == user_id)
+        .order_by(PaperTrade.created_at.asc(), PaperTrade.id.asc())
+    )
+    for t in rows:
+        prev = running.get(t.ticker, 0)
+        if t.side == "buy":
+            if prev <= 0:  # 신규 진입(0에서 양수로)
+                d = t.created_at.astimezone(KST) if t.created_at else None
+                since[t.ticker] = d.strftime("%Y-%m-%d") if d else None
+            running[t.ticker] = prev + t.qty
+        else:  # sell
+            running[t.ticker] = prev - t.qty
+            if running[t.ticker] <= 0:
+                since.pop(t.ticker, None)  # 전량 청산 → 진입일 리셋
+    return since
+
+
 def _build_portfolio(db: Session, user_id: int) -> PortfolioResponse:
     acc = _get_or_create_account(db, user_id)
+    since_map = _holding_since_map(db, user_id)
+    today_kst = datetime.now(KST).date()
     items = []
     holdings_value = 0
     for h in _holdings(db, user_id):
@@ -92,12 +122,21 @@ def _build_portfolio(db: Session, user_id: int) -> PortfolioResponse:
         pnl = eval_value - cost_value
         pnl_pct = (pnl / cost_value * 100.0) if cost_value > 0 else 0.0
         holdings_value += eval_value
+        since = since_map.get(h.ticker)
+        holding_days = None
+        if since:
+            try:
+                d0 = datetime.strptime(since, "%Y-%m-%d").date()
+                holding_days = (today_kst - d0).days
+            except ValueError:
+                holding_days = None
         items.append(HoldingItem(
             ticker=h.ticker, name=p["name"], qty=h.qty,
             avg_price=round(h.avg_price, 2), current_price=cur,
             eval_value=eval_value, cost_value=cost_value,
             pnl=pnl, pnl_pct=round(pnl_pct, 2),
             price_source=p.get("source", "close"),
+            since=since, holding_days=holding_days,
         ))
     items.sort(key=lambda x: x.eval_value, reverse=True)
     total_value = acc.cash + holdings_value
@@ -113,8 +152,7 @@ def _build_portfolio(db: Session, user_id: int) -> PortfolioResponse:
 
 def _today_kst() -> str:
     """KST 기준 YYYYMMDD (수집/거래일 기준 통일)."""
-    from datetime import timedelta
-    return (datetime.now(timezone.utc) + timedelta(hours=9)).strftime("%Y%m%d")
+    return datetime.now(KST).strftime("%Y%m%d")
 
 
 def _user_total_value(db: Session, user_id: int, price_fn) -> int:

--- a/ETF_RAG/frontend/src/app/invest/page.tsx
+++ b/ETF_RAG/frontend/src/app/invest/page.tsx
@@ -157,6 +157,34 @@ export default function InvestPage() {
     }
   };
 
+  // 거래내역 CSV 다운로드 (클라이언트 측, 백엔드 불필요). Excel 한글 위해 BOM.
+  const exportCsv = () => {
+    if (!trades.length) return;
+    const esc = (v: string | number | null) => {
+      const s = v == null ? "" : String(v);
+      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    const header = ["일시", "종목", "종목코드", "구분", "수량", "단가", "금액", "실현손익"];
+    const rows = trades.map((t) => [
+      t.created_at?.replace("T", " ").slice(0, 19) ?? "",
+      t.name ?? t.ticker,
+      t.ticker,
+      t.side === "buy" ? "매수" : "매도",
+      t.qty,
+      Math.round(t.price),
+      t.amount,
+      t.realized_pnl ?? "",
+    ]);
+    const csv = [header, ...rows].map((r) => r.map(esc).join(",")).join("\r\n");
+    const blob = new Blob(["﻿" + csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `가상투자_거래내역_${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const doDividend = async () => {
     setBusy(true);
     setMsg(null);
@@ -319,7 +347,14 @@ export default function InvestPage() {
               <tbody>
                 {pf.holdings.map((h) => (
                   <tr key={h.ticker}>
-                    <td className="text-left">{h.name}</td>
+                    <td className="text-left">
+                      {h.name}
+                      {h.holding_days != null && (
+                        <span className="block text-[10px] text-gray-400">
+                          {h.since} · {h.holding_days}일째
+                        </span>
+                      )}
+                    </td>
                     <td className="text-right tabular-nums">{h.qty.toLocaleString("ko-KR")}</td>
                     <td className="text-right tabular-nums">{Math.round(h.avg_price).toLocaleString("ko-KR")}</td>
                     <td className="text-right tabular-nums">{h.current_price.toLocaleString("ko-KR")}</td>
@@ -415,7 +450,17 @@ export default function InvestPage() {
       {/* 거래 내역 */}
       {trades.length > 0 && (
         <section className="mb-5">
-          <h2 className="mb-2 text-sm font-semibold text-gray-800">거래 내역</h2>
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-gray-800">거래 내역</h2>
+            <button
+              type="button"
+              onClick={exportCsv}
+              title="거래 내역을 CSV 파일로 내려받기"
+              className="rounded-lg border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100"
+            >
+              ⬇ CSV 내보내기
+            </button>
+          </div>
           <div className="overflow-x-auto">
             <table className="comparison-table text-xs">
               <thead>
@@ -426,6 +471,7 @@ export default function InvestPage() {
                   <th className="text-right">수량</th>
                   <th className="text-right">단가</th>
                   <th className="text-right">금액</th>
+                  <th className="text-right">실현손익</th>
                 </tr>
               </thead>
               <tbody>
@@ -441,6 +487,11 @@ export default function InvestPage() {
                     <td className="text-right tabular-nums">{t.qty.toLocaleString("ko-KR")}</td>
                     <td className="text-right tabular-nums">{Math.round(t.price).toLocaleString("ko-KR")}</td>
                     <td className="text-right tabular-nums">{t.amount.toLocaleString("ko-KR")}</td>
+                    <td className={`text-right tabular-nums ${t.realized_pnl == null ? "text-gray-300" : signColor(t.realized_pnl)}`}>
+                      {t.realized_pnl == null
+                        ? "-"
+                        : `${t.realized_pnl > 0 ? "+" : ""}${t.realized_pnl.toLocaleString("ko-KR")}`}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -250,6 +250,8 @@ export interface PaperHolding {
   pnl: number;
   pnl_pct: number;
   price_source: string;
+  since?: string | null;        // 보유 시작일 YYYY-MM-DD
+  holding_days?: number | null; // 보유 일수
 }
 export interface PaperPortfolio {
   cash: number;

--- a/ETF_RAG/tests/test_paper.py
+++ b/ETF_RAG/tests/test_paper.py
@@ -411,3 +411,62 @@ def test_dividend_no_dps_holdings(client):
         r = client.post("/me/paper/dividend", headers=auth)
     b = r.json()
     assert b["paid"] is False and b["total"] == 0
+
+
+def test_portfolio_holding_since_and_days(client):
+    """보유 종목에 보유 시작일(since)·보유일수(holding_days)가 채워진다."""
+    auth = _auth(client)
+    with _price_patch({"005930": 100}):
+        client.post("/me/paper/buy", json={"ticker": "005930", "qty": 10}, headers=auth)
+        pf = client.get("/me/paper/portfolio", headers=auth).json()
+    h = pf["holdings"][0]
+    assert h["since"] is not None          # YYYY-MM-DD
+    assert len(h["since"]) == 10
+    assert h["holding_days"] is not None and h["holding_days"] >= 0
+
+
+def test_holding_since_map_reentry():
+    """전량 매도 후 재매수 시 since가 '재진입일'로 갱신된다."""
+    from datetime import datetime, timezone, timedelta
+    from unittest.mock import MagicMock
+    from api import paper
+
+    KST = timezone(timedelta(hours=9))
+
+    class T:  # PaperTrade 더미
+        def __init__(self, ticker, side, qty, day):
+            self.ticker = ticker; self.side = side; self.qty = qty; self.id = day
+            self.created_at = datetime(2026, 6, day, 10, 0, tzinfo=KST)
+
+    trades = [
+        T("005930", "buy", 10, 1),    # 6/1 진입
+        T("005930", "sell", 10, 5),   # 6/5 전량 청산
+        T("005930", "buy", 5, 10),    # 6/10 재진입 ← since 기준
+        T("000660", "buy", 3, 2),     # 6/2 진입(보유 유지)
+    ]
+    db = MagicMock()
+    db.scalars.return_value = trades
+    out = paper._holding_since_map(db, user_id=1)
+    assert out["005930"] == "2026-06-10"   # 재진입일
+    assert out["000660"] == "2026-06-02"
+
+
+def test_holding_since_map_fully_sold_excluded():
+    """전량 매도해 보유 0인 종목은 since에서 제외."""
+    from datetime import datetime, timezone, timedelta
+    from unittest.mock import MagicMock
+    from api import paper
+    KST = timezone(timedelta(hours=9))
+
+    class T:
+        def __init__(self, ticker, side, qty, day):
+            self.ticker = ticker; self.side = side; self.qty = qty; self.id = day
+            self.created_at = datetime(2026, 6, day, 10, 0, tzinfo=KST)
+
+    db = MagicMock()
+    db.scalars.return_value = [
+        T("005930", "buy", 10, 1),
+        T("005930", "sell", 10, 3),   # 전량 청산
+    ]
+    out = paper._holding_since_map(db, user_id=1)
+    assert "005930" not in out


### PR DESCRIPTION
## 배경
ToDo 1번 — 가상투자 실용성 보강. 데이터가 이미 있어 빠르게 구현.

## 1) 보유 종목 보유기간
- 백엔드: `HoldingItem`에 `since`(현재 보유 진입일)·`holding_days` 추가
- `_holding_since_map`: 거래 시간순 누적수량을 추적해 **0→양수가 되는 마지막 시점**을 진입일로(전량 청산 후 재매수 시 **재진입일** 반영). N+1 없이 1쿼리로 집계
- 프론트: 보유 표 종목명 아래 `YYYY-MM-DD · N일째`
- `KST` 상수 정리(`_today_kst`도 통일)

## 2) 거래내역 CSV 내보내기
- **클라이언트 측** 생성·다운로드(백엔드 0). Excel 한글 깨짐 방지 UTF-8 BOM + 셀 이스케이프(쉼표/따옴표/줄바꿈)
- 컬럼: 일시 / 종목 / 종목코드 / 구분 / 수량 / 단가 / 금액 / 실현손익

## 3) 거래내역 표 실현손익 컬럼
- 매도 행에 실현손익(손익 색상), 매수는 `-`

## 검증
- 테스트 +3 (보유기간 통합 1 · 재진입/청산 단위 2), 전체 **857 통과**
- `tsc` + `next build`(13 라우트) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)