### PR TITLE
feat(frontend): 가상투자 보유종목 클릭→주문 + 채팅 관심종목 종목명

### DIFF
--- a/ETF_RAG/frontend/src/app/invest/page.tsx
+++ b/ETF_RAG/frontend/src/app/invest/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/lib/AuthContext";
 import {
@@ -55,6 +55,7 @@ export default function InvestPage() {
   const [ticker, setTicker] = useState("");
   const [tickerLabel, setTickerLabel] = useState("");
   const [qty, setQty] = useState("");
+  const orderRef = useRef<HTMLElement>(null); // 보유종목 클릭 시 주문 영역으로 스크롤
   const [price, setPrice] = useState<PriceData | null>(null); // 선택 종목 현재가
 
   const refresh = useCallback(async () => {
@@ -103,6 +104,12 @@ export default function InvestPage() {
     setPrice(null);
     const p = await getPrice(sel.ticker);
     if (p) setPrice(p);
+  };
+
+  // 보유 종목 행 클릭 → 주문 영역에 채우고 스크롤(바로 매수/매도)
+  const onPickHolding = (h: { ticker: string; name: string }) => {
+    onSelectTicker(h);
+    orderRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   // 현금의 일정 비율로 매수 가능한 수량 자동 입력 (현재가 기준 내림)
@@ -233,7 +240,7 @@ export default function InvestPage() {
       )}
 
       {/* 매수/매도 */}
-      <section className="mb-5 rounded-xl border border-gray-200 dark:border-gray-800 p-4">
+      <section ref={orderRef} className="mb-5 scroll-mt-4 rounded-xl border border-gray-200 dark:border-gray-800 p-4">
         <h2 className="mb-2 text-sm font-semibold text-gray-800">주문</h2>
         <TickerSearch
           onSelect={onSelectTicker}
@@ -329,6 +336,7 @@ export default function InvestPage() {
           <div className="mb-3">
             <PortfolioPie holdings={pf.holdings} cash={pf.cash} />
           </div>
+          <p className="mb-1 text-[11px] text-gray-400">💡 종목을 누르면 주문 영역에 채워져요 (매수·매도)</p>
           <div className="overflow-x-auto">
             <table className="comparison-table text-xs">
               <thead>
@@ -343,9 +351,14 @@ export default function InvestPage() {
               </thead>
               <tbody>
                 {pf.holdings.map((h) => (
-                  <tr key={h.ticker}>
+                  <tr
+                    key={h.ticker}
+                    onClick={() => onPickHolding({ ticker: h.ticker, name: h.name })}
+                    title="클릭하면 주문 영역에 채워져요 (매수/매도)"
+                    className="cursor-pointer hover:bg-blue-50"
+                  >
                     <td className="text-left">
-                      {h.name}
+                      <span className="font-medium text-blue-700">{h.name}</span>
                       {h.holding_days != null && (
                         <span className="block text-[10px] text-gray-400">
                           {h.since} · {h.holding_days}일째

--- a/ETF_RAG/frontend/src/components/WatchlistBar.tsx
+++ b/ETF_RAG/frontend/src/components/WatchlistBar.tsx
@@ -1,23 +1,54 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { useWatchlist } from "@/lib/useWatchlist";
+import { getWatchlistDetail } from "@/lib/auth";
+import type { WatchlistDetailItem } from "@/lib/types";
 
-/** 로그인 사용자의 관심종목 칩 목록. 클릭 시 기술적 분석 탭으로. 비어있거나 비로그인이면 숨김. */
+/** 로그인 사용자의 관심종목 칩. 종목명 표시(티커 작게). 클릭 시 기술적 분석 탭으로.
+ * 비어있거나 비로그인이면 숨김. */
 export default function WatchlistBar() {
   const { enabled, tickers } = useWatchlist();
+  const [detail, setDetail] = useState<WatchlistDetailItem[]>([]);
+
+  // 관심종목 목록 변화 시 종목명 포함 상세 재로드
+  useEffect(() => {
+    if (!enabled || tickers.length === 0) {
+      setDetail([]);
+      return;
+    }
+    let cancelled = false;
+    getWatchlistDetail().then((d) => {
+      if (!cancelled) setDetail(d);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // tickers 배열 내용 변화를 키로 감지
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, tickers.join(",")]);
+
   if (!enabled || tickers.length === 0) return null;
+
+  // detail 로드 전/실패 시엔 티커로 fallback
+  const items: WatchlistDetailItem[] =
+    detail.length > 0 ? detail : tickers.map((t) => ({ ticker: t, name: t }));
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-gray-100 pb-3">
       <span className="text-xs text-gray-500">⭐ 관심종목</span>
-      {tickers.map((t) => (
+      {items.map((it) => (
         <Link
-          key={t}
-          href={`/technical?ticker=${encodeURIComponent(t)}`}
+          key={it.ticker}
+          href={`/technical?ticker=${encodeURIComponent(it.ticker)}`}
+          title={it.ticker}
           className="rounded-full border border-gray-200 dark:border-gray-800 bg-gray-50 px-3 py-1 text-xs text-gray-700 hover:bg-gray-100"
         >
-          {t}
+          {it.name}
+          {it.name !== it.ticker && (
+            <span className="ml-1 text-[10px] text-gray-400">{it.ticker}</span>
+          )}
         </Link>
       ))}
     </div>


### PR DESCRIPTION
## 1) 가상투자 보유종목 클릭 → 매수/매도
사용자 요청 — `/invest` 보유 종목을 누르면 바로 주문 가능하게.
- 보유 표 행 클릭 → `onPickHolding`: 기존 `onSelectTicker` 재사용(종목명·현재가 채움) + 주문 영역으로 smooth 스크롤
- 행 `cursor-pointer`/hover, 종목명 파란 강조, "💡 종목을 누르면 주문 영역에 채워져요" 안내
- 보유 종목 추가매수/매도가 클릭 한 번으로

## 2) 채팅 탭 관심종목 종목명 표시
사용자 요청 — 채팅 탭 관심종목이 티커였던 것을 종목명으로.
- `WatchlistBar`가 `getWatchlistDetail`(`/me/watchlist/detail`, 사이드바와 동일 API 재사용)로 종목명 로드
- 관심종목 변경 시 재로드, 로드 전/실패 시 티커 fallback
- 종목명 + 티커(작게) 표시

## 검증
- `tsc` + 테스트 17 + `next build`(13 라우트) 통과, **백엔드 변경 없음**

🤖 Generated with [Claude Code](https://claude.com/claude-code)