### PR TITLE
fix(collect): 부분 누락(ETF/주식 한쪽만) 감지 + stale 경계 보정

### DIFF
--- a/ETF_RAG/scripts/verify_and_recover.py
+++ b/ETF_RAG/scripts/verify_and_recover.py
@@ -60,20 +60,44 @@ def get_expected_business_days(n_days: int = 10) -> list[str]:
     return sorted(result)
 
 
+# 정상 영업일 하한 — ETF/주식을 각각 검사(한쪽만 빠진 날 감지). 휴장일은 둘 다 0.
+_MIN_ETF = 500
+_MIN_STOCK = 1500
+
+
 def find_missing_dates(conn, expected_dates: list[str]) -> list[str]:
-    """DB에서 누락된 영업일 찾기."""
+    """DB에서 누락된 영업일 찾기.
+
+    ETF/주식을 분리 검사 — 한쪽만 빠진 날(예: 주식 수집 실패로 ETF만 존재)도
+    감지한다. 둘 다 0이면 휴장일로 보고 정상 처리(recover에서 0건=휴장 확인).
+    """
     missing = []
     for date in expected_dates:
-        cur = conn.execute(
-            "SELECT COUNT(DISTINCT ticker) FROM daily_prices WHERE date = ?",
+        row = conn.execute(
+            """
+            SELECT
+              SUM(CASE WHEN i.type='etf' THEN 1 ELSE 0 END) etf_n,
+              SUM(CASE WHEN i.type='stock' THEN 1 ELSE 0 END) stock_n
+            FROM daily_prices p JOIN instruments i ON p.ticker = i.ticker
+            WHERE p.date = ?
+            """,
             (date,),
-        )
-        count = cur.fetchone()[0]
-        if count < 500:  # 최소 500종목은 있어야 정상
-            missing.append((date, count))
-            logger.warning(f"누락 감지: {date} — {count}종목 (최소 500 필요)")
+        ).fetchone()
+        etf_n = row[0] or 0
+        stock_n = row[1] or 0
+        if etf_n == 0 and stock_n == 0:
+            # 둘 다 없음 → 휴장일 후보. recover의 수집 시도(0건=휴장)로 자연 확인.
+            missing.append((date, 0))
+            logger.warning(f"누락 감지: {date} — 데이터 없음(휴장일 가능)")
+        elif etf_n < _MIN_ETF or stock_n < _MIN_STOCK:
+            # 한쪽만 부족 → 부분 누락(수집 중단 등). 보충 대상.
+            missing.append((date, etf_n + stock_n))
+            logger.warning(
+                f"부분 누락 감지: {date} — ETF {etf_n}/주식 {stock_n} "
+                f"(하한 ETF {_MIN_ETF}/주식 {_MIN_STOCK})"
+            )
         else:
-            logger.info(f"정상: {date} — {count}종목")
+            logger.info(f"정상: {date} — ETF {etf_n}/주식 {stock_n}")
     return missing
 
 

--- a/ETF_RAG/src/data/db_downloader.py
+++ b/ETF_RAG/src/data/db_downloader.py
@@ -75,7 +75,7 @@ def _is_full_depth(db_path: Path) -> bool:
 
 
 def _max_stale_days() -> int:
-    """DB_MAX_STALE_DAYS 환경변수(없으면 기본 5, 0이면 비활성)."""
+    """DB_MAX_STALE_DAYS 환경변수(없으면 기본 3, 0이면 비활성)."""
     try:
         return int(os.getenv("DB_MAX_STALE_DAYS", str(_STALE_DAYS_DEFAULT)))
     except (TypeError, ValueError):
@@ -102,8 +102,8 @@ def _is_fresh_enough(db_path: Path) -> bool:
             return False
         latest_dt = datetime.strptime(str(latest), "%Y%m%d").date()
         age = (datetime.now(KST).date() - latest_dt).days
-        if age > max_days:
-            logger.warning(f"DB 최신일 {latest} ({age}일 전) — stale 임계 {max_days}일 초과")
+        if age >= max_days:
+            logger.warning(f"DB 최신일 {latest} ({age}일 전) — stale 임계 {max_days}일 도달")
             return False
         return True
     except Exception:  # noqa: BLE001 — 판단 불가 시 보수적으로 fresh 취급(재다운 안 함)
@@ -115,7 +115,7 @@ def ensure_db(db_path: Path) -> bool:
 
     이미 존재하더라도 (1) 무결성 검사 — 손상(malformed)이면 재다운로드,
     (2) 깊이 검사 — 일일수집만으로 쌓인 얕은 1년치 DB면 full Release로 교체,
