### PR TITLE
feat(frontend): 공통 UX 피드백 컴포넌트 — 로딩/에러/빈상태 통일 + 접근성

### DIFF
--- a/ETF_RAG/frontend/src/app/account/page.tsx
+++ b/ETF_RAG/frontend/src/app/account/page.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/lib/AuthContext";
 import { changePassword, deleteAccount, updateNickname } from "@/lib/auth";
+import { Notice } from "@/components/Feedback";
 
 export default function AccountPage() {
   const { user, loading, logout, refresh } = useAuth();
@@ -70,15 +71,6 @@ function Card({
   );
 }
 
-function Notice({ msg, kind }: { msg: string; kind: "ok" | "err" }) {
-  return (
-    <p
-      className={`mt-2 text-xs ${kind === "ok" ? "text-green-600" : "text-red-600"}`}
-    >
-      {msg}
-    </p>
-  );
-}
 
 const inputCls =
   "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none";
@@ -129,7 +121,7 @@ function NicknameSection({
           저장
         </button>
       </form>
-      {msg && <Notice msg={msg.t} kind={msg.k} />}
+      {msg && <Notice message={msg.t} kind={msg.k} />}
     </Card>
   );
 }
@@ -201,7 +193,7 @@ function PasswordSection() {
           비밀번호 변경
         </button>
       </form>
-      {msg && <Notice msg={msg.t} kind={msg.k} />}
+      {msg && <Notice message={msg.t} kind={msg.k} />}
     </Card>
   );
 }
@@ -270,7 +262,7 @@ function DeleteSection({ onDeleted }: { onDeleted: () => void }) {
           </div>
         </form>
       )}
-      {err && <Notice msg={err} kind="err" />}
+      {err && <Notice message={err} kind="err" />}
     </Card>
   );
 }

--- a/ETF_RAG/frontend/src/app/comparison/page.tsx
+++ b/ETF_RAG/frontend/src/app/comparison/page.tsx
@@ -12,6 +12,7 @@ import TickerSearch from "@/components/TickerSearch";
 import ChartImage from "@/components/ChartImage";
 import ComparisonTable from "@/components/ComparisonTable";
 import DataRangeNote from "@/components/DataRangeNote";
+import { Loading, ErrorText } from "@/components/Feedback";
 import WatchlistStar from "@/components/WatchlistStar";
 
 // 상대 수익률 차트 기간 (1주=5거래일, 1개월=20, 3개월=60 ...)
