### PR TITLE
feat(eval): 임베딩 비교 정식화(BGE-M3) + RAG 검색 품질 CI 게이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,56 @@ jobs:
             echo "### Test Coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
             echo "Total coverage: ${TOTAL}%"
           fi
+
+  # RAG 검색 품질 게이트 — retrieval Hit Rate가 임계 미만이면 실패(검색 회귀 감지).
+  # OPENAI_API_KEY는 FAISS 인덱싱(임베딩)에 필요 → secret 있을 때만 실행, 없으면 skip.
+  # RAGAS full(답변 품질)은 비용·비결정성으로 CI 제외 — 로컬에서 run_eval.py로 측정.
+  rag-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # eval/retriever/데이터 변경 시에만 (테스트와 별개로 트리거 좁힘)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check OPENAI_API_KEY presence
+        id: key
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -n "$OPENAI_API_KEY" ]; then
+            echo "has_key=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_key=false" >> $GITHUB_OUTPUT
+            echo "OPENAI_API_KEY secret 미설정 — RAG 게이트 skip(설정 시 자동 활성화)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Set up Python
+        if: steps.key.outputs.has_key == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: ETF_RAG/requirements.txt
+
+      - name: Install system dependencies
+        if: steps.key.outputs.has_key == 'true'
+        run: sudo apt-get update && sudo apt-get install -y fonts-nanum
+
+      - name: Install Python dependencies
+        if: steps.key.outputs.has_key == 'true'
+        run: |
+          pip install --upgrade pip
+          pip install -r ETF_RAG/requirements.txt
+
+      - name: Run retrieval Hit Rate gate
+        if: steps.key.outputs.has_key == 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}/ETF_RAG
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          cd ETF_RAG
+          # --no-llm: RAGAS(유료 GPT) 없이 검색만. --min-hit-rate: 임계 미만이면 exit 1.
+          python eval/run_eval.py --no-llm --min-hit-rate 0.90 | tee eval_out.txt
+          echo "### RAG 검색 게이트" >> $GITHUB_STEP_SUMMARY
+          grep -E "Hit Rate|게이트" eval_out.txt >> $GITHUB_STEP_SUMMARY || true

--- a/ETF_RAG/eval/EMBEDDING_COMPARISON.md
+++ b/ETF_RAG/eval/EMBEDDING_COMPARISON.md
@@ -1,0 +1,55 @@
+# 임베딩 모델 비교 리포트 — OpenAI vs BGE-M3
+
+ETF RAG 검색 품질을 임베딩 모델별로 정량 비교한 실험 기록.
+재현: `python eval/exp_embedding_ab.py`(전체) / `--quick`(ETF만). BGE-M3는
+`langchain-huggingface` + `sentence-transformers` 설치 시 자동 포함, 없으면 skip.
+
+## 비교 대상
+
+| 태그 | 모델 | 차원 | 비고 |
+|------|------|------|------|
+| small | `text-embedding-3-small` | 1536 | **현행** (OpenAI API) |
+| large | `text-embedding-3-large` | 3072 | OpenAI 상위 (API) |
+| bge-m3 | `BAAI/bge-m3` | 1024 | 한국어 포함 다국어 특화 (로컬, 선택 설치) |
+
+## 평가 설계
+
+- 데이터셋: `eval_dataset.json`(--quick=ETF 42문항, expected_ticker 보유분).
+- **두 모드**로 측정:
+  - **full (실서비스)**: 이름 직접매칭 + BM25 + dense + Cohere Rerank — 실제 파이프라인.
+  - **dense_only**: 직접매칭 off + `sparse_weight=0` → **임베딩 순수 변별력**만 격리.
+- 순위 민감 지표: **MRR / Hit@1 / Hit@3 / Hit@5** (Hit@5만 보면 천장이라 변별 불가 → MRR·Hit@1 중심).
+
+## 결과 (dense_only, ETF 42문항)
+
+| 모델 | MRR | Hit@1 | Hit@3 | Hit@5 |
+|------|-----|-------|-------|-------|
+| **small (현행)** | 0.495 | 0.429 | 0.524 | 0.619 |
+| **large** | **0.874** | **0.857** | **0.881** | **0.905** |
+| **bge-m3** | 0.576 | 0.571 | 0.571 | 0.595 |
+
+**Δ vs small (dense_only):**
+- large: MRR **+0.379**, Hit@1 **+0.428** — 압도적
+- bge-m3: MRR +0.081, Hit@1 +0.143, Hit@5 −0.024 — small보다 약간 우위, large엔 크게 못 미침
+
+### full 파이프라인 (실서비스)
+
+| 모델 | MRR | Hit@1 | Hit@5 |
+|------|-----|-------|-------|
+| small / large / bge-m3 | **1.0** | **1.0** | **1.0** |
+
+→ **세 모델 모두 천장.** 하이브리드 검색(이름 직접매칭 + BM25 + Rerank)이 임베딩 약점을 메워, **실서비스 체감 차이는 0**.
+
+## 결론 / 의사결정
+
+1. **현행 `text-embedding-3-small` 유지.** full 파이프라인이 천장이라 모델 교체의 실서비스 이득이 없음. small이 가장 싸고 빠름(인덱싱 38s).
+2. **순수 dense 의존도가 커지면(예: PDF 투자설명서 등 비정형 문서 확대) `large`가 1순위.** dense-only MRR 0.49→0.87로 압도. 비용·인덱싱(2배) 감수 가치.
+3. **BGE-M3(한국어 특화)는 이 도메인에서 기대만큼 강하지 않음.** 종목명·금융용어 위주라 한국어 일반 코퍼스 특화의 이점이 작고, small보다 약간 나은 수준. 게다가 **로컬 CPU 임베딩이 매우 느림**(3천여 문서 첫 인덱싱 ~18분, Mac MPS는 OOM) → 운영 부담 큼. 비용 0(외부 미전송)이 꼭 필요한 경우에만.
+
+## 실행 함정 (재현 시 참고)
+
+- **torch < 2.6 + .bin 가중치**: `torch.load` 보안 차단(CVE-2025-32434). Python 3.9는 torch 2.2.2가 최대라 업그레이드 불가 → BGE-M3는 **safetensors 포함 revision 고정**으로 회피(`exp_embedding_ab.py`의 MODELS revision).
+- **Mac MPS OOM**: 대량 문서 임베딩 시 GPU 메모리 부족 → `model_kwargs={"device": "cpu"}` + 작은 batch_size로 CPU 강제(느리지만 안정).
+- BGE-M3 의존성은 **배포 미포함**(requirements 주석). 실험 전용.
+
+_측정: 2026-06-29, 결과 JSON: `eval/results/exp_embedding_ab_*.json`_