-    (3) 신선도 검사 — 최신일이 stale 임계(DB_MAX_STALE_DAYS, 기본 5일) 초과면
+    (3) 신선도 검사 — 최신일이 stale 임계(DB_MAX_STALE_DAYS, 기본 3일) 도달이면
         Release(매일 갱신)로 재다운로드. 영속 볼륨에서 DB가 굳는 문제 대응.
     """
     if db_path.exists():

--- a/ETF_RAG/tests/test_db_downloader.py
+++ b/ETF_RAG/tests/test_db_downloader.py
@@ -190,3 +190,25 @@ def test_ensure_db_skips_when_fresh_and_deep(tmp_path, monkeypatch):
         raise AssertionError("재다운하면 안 됨")
     monkeypatch.setattr("src.data.db_downloader._download", fake_download)
     assert ensure_db(db) is True
+
+
+def test_is_fresh_enough_boundary_exactly_threshold(tmp_path, monkeypatch):
+    """정확히 임계일(기본 3일) 전 데이터는 stale로 잡힌다(>= 경계)."""
+    from datetime import datetime, timezone, timedelta
+    from src.data.db_downloader import _is_fresh_enough
+    KST = timezone(timedelta(hours=9))
+    three_days_ago = (datetime.now(KST).date() - timedelta(days=3)).strftime("%Y%m%d")
+    db = tmp_path / "edge.db"
+    _make_db_with_date(db, three_days_ago)
+    assert _is_fresh_enough(db) is False  # 3 >= 3 → stale
+
+
+def test_is_fresh_enough_one_day_old_true(tmp_path):
+    """1일 전(평일 정상 지연)은 fresh."""
+    from datetime import datetime, timezone, timedelta
+    from src.data.db_downloader import _is_fresh_enough
+    KST = timezone(timedelta(hours=9))
+    one_day_ago = (datetime.now(KST).date() - timedelta(days=1)).strftime("%Y%m%d")
+    db = tmp_path / "y.db"
+    _make_db_with_date(db, one_day_ago)
+    assert _is_fresh_enough(db) is True

--- a/ETF_RAG/tests/test_verify_recover.py
+++ b/ETF_RAG/tests/test_verify_recover.py
@@ -1,0 +1,64 @@
+"""verify_and_recover.find_missing_dates — ETF/주식 분리 누락 감지 검증.
+
+회귀 대상: ETF만 있고 주식이 0인 날(수집 중단)을 'COUNT(ticker)<500'만 보던
+기존 로직이 정상 처리해 누락을 방치하던 버그(2026-06-26 6/22·6/25 케이스).
+"""
+
+import sqlite3
+
+import pytest
+
+from scripts.verify_and_recover import find_missing_dates
+
+
+def _make_conn(rows):
+    """rows: [(ticker, date, type)] → in-memory DB(daily_prices+instruments)."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE daily_prices (ticker TEXT, date TEXT, close INTEGER)")
+    conn.execute("CREATE TABLE instruments (ticker TEXT PRIMARY KEY, type TEXT)")
+    seen = set()
+    for ticker, date, typ in rows:
+        conn.execute("INSERT INTO daily_prices VALUES (?,?,1)", (ticker, date))
+        if ticker not in seen:
+            conn.execute("INSERT INTO instruments VALUES (?,?)", (ticker, typ))
+            seen.add(ticker)
+    conn.commit()
+    return conn
+
+
+def _rows(date, n_etf, n_stock):
+    r = [(f"E{i:05d}", date, "etf") for i in range(n_etf)]
+    r += [(f"S{i:05d}", date, "stock") for i in range(n_stock)]
+    return r
+
+
+def test_normal_day_not_flagged():
+    conn = _make_conn(_rows("20260623", 1100, 2700))
+    assert find_missing_dates(conn, ["20260623"]) == []
+
+
+def test_stock_missing_flagged():
+    """ETF만 있고 주식 0 → 부분 누락 감지(기존 버그가 놓치던 케이스)."""
+    conn = _make_conn(_rows("20260622", 1140, 0))
+    missing = find_missing_dates(conn, ["20260622"])
+    assert [m[0] for m in missing] == ["20260622"]
+
+
+def test_etf_missing_flagged():
+    """주식만 있고 ETF 0 → 부분 누락 감지."""
+    conn = _make_conn(_rows("20260626", 0, 2700))
+    missing = find_missing_dates(conn, ["20260626"])
+    assert [m[0] for m in missing] == ["20260626"]
+
+
+def test_empty_day_flagged_as_holiday_candidate():
+    """둘 다 0 → 휴장일 후보로 감지(recover에서 0건=휴장 확인)."""
+    conn = _make_conn([])
+    missing = find_missing_dates(conn, ["20260620"])
+    assert [m[0] for m in missing] == ["20260620"]
+
+
+def test_stock_below_threshold_flagged():
+    """주식이 하한(1500) 미만이면 누락."""
+    conn = _make_conn(_rows("20260624", 1100, 800))
+    assert [m[0] for m in find_missing_dates(conn, ["20260624"])] == ["20260624"]


### PR DESCRIPTION
## 배경 (ToDo B — 로컬 DB 누락)
로컬 DB의 **6/22(월)·6/25(목)에 주식이 0**(ETF만 존재). 수집 로그 보니 ETF 개별 지표(괴리율/추적오차) 수집이 ConnectionReset으로 수 시간 지연 → 주식 수집 단계 미도달.

**진짜 문제는 검증이 이를 못 잡은 것**: `find_missing_dates`가 `COUNT(DISTINCT ticker) < 500`만 봐서, ETF만 1140개 있어도 "정상"으로 통과 → 부분 누락 방치, 자동 복구 안 됨.

## 수정
### verify_and_recover: ETF/주식 분리 감지
- `instruments.type`으로 ETF/주식 **각각** 카운트 (하한 ETF 500 / 주식 1500)
- 둘 다 0 → 휴장일 후보 / 한쪽만 부족 → 부분 누락(보충 대상)
- **로컬 6/22·6/25 보충 수집으로 주식 2875개씩 복구 완료** ✅

### db_downloader: stale 경계 보정
- `age > max_days` → `age >= max_days` (임계 3일이면 정확히 3일 전도 stale)
- 프로덕션 6/23 DB(3일 전)가 경계 미달로 안 잡히던 것 수정

## 검증
- `test_verify_recover` 5개(분리 감지/휴장/하한) + stale 경계 2개, 전체 **869 통과**

🤖 Generated with [Claude Code](https://claude.com/claude-code)