### PR TITLE
feat(auth): 나이대(선택) 수집 + ID/비밀번호 찾기 안내

### DIFF
--- a/ETF_RAG/api/auth.py
+++ b/ETF_RAG/api/auth.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from config import JWT_ALGORITHM, JWT_EXPIRE_MINUTES, JWT_SECRET
 from api.db import get_db
 from api.models import (
+    AGE_GROUPS,
     AccountDeleteRequest,
     LoginRequest,
     PasswordChangeRequest,
@@ -95,6 +96,8 @@ def signup(req: SignupRequest, db: Session = Depends(get_db)) -> TokenResponse:
     if db.scalar(select(User).where(User.email == req.email)) is not None:
         raise HTTPException(status_code=400, detail="이미 가입된 이메일입니다.")
     user = User(email=req.email, password_hash=hash_password(req.password))
+    if req.age_group in AGE_GROUPS:  # 선택 — 허용값만 저장, 그 외 무시
+        user.age_group = req.age_group
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -120,7 +123,8 @@ def _display_nickname(user: User) -> str:
 
 def _user_response(user: User) -> UserResponse:
     return UserResponse(
-        id=user.id, email=user.email, nickname=_display_nickname(user)
+        id=user.id, email=user.email, nickname=_display_nickname(user),
+        age_group=user.age_group or None,
     )
 
 
@@ -150,11 +154,14 @@ def update_profile(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> UserResponse:
-    """닉네임 변경. 공백만 입력은 거부."""
+    """닉네임 변경(+선택 나이대). 공백만 입력은 거부."""
     nickname = req.nickname.strip()
     if not nickname:
         raise HTTPException(status_code=400, detail="닉네임을 입력하세요.")
     user.nickname = nickname
+    # 나이대: None이면 미변경, 허용값이면 설정, 그 외(빈값 등)는 미설정으로 비움
+    if req.age_group is not None:
+        user.age_group = req.age_group if req.age_group in AGE_GROUPS else None
     db.commit()
     db.refresh(user)
     return _user_response(user)

--- a/ETF_RAG/api/db.py
+++ b/ETF_RAG/api/db.py
@@ -50,6 +50,10 @@ def _migrate_add_columns() -> None:
         with engine.begin() as conn:
             conn.execute(text("ALTER TABLE users ADD COLUMN nickname VARCHAR(40)"))
         logger.info("마이그레이션: users.nickname 컬럼 추가")
+    if "age_group" not in cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE users ADD COLUMN age_group VARCHAR(10)"))
+        logger.info("마이그레이션: users.age_group 컬럼 추가")
 
     # paper_accounts.started_at (라운드 결산 기간 산정용). 기존 행은 created_at으로 채움.
     if "paper_accounts" in insp.get_table_names():

--- a/ETF_RAG/api/models.py
+++ b/ETF_RAG/api/models.py
@@ -44,9 +44,14 @@ class ComparisonRequest(BaseModel):
 
 
 # ── 인증 ────────────────────────────────────────────────
+# 허용 나이대 버킷 (분류정보, 선택). 빈 문자열은 '미설정'으로 처리.
+AGE_GROUPS = ("10대", "20대", "30대", "40대", "50대", "60대", "70대 이상")
+
+
 class SignupRequest(BaseModel):
     email: EmailStr
     password: str = Field(..., min_length=8, max_length=128)
+    age_group: Optional[str] = None  # 선택 — AGE_GROUPS 중 하나(아니면 무시)
 
 
 class LoginRequest(BaseModel):
@@ -63,6 +68,7 @@ class UserResponse(BaseModel):
     id: int
     email: EmailStr
     nickname: str  # 미설정 시 이메일 local-part로 fallback (auth.py에서 채움)
+    age_group: Optional[str] = None  # 나이대(선택, 미설정 시 None)
 
 
 class PasswordChangeRequest(BaseModel):
@@ -73,6 +79,8 @@ class PasswordChangeRequest(BaseModel):
 class ProfileUpdateRequest(BaseModel):
     # 1~40자. 공백만 입력 방지는 라우터에서 strip 후 검증.
     nickname: str = Field(..., min_length=1, max_length=40)
+    # 나이대(선택). None=변경 안 함, "" 또는 미허용값=미설정으로 비움, 허용값=설정.
+    age_group: Optional[str] = None
 
 
 class AccountDeleteRequest(BaseModel):

--- a/ETF_RAG/api/models_db.py
+++ b/ETF_RAG/api/models_db.py
@@ -39,6 +39,9 @@ class User(Base):
     # 표시용 닉네임(선택). 로그인은 이메일로, 이건 화면 표시·가상투자 랭킹 등에 사용.
     # 기존 유저/미입력은 NULL → 응답 시 이메일 local-part로 fallback.
     nickname: Mapped[Optional[str]] = mapped_column(String(40), nullable=True)
+    # 나이대(선택). 분류정보(10대~70대 이상 7버킷, 식별정보 아님) — 맞춤 추천 등에 활용.
+    # 기존 유저/미입력은 NULL. 이름·성별 등 민감정보는 수집하지 않음(개인정보 최소화).
+    age_group: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, server_default=func.now()
     )

--- a/ETF_RAG/frontend/src/app/account/page.tsx
+++ b/ETF_RAG/frontend/src/app/account/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/lib/AuthContext";
-import { changePassword, deleteAccount, updateNickname } from "@/lib/auth";
+import { AGE_GROUPS, changePassword, deleteAccount, updateProfile } from "@/lib/auth";
 import { Notice } from "@/components/Feedback";
 
 export default function AccountPage() {
@@ -40,6 +40,7 @@ export default function AccountPage() {
 
       <NicknameSection
         current={user.nickname}
+        currentAge={user.age_group ?? ""}
         onSaved={refresh}
       />
       <PasswordSection />
@@ -79,23 +80,28 @@ const btnCls =
 
 function NicknameSection({
   current,
+  currentAge,
   onSaved,
 }: {
   current: string;
+  currentAge: string;
   onSaved: () => Promise<void>;
 }) {
   const [value, setValue] = useState(current);
+  const [age, setAge] = useState(currentAge);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ k: "ok" | "err"; t: string } | null>(null);
+
+  const changed = value.trim() !== current || age !== currentAge;
 
   const save = async (e: React.FormEvent) => {
     e.preventDefault();
     setMsg(null);
     setBusy(true);
     try {
-      await updateNickname(value.trim());
+      await updateProfile(value.trim(), age); // age "" → 미설정으로 비움
       await onSaved();
-      setMsg({ k: "ok", t: "닉네임을 변경했어요." });
+      setMsg({ k: "ok", t: "저장했어요." });
     } catch (err) {
       setMsg({ k: "err", t: err instanceof Error ? err.message : "오류" });
     } finally {
@@ -104,8 +110,8 @@ function NicknameSection({
   };
 
   return (
-    <Card title="닉네임" desc="화면에 표시되는 이름이에요. 로그인에는 영향 없어요.">
-      <form onSubmit={save} className="flex gap-2">
+    <Card title="프로필" desc="화면 표시 이름과 나이대(선택). 로그인에는 영향 없어요.">
+      <form onSubmit={save} className="flex flex-col gap-2">
         <input
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -113,10 +119,20 @@ function NicknameSection({
           placeholder="닉네임"
           className={inputCls}
         />
+        <select
+          value={age}
+          onChange={(e) => setAge(e.target.value)}
+          className={inputCls}
+        >
+          <option value="">나이대 선택 안 함</option>
+          {AGE_GROUPS.map((g) => (
+            <option key={g} value={g}>{g}</option>
+          ))}
+        </select>
         <button
           type="submit"
-          disabled={busy || !value.trim() || value.trim() === current}
-          className={btnCls + " shrink-0"}
+          disabled={busy || !value.trim() || !changed}
+          className={btnCls}
         >
           저장
         </button>

--- a/ETF_RAG/frontend/src/app/login/page.tsx
+++ b/ETF_RAG/frontend/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useAuth } from "@/lib/AuthContext";
+import { AGE_GROUPS } from "@/lib/auth";
 
 export default function LoginPage() {
   const { login, signup } = useAuth();
@@ -10,6 +11,8 @@ export default function LoginPage() {
   const [mode, setMode] = useState<"login" | "signup">("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [ageGroup, setAgeGroup] = useState(""); // 선택
+  const [showFind, setShowFind] = useState(false); // ID/비번 찾기 안내
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -19,7 +22,7 @@ export default function LoginPage() {
     setBusy(true);
     try {
       if (mode === "login") await login(email, password);
-      else await signup(email, password);
+      else await signup(email, password, ageGroup || undefined);
       router.push("/"); // 채팅으로
     } catch (err) {
       setError(
@@ -58,6 +61,23 @@ export default function LoginPage() {
           placeholder={mode === "signup" ? "비밀번호 (8자 이상)" : "비밀번호"}
           className="rounded-xl border border-gray-300 dark:border-gray-700 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
         />
+        {mode === "signup" && (
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-gray-500">
+              나이대 <span className="text-gray-400">(선택 — 맞춤 추천에 활용, 이름·성별은 받지 않아요)</span>
+            </span>
+            <select
+              value={ageGroup}
+              onChange={(e) => setAgeGroup(e.target.value)}
+              className="rounded-xl border border-gray-300 dark:border-gray-700 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none"
+            >
+              <option value="">선택 안 함</option>
+              {AGE_GROUPS.map((g) => (
+                <option key={g} value={g}>{g}</option>
+              ))}
+            </select>
+          </label>
+        )}
         {error && <p className="text-xs text-red-600">{error}</p>}
         <button
           type="submit"
@@ -68,18 +88,42 @@ export default function LoginPage() {
         </button>
       </form>
 
-      <button
-        type="button"
-        onClick={() => {
-          setMode(mode === "login" ? "signup" : "login");
-          setError(null);
-        }}
-        className="mt-4 text-xs text-blue-600 hover:underline"
-      >
-        {mode === "login"
-          ? "계정이 없으신가요? 회원가입"
-          : "이미 계정이 있으신가요? 로그인"}
-      </button>
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => {
+            setMode(mode === "login" ? "signup" : "login");
+            setError(null);
+            setShowFind(false);
+          }}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          {mode === "login"
+            ? "계정이 없으신가요? 회원가입"
+            : "이미 계정이 있으신가요? 로그인"}
+        </button>
+        {mode === "login" && (
+          <button
+            type="button"
+            onClick={() => setShowFind((v) => !v)}
+            className="text-xs text-gray-500 hover:underline"
+          >
+            아이디·비밀번호 찾기
+          </button>
+        )}
+      </div>
+
+      {mode === "login" && showFind && (
+        <div className="mt-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-gray-50 p-3 text-xs leading-relaxed text-gray-600">
+          <p className="mb-1">
+            <b>아이디</b>: 가입하신 <b>이메일이 곧 아이디</b>예요. 이메일 주소로 로그인하세요.
+          </p>
+          <p>
+            <b>비밀번호</b>: 현재 이메일 재설정은 준비 중이에요. 로그인이 되는 상태라면{" "}
+            <b>계정 설정</b>에서 변경할 수 있고, 완전히 잊으셨다면 문의해 주세요.
+          </p>
+        </div>
+      )}
     </main>
   );
 }

--- a/ETF_RAG/frontend/src/lib/AuthContext.tsx
+++ b/ETF_RAG/frontend/src/lib/AuthContext.tsx
@@ -20,7 +20,7 @@ interface AuthState {
   user: AuthUser | null;
   loading: boolean; // 초기 토큰 검증 중
   login: (email: string, password: string) => Promise<void>;
-  signup: (email: string, password: string) => Promise<void>;
+  signup: (email: string, password: string, ageGroup?: string) => Promise<void>;
   logout: () => void;
   refresh: () => Promise<void>; // 닉네임 변경 등 후 user 재동기화
 }
@@ -52,8 +52,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(await fetchMe());
   };
 
-  const signup = async (email: string, password: string) => {
-    const token = await apiSignup(email, password);
+  const signup = async (email: string, password: string, ageGroup?: string) => {
+    const token = await apiSignup(email, password, ageGroup);
     setToken(token);
     setUser(await fetchMe());
   };

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -25,11 +25,15 @@ export interface AuthUser {
   id: number;
   email: string;
   nickname: string; // 미설정 시 백엔드가 이메일 앞부분으로 채워 보냄
+  age_group?: string | null; // 나이대(선택)
 }
+
+// 허용 나이대 — 백엔드 AGE_GROUPS와 일치
+export const AGE_GROUPS = ["10대", "20대", "30대", "40대", "50대", "60대", "70대 이상"];
 
 async function postAuth(
   path: string,
-  body: { email: string; password: string },
+  body: Record<string, unknown>,
 ): Promise<string> {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
@@ -44,8 +48,12 @@ async function postAuth(
   return data.access_token as string;
 }
 
-export async function signup(email: string, password: string): Promise<string> {
-  return postAuth("/auth/signup", { email, password });
+export async function signup(
+  email: string,
+  password: string,
+  ageGroup?: string,
+): Promise<string> {
+  return postAuth("/auth/signup", { email, password, age_group: ageGroup || null });
 }
 
 export async function login(email: string, password: string): Promise<string> {
@@ -85,15 +93,23 @@ export async function changePassword(
   if (!res.ok) throw new Error(await readDetail(res));
 }
 
-export async function updateNickname(nickname: string): Promise<AuthUser> {
+export async function updateProfile(
+  nickname: string,
+  ageGroup?: string | null,
+): Promise<AuthUser> {
+  const body: Record<string, unknown> = { nickname };
+  if (ageGroup !== undefined) body.age_group = ageGroup; // undefined면 미변경
   const res = await fetch(`${API_BASE}/auth/profile`, {
     method: "PUT",
     headers: { "Content-Type": "application/json", ...authHeader() },
-    body: JSON.stringify({ nickname }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(await readDetail(res));
   return (await res.json()) as AuthUser;
 }
+
+// 하위호환 별칭 (기존 호출부 유지)
+export const updateNickname = (nickname: string) => updateProfile(nickname);
 
 export async function deleteAccount(password: string): Promise<void> {
   const res = await fetch(`${API_BASE}/auth/me`, {

--- a/ETF_RAG/tests/test_auth.py
+++ b/ETF_RAG/tests/test_auth.py
@@ -276,3 +276,40 @@ def test_delete_account_purges_paper_trading(client):
     pf2 = client.get("/me/paper/portfolio", headers=_auth(token2)).json()
     assert pf2["holdings"] == []
     assert pf2["cash"] == 100_000_000
+
+
+# ── 나이대(age_group) 선택 수집 ──
+
+def test_signup_with_age_group(client):
+    r = client.post("/auth/signup", json={
+        "email": "age@b.com", "password": "pw123456", "age_group": "30대"})
+    assert r.status_code == 201
+    token = r.json()["access_token"]
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.json()["age_group"] == "30대"
+
+
+def test_signup_without_age_group_is_none(client):
+    r = client.post("/auth/signup", json={"email": "noage@b.com", "password": "pw123456"})
+    token = r.json()["access_token"]
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.json()["age_group"] is None
+
+
+def test_signup_invalid_age_group_ignored(client):
+    r = client.post("/auth/signup", json={
+        "email": "bad@b.com", "password": "pw123456", "age_group": "백살"})
+    token = r.json()["access_token"]
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert me.json()["age_group"] is None  # 미허용값은 무시
+
+
+def test_profile_update_age_group(client):
+    r = client.post("/auth/signup", json={"email": "p@b.com", "password": "pw123456"})
+    h = {"Authorization": f"Bearer {r.json()['access_token']}"}
+    upd = client.put("/auth/profile", json={"nickname": "닉", "age_group": "40대"}, headers=h)
+    assert upd.status_code == 200
+    assert upd.json()["age_group"] == "40대"
+    # 나이대 미전송(None) → 기존 유지
+    upd2 = client.put("/auth/profile", json={"nickname": "닉2"}, headers=h)
+    assert upd2.json()["age_group"] == "40대"


### PR DESCRIPTION
## 1) 나이대(age_group) 선택 수집
사용자 요청 — 회원가입 시 나이대만(이름·성별 X). **개인정보 최소화**: 분류정보(10대~70대 이상 7버킷)라 식별 불가, PIPA 부담 낮음. 맞춤 추천에 활용 대비.
- `User.age_group` 컬럼 + 멱등 마이그레이션(nickname 패턴 재사용)
- `SignupRequest`/`ProfileUpdateRequest`/`UserResponse`에 age_group (허용값만 저장·그 외 무시 / profile은 None=미변경)
- `AGE_GROUPS` 상수(백엔드·프론트 일치)
- 프론트: 회원가입 폼 나이대 select(선택), 계정설정 '프로필' 섹션(닉네임+나이대 통합 저장)
- 테스트 +4

## 2) ID/비밀번호 찾기 — 안내 방식 (메일 인프라 없이)
- **ID**: 이 서비스는 **이메일=아이디** → "이메일로 로그인" 안내
- **비밀번호**: 재설정 메일은 SMTP 인프라 필요 → 보류 상태. 로그인 화면에 "아이디·비밀번호 찾기" 토글 안내(ID=이메일 / 비번=로그인 시 계정설정 변경, 분실 시 문의)
- 메일 인프라(Resend/SendGrid 등)는 원하시면 후속으로 추가 가능

## 검증
- 백엔드 **873** + 프론트 17, tsc + build(13 라우트) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)