--- a/ETF_RAG/eval/exp_embedding_ab.py
+++ b/ETF_RAG/eval/exp_embedding_ab.py
@@ -48,24 +48,60 @@ EVAL_DIR = Path(__file__).parent
 DATASET_PATH = EVAL_DIR / "eval_dataset.json"
 RESULTS_DIR = EVAL_DIR / "results"
 
+# 비교 대상 모델 정의. provider로 OpenAI / HuggingFace(로컬) 분기.
+# bge-m3는 한국어 포함 다국어 특화(1024차원) — 로컬 모델이라 선택적 설치.
 MODELS = {
-    "small": "text-embedding-3-small",  # 현행 (1536차원)
-    "large": "text-embedding-3-large",  # 비교 대상 (3072차원)
+    "small":  {"provider": "openai", "name": "text-embedding-3-small"},  # 현행 (1536)
+    "large":  {"provider": "openai", "name": "text-embedding-3-large"},  # OpenAI 상위 (3072)
+    # 한국어 특화 로컬(1024). revision: safetensors 포함 커밋 고정(torch<2.6 .bin 차단 회피).
+    "bge-m3": {"provider": "hf", "name": "BAAI/bge-m3",
+               "revision": "9a0624b896d81da7492a910ffa53731274b6cf3d"},
 }
 
 # dense 검색이 변별력을 갖는 "어려운" 유형 — 종목명이 명시 안 돼 직접 매칭이 안 먹는 질문군
 HARD_TYPES = {"recommend", "risk", "general"}
 
 
-def _patch_embeddings(model_name: str):
-    """get_embeddings()를 지정 OpenAI 모델로 런타임 치환. 본체 파일 불변."""
-    from langchain_openai import OpenAIEmbeddings
-    vs_mod.get_embeddings = lambda: OpenAIEmbeddings(model=model_name)
+def _hf_available() -> bool:
+    """BGE-M3 실행에 필요한 langchain-huggingface + sentence-transformers 설치 여부."""
+    try:
+        import langchain_huggingface  # noqa: F401
+        import sentence_transformers  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _patch_embeddings(tag: str):
+    """get_embeddings()를 지정 모델로 런타임 치환. 본체 파일 불변.
+
+    OpenAI는 API, HuggingFace(bge-m3)는 로컬 sentence-transformers.
+    """
+    spec = MODELS[tag]
+    if spec["provider"] == "openai":
+        from langchain_openai import OpenAIEmbeddings
+        vs_mod.get_embeddings = lambda: OpenAIEmbeddings(model=spec["name"])
+    else:  # hf — 로컬 임베딩 (정규화 권장: bge 계열은 cosine 사용)
+        from langchain_huggingface import HuggingFaceEmbeddings
+        # torch<2.6은 .bin(torch.load) 로드가 CVE-2025-32434로 차단됨.
+        # Python 3.9는 torch 2.2.2가 최대라 업그레이드 불가 → safetensors가 포함된
+        # revision을 명시해 .bin 경로를 회피한다. (BGE-M3 safetensors 커밋)
+        rev = spec.get("revision")
+        # device="cpu": Mac MPS(GPU) OOM 회피(대량 문서 임베딩 시). 느리지만 안정.
+        # batch_size 작게 + normalize(cosine).
+        mk = {"device": "cpu"}
+        if rev:
+            mk["revision"] = rev
+        vs_mod.get_embeddings = lambda: HuggingFaceEmbeddings(
+            model_name=spec["name"],
+            model_kwargs=mk,
+            encode_kwargs={"normalize_embeddings": True, "batch_size": 16},
+        )
 
 
 def _build_retrievers(model_tag: str):
     """모델별 prefix로 격리된 retriever 구축 (ETF + 주식)."""
-    _patch_embeddings(MODELS[model_tag])
+    _patch_embeddings(model_tag)
 
     etf_docs = create_documents(load_etf_data(), include_pdfs=False)
     stock_docs = create_stock_documents(load_stock_data())
@@ -157,10 +193,18 @@ def run(quick=False):
         dataset = [d for d in dataset if d.get("asset_type", "etf") == "etf"]
     logger.info(f"데이터셋 {len(dataset)}개 (quick={quick})")
 
-    summary = {"config": {}, "models": {}}
+    summary = {"config": {}, "models": {}, "skipped": []}
     orig_hybrid = copy.deepcopy(config.HYBRID_SEARCH)
 
-    for tag in ("small", "large"):
+    # 실행할 모델: OpenAI 2종은 항상, bge-m3는 의존성 있을 때만(없으면 skip 기록)
+    tags = ["small", "large"]
+    if _hf_available():
+        tags.append("bge-m3")
+    else:
+        summary["skipped"].append("bge-m3 (langchain-huggingface/sentence-transformers 미설치)")
+        logger.warning("bge-m3 skip — `pip install langchain-huggingface sentence-transformers`")
+
+    for tag in tags:
         etf_r, stock_r = _build_retrievers(tag)
         model_result = {}
 
@@ -184,17 +228,22 @@ def run(quick=False):
         summary["models"][tag] = model_result
         logger.info(f"[{tag}] full={model_result['full']} dense_only={model_result['dense_only']}")
 
-    # delta (large - small), dense-only 기준 (임베딩 변별이 가장 잘 드러나는 모드)
-    s, l = summary["models"]["small"]["dense_only"], summary["models"]["large"]["dense_only"]
-    if s and l:
-        summary["delta_dense_only"] = {
-            kk: round(l[kk] - s[kk], 4) for kk in ("mrr", "hit@1", "hit@3", "hit@5")
-        }
+    # delta — small(현행) 대비 각 모델, dense-only 기준(임베딩 순수 변별이 드러나는 모드)
+    base = summary["models"]["small"]["dense_only"]
+    summary["delta_vs_small_dense_only"] = {}
+    for tag in tags:
+        if tag == "small":
+            continue
+        cmp = summary["models"][tag]["dense_only"]
+        if base and cmp:
+            summary["delta_vs_small_dense_only"][tag] = {
+                kk: round(cmp[kk] - base[kk], 4) for kk in ("mrr", "hit@1", "hit@3", "hit@5")
+            }
     summary["config"] = {
         "dataset_size": len(dataset),
-        "models": MODELS,
+        "models": {t: MODELS[t]["name"] for t in tags},
         "modes": ["full (실서비스)", "dense_only (직접매칭off + sparse=0)"],
-        "note": "Hit@5 천장 효과 → dense_only MRR/Hit@1로 판정",
+        "note": "Hit@5 천장 효과 → dense_only MRR/Hit@1로 판정. bge-m3는 한국어 특화 비교용.",
     }
     return summary
 
@@ -213,16 +262,17 @@ def main():
     out.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
 
     print("\n" + "=" * 60)
-    print("임베딩 A/B 결과 (text-embedding-3 small vs large)")
+    print("임베딩 비교 결과 (OpenAI small/large vs BGE-M3)")
     print("=" * 60)
-    for tag in ("small", "large"):
-        m = summary["models"][tag]
-        print(f"\n[{tag}]  ({m['elapsed_sec']}s)")
+    for tag, m in summary["models"].items():
+        print(f"\n[{tag}] {summary['config']['models'].get(tag, '')}  ({m['elapsed_sec']}s)")
         print(f"  full       : {m['full']}")
         print(f"  dense_only : {m['dense_only']}")
         print(f"  dense_hard : {m['dense_only_hard']}")
-    if "delta_dense_only" in summary:
-        print(f"\nΔ (large - small, dense_only): {summary['delta_dense_only']}")
+    for tag, d in summary.get("delta_vs_small_dense_only", {}).items():
+        print(f"\nΔ ({tag} - small, dense_only): {d}")
+    for s in summary.get("skipped", []):
+        print(f"\n⏭  skip: {s}")
     print(f"\n결과 저장: {out}")
 
 