@@ -152,8 +153,8 @@ export default function ComparisonPage() {
         </span>
       </div>
 
-      {loading && <p className="mt-6 text-center text-sm text-gray-400">비교 중…</p>}
-      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+      {loading && <Loading text="비교 중…" />}
+      {error && <ErrorText message={error} />}
 
       {data && !loading && (
         <div className="mt-5">

--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -6,6 +6,7 @@ import type { FinancialResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import ChartImage from "@/components/ChartImage";
 import DataRangeNote from "@/components/DataRangeNote";
+import { Loading, ErrorText } from "@/components/Feedback";
 import WatchlistStar from "@/components/WatchlistStar";
 
 // 억원 단위
@@ -125,8 +126,8 @@ export default function FinancialPage() {
         </span>
       </div>
 
-      {loading && <p className="mt-6 text-center text-sm text-gray-400">조회 중…</p>}
-      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+      {loading && <Loading text="조회 중…" />}
+      {error && <ErrorText message={error} />}
 
       {data && !loading && (
         <div className="mt-5">

--- a/ETF_RAG/frontend/src/app/invest/page.tsx
+++ b/ETF_RAG/frontend/src/app/invest/page.tsx
@@ -28,6 +28,7 @@ import type {
 import TickerSearch from "@/components/TickerSearch";
 import ChartImage from "@/components/ChartImage";
 import PortfolioPie from "@/components/PortfolioPie";
+import { Notice, EmptyState } from "@/components/Feedback";
 
 const won = (v: number) => `${Math.round(v).toLocaleString("ko-KR")}원`;
 function signColor(v: number): string {
@@ -304,11 +305,7 @@ export default function InvestPage() {
             예상 금액 약 {won(price.price * parseInt(qty, 10))}
           </p>
         )}
-        {msg && (
-          <p className={`mt-2 text-xs ${msg.k === "ok" ? "text-green-600" : "text-red-600"}`}>
-            {msg.t}
-          </p>
-        )}
+        {msg && <Notice message={msg.t} kind={msg.k} />}
       </section>
 
       {/* 보유 현황 */}
@@ -371,7 +368,7 @@ export default function InvestPage() {
           </div>
           </>
         ) : (
-          <p className="text-xs text-gray-400">보유 종목이 없어요. 위에서 매수해 보세요.</p>
+          <EmptyState icon="📦" message="보유 종목이 없어요. 위에서 매수해 보세요." />
         )}
       </section>
 

--- a/ETF_RAG/frontend/src/app/outlook/page.tsx
+++ b/ETF_RAG/frontend/src/app/outlook/page.tsx
@@ -5,6 +5,7 @@ import { getOutlook } from "@/lib/api";
 import type { OutlookResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import DataRangeNote from "@/components/DataRangeNote";
+import { Loading, ErrorText } from "@/components/Feedback";
 import WatchlistStar from "@/components/WatchlistStar";
 
 const HORIZONS = ["1m", "3m", "6m", "1y"];
@@ -103,8 +104,8 @@ export default function OutlookPage() {
         </div>
       )}
 
-      {loading && <p className="mt-6 text-center text-sm text-gray-400">분석 중…</p>}
-      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+      {loading && <Loading text="분석 중…" />}
+      {error && <ErrorText message={error} />}
 
       {data && !loading && (
         <div className="mt-5 space-y-4">

--- a/ETF_RAG/frontend/src/app/sector/page.tsx
+++ b/ETF_RAG/frontend/src/app/sector/page.tsx
@@ -5,6 +5,7 @@ import { getSector } from "@/lib/api";
 import type { SectorResponse } from "@/lib/types";
 import ChartImage from "@/components/ChartImage";
 import DataRangeNote from "@/components/DataRangeNote";
+import { Loading, ErrorText } from "@/components/Feedback";
 
 function jo(v: number): string {
   const 조 = 1_0000_0000_0000;
@@ -75,10 +76,8 @@ export default function SectorPage() {
       <h1 className="mb-1 text-lg font-bold text-gray-900">🏭 섹터 분석</h1>
       <p className="mb-4 text-xs text-gray-500">업종별 등락률·시가총액·밸류에이션</p>
 
-      {loading && !data && (
-        <p className="mt-6 text-center text-sm text-gray-400">불러오는 중…</p>
-      )}
-      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+      {loading && !data && <Loading text="불러오는 중…" />}
+      {error && <ErrorText message={error} />}
 
       {data && (
         <div className="space-y-4">

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -7,6 +7,7 @@ import type { TechnicalResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
 import WatchlistStar from "@/components/WatchlistStar";
 import DataRangeNote from "@/components/DataRangeNote";
+import { Loading, ErrorText } from "@/components/Feedback";
 import PriceCard from "@/components/PriceCard";
 import OrderbookCard from "@/components/OrderbookCard";
 
@@ -147,10 +148,8 @@ function TechnicalInner() {
         </div>
       )}
 
-      {loading && (
-        <p className="mt-6 text-center text-sm text-gray-400">분석 중…</p>
-      )}
-      {error && <p className="mt-6 text-center text-sm text-red-600">{error}</p>}
+      {loading && <Loading text="분석 중…" />}
+      {error && <ErrorText message={error} />}
 
       {data && !loading && (
         <div className="mt-5">

--- a/ETF_RAG/frontend/src/components/ChatMessage.tsx
+++ b/ETF_RAG/frontend/src/components/ChatMessage.tsx
@@ -3,6 +3,7 @@ import remarkGfm from "remark-gfm";
 import type { UiMessage } from "@/lib/types";
 import { questionTypeLabel } from "@/lib/labels";
 import StructuredDataView from "./StructuredData";
+import { Spinner } from "./Feedback";
 
 export default function ChatMessage({ message }: { message: UiMessage }) {
   const isUser = message.role === "user";
@@ -28,7 +29,10 @@ export default function ChatMessage({ message }: { message: UiMessage }) {
 
         {/* 스트리밍 중 상태줄 (도구 호출 등). 본문이 아직 없을 때만. */}
         {!isUser && message.status && !message.content && (
-          <div className="text-xs text-gray-500">{message.status}</div>
+          <div role="status" aria-live="polite" className="flex items-center gap-2 text-xs text-gray-500">
+            <Spinner className="h-3 w-3" />
+            <span>{message.status}</span>
+          </div>
         )}
 
         {isUser ? (

--- a/ETF_RAG/frontend/src/components/Feedback.tsx
+++ b/ETF_RAG/frontend/src/components/Feedback.tsx
@@ -1,0 +1,68 @@
+/**
+ * 공통 UX 피드백 컴포넌트 — 로딩/에러/성공/빈 상태를 한 곳에서 통일.
+ * 페이지마다 인라인으로 흩어져 있던 "...중…"/text-red-600/text-gray-400을 대체한다.
+ */
+
+/** 작은 회전 스피너 (Tailwind animate-spin, 추가 CSS 불필요). */
+export function Spinner({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-block animate-spin rounded-full border-2 border-gray-300 border-t-blue-500 ${className}`}
+    />
+  );
+}
+
+/** 데이터 로딩 중 — 스피너 + 문구. role=status/aria-busy로 스크린리더 안내. */
+export function Loading({ text = "불러오는 중…" }: { text?: string }) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="mt-6 flex items-center justify-center gap-2 text-sm text-gray-400"
+    >
+      <Spinner className="h-4 w-4" />
+      <span>{text}</span>
+    </div>
+  );
+}
+
+/** API 실패 등 에러 메시지. aria-live로 알림. */
+export function ErrorText({ message }: { message: string }) {
+  return (
+    <p role="alert" className="mt-6 text-center text-sm text-red-600">
+      {message}
+    </p>
+  );
+}
+
+/** 액션 결과 알림(성공/실패). 폼·거래 등 인라인 피드백 통일. */
+export function Notice({ message, kind = "ok" }: { message: string; kind?: "ok" | "err" }) {
+  return (
+    <p
+      role={kind === "err" ? "alert" : "status"}
+      className={`mt-2 text-xs ${kind === "ok" ? "text-green-600" : "text-red-600"}`}
+    >
+      {message}
+    </p>
+  );
+}
+
+/** 빈 상태 — 아이콘 + 메시지 + (선택) 행동 유도. */
+export function EmptyState({
+  icon = "📭",
+  message,
+  action,
+}: {
+  icon?: string;
+  message: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="mt-4 flex flex-col items-center gap-2 py-6 text-center">
+      <span className="text-2xl" aria-hidden="true">{icon}</span>
+      <p className="text-xs text-gray-400">{message}</p>
+      {action}
+    </div>
+  );
+}


### PR DESCRIPTION
## 배경
UX 다듬기. Explore로 프론트 현황 조사 → 컴포넌트 재사용은 우수하나, **로딩이 텍스트뿐(스피너 없음)·빈 상태 제각각·에러/성공 인라인 중복·접근성 희소**가 약점.

## 신규 `components/Feedback.tsx`
- **Spinner**: Tailwind `animate-spin` 회전 스피너(추가 CSS 0)
- **Loading**: 스피너+문구, `role=status`/`aria-busy`
- **ErrorText**: `role=alert` 에러 메시지
- **Notice**: 성공/실패 인라인 알림
- **EmptyState**: 아이콘+메시지+선택 CTA

## 적용
- 5개 데이터 탭(technical/financial/comparison/outlook/sector): 로딩 텍스트 → `<Loading>`(스피너 추가), 인라인 에러 → `<ErrorText>`
- invest: `msg` → `<Notice>`, "보유 종목 없음" → `<EmptyState icon="📦">`
- account: 자체 `Notice` 정의 제거 → **공통 Notice 재사용**(중복 제거)
- ChatMessage 스트리밍 상태줄: 스피너 + `role=status`/`aria-live=polite`(스크린리더)

## 범위 밖 (의도)
- **다크모드**: 색 토큰 전면 교체 + globals 주석대로 말풍선 충돌 위험 → 별도 작업으로 보류

## 검증
- `tsc` + `next build`(13 라우트) 통과, **백엔드 변경 없음**

🤖 Generated with [Claude Code](https://claude.com/claude-code)