--- a/ETF_RAG/eval/run_eval.py
+++ b/ETF_RAG/eval/run_eval.py
@@ -579,13 +579,17 @@ def main():
 
     # --sample N 옵션: RAGAS 평가 시 샘플 수 제한 (비용 절감)
     # --types a,b,c 옵션: 특정 question_type만 평가 (신규 도구 집중 평가용)
+    # --min-hit-rate X: retrieval Hit Rate가 X 미만이면 exit 1 (CI 게이트용, 0~1)
     sample_size = None
     types = None
+    min_hit_rate = None
     for i, arg in enumerate(sys.argv):
         if arg == "--sample" and i + 1 < len(sys.argv):
             sample_size = int(sys.argv[i + 1])
         if arg == "--types" and i + 1 < len(sys.argv):
             types = [t.strip() for t in sys.argv[i + 1].split(",") if t.strip()]
+        if arg == "--min-hit-rate" and i + 1 < len(sys.argv):
+            min_hit_rate = float(sys.argv[i + 1])
 
     logger.info("평가 데이터셋 로드...")
     dataset = load_eval_dataset(types=types)
@@ -632,6 +636,16 @@ def main():
     output_path, summary = save_results(retrieval_results, ragas_results)
     print_summary(summary)
     logger.info(f"\n결과 저장: {output_path}")
+
+    # CI 게이트 — retrieval Hit Rate가 임계 미만이면 실패 처리(검색 품질 회귀 감지)
+    if min_hit_rate is not None:
+        hit_rate = summary["retrieval"]["hit_rate"]
+        if hit_rate < min_hit_rate:
+            print(
+                f"\n❌ 게이트 실패: Hit Rate {hit_rate:.1%} < 임계 {min_hit_rate:.1%}"
+            )
+            sys.exit(1)
+        print(f"\n✅ 게이트 통과: Hit Rate {hit_rate:.1%} ≥ 임계 {min_hit_rate:.1%}")
 
 
 if __name__ == "__main__":

--- a/ETF_RAG/requirements.txt
+++ b/ETF_RAG/requirements.txt
@@ -42,3 +42,9 @@ pytest>=7.0.0,<9.0
 # 유지를 위해 기본 미포함 — 쓰려면 주석 해제(transformers+torch ~수백MB).
 # transformers>=4.30,<5
 # torch>=2.0,<3
+
+# --- 임베딩 비교 실험 (선택, 배포 불필요) ---
+# eval/exp_embedding_ab.py 에서 BGE-M3(한국어 특화 로컬 임베딩)를 OpenAI와 비교할 때만 필요.
+# 미설치 시 실험은 bge-m3를 자동 skip(OpenAI small/large만 비교). 모델 ~2GB.
+# langchain-huggingface>=0.1,<1
+# sentence-transformers>=2.2,<4


### PR DESCRIPTION
## 1) 임베딩 비교 실험 정식화 — BGE-M3 vs OpenAI
`exp_embedding_ab.py`에 **BGE-M3**(한국어 특화 로컬, 1024d) 추가. provider 분기(OpenAI API/HF 로컬), 미설치 시 자동 skip(배포 무관).

**실측 결과** (`eval/EMBEDDING_COMPARISON.md`, dense_only ETF 42문항):
| 모델 | MRR | Hit@1 |
|------|-----|-------|
| small (현행) | 0.495 | 0.429 |
| large | **0.874** | **0.857** |
| bge-m3 | 0.576 | 0.571 |

- **full 파이프라인은 셋 다 천장(1.0)** — 하이브리드 검색(이름매칭+BM25+Rerank)이 임베딩 약점을 메움 → **현행 small 유지** 결정
- dense 의존도 커지면(PDF 등) **large 1순위**. BGE-M3는 이 도메인(종목명/금융)에선 기대만큼 강하지 않고 CPU 임베딩 매우 느림
- 함정 해결: torch<2.6 .bin 보안차단(CVE-2025-32434)→safetensors revision 고정 / Mac MPS OOM→CPU 강제

## 2) RAG 평가 자동화 — CI 검색 품질 게이트
- `run_eval.py --min-hit-rate X`: retrieval Hit Rate 미만이면 exit 1 (통과/실패 케이스 검증 완료)
- `ci.yml` rag-eval job: **OPENAI_API_KEY secret 있을 때만** 실행(없으면 skip→CI green), `--no-llm --min-hit-rate 0.90`으로 검색 회귀 감지. RAGAS full(유료·비결정)은 CI 제외(로컬 측정)

## 검증
- 백엔드 **873 통과**(회귀 0), YAML 유효, 게이트 통과/실패 exit 코드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)