### PR TITLE
feat(news): 뉴스 감성 시계열 + 전용 뉴스 탭

### DIFF
--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -39,6 +39,7 @@ from src.data.chart_generator import (
     generate_sector_overview_chart,
     generate_sector_detail_chart,
     generate_sector_trend_chart,
+    generate_news_sentiment_chart,
 )
 from src.data.database import (
     get_connection,
@@ -346,6 +347,39 @@ async def sector(
     result = await run_in_threadpool(_sector_blocking, sector, period)
     if result is None:
         raise HTTPException(404, "섹터 데이터를 찾을 수 없습니다.")
+    return result
+
+
+# ── 뉴스 감성 + 시계열 ──────────────────────────────────────────────
+def _news_blocking(query: str, max_articles: int) -> Optional[dict]:
+    """종목 뉴스 수집 + 감성 분석 + 일별 감성 시계열 차트.
+
+    구조화 데이터로 종목명 해석 후 get_stock_news_summary 호출.
+    감성 시계열은 기사별 (발행일 + 감성)을 날짜별로 집계(별도 스냅샷 불필요).
+    """
+    from src.data.news import get_stock_news_summary, build_sentiment_timeseries
+
+    data = _find_structured_data(query)
+    name = data.get("name") if data else query
+
+    result = get_stock_news_summary(name, max_articles=max_articles)
+    articles = result.get("articles", [])
+    series = build_sentiment_timeseries(articles)
+    result["timeseries"] = series
+    result["chart_b64"] = generate_news_sentiment_chart(series, name) if series else None
+    result["name"] = name
+    result["ticker"] = data.get("ticker") if data else None
+    return result
+
+
+@router.get("/news", response_model=None)
+async def news(
+    ticker: str = Query(..., min_length=1),
+    max_articles: int = Query(10, ge=3, le=20),
+):
+    result = await run_in_threadpool(_news_blocking, ticker, max_articles)
+    if result is None:
+        raise HTTPException(404, "종목을 찾을 수 없습니다.")
     return result
 
 

--- a/ETF_RAG/frontend/src/app/news/page.tsx
+++ b/ETF_RAG/frontend/src/app/news/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { getNews } from "@/lib/api";
+import type { NewsResponse } from "@/lib/types";
+import TickerSearch from "@/components/TickerSearch";
+import ChartImage from "@/components/ChartImage";
+import DataRangeNote from "@/components/DataRangeNote";
+import { Loading, ErrorText, EmptyState } from "@/components/Feedback";
+
+// 감성 → 색상 배지
+function sentBadge(s: string): string {
+  if (s === "긍정") return "bg-red-50 text-red-600";
+  if (s === "부정") return "bg-blue-50 text-blue-600";
+  if (s === "중립") return "bg-gray-100 text-gray-500";
+  return "bg-gray-50 text-gray-400";
+}
+
+function overallColor(s: string): string {
+  if (s === "긍정") return "text-red-600";
+  if (s === "부정") return "text-blue-600";
+  if (s === "혼재") return "text-amber-600";
+  return "text-gray-500";
+}
+
+export default function NewsPage() {
+  const [data, setData] = useState<NewsResponse | null>(null);
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSelect = async (sel: { ticker: string; name: string }) => {
+    setName(sel.name);
+    setLoading(true);
+    setError(null);
+    setData(null);
+    try {
+      const res = await getNews(sel.ticker);
+      if (!res) setError("종목을 찾을 수 없어요.");
+      else setData(res);
+    } catch {
+      setError("뉴스를 가져오지 못했어요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-3 py-5 sm:px-4">
+      <h1 className="mb-1 text-lg font-bold text-gray-900">📰 뉴스 감성</h1>
+      <p className="mb-4 text-xs text-gray-500">
+        종목 뉴스를 모아 긍정/부정을 분석하고, 일별 감성 추이를 보여줍니다 (최근 약 1주)
+      </p>
+
+      <TickerSearch onSelect={onSelect} />
+
+      {loading && <Loading text="뉴스 분석 중…" />}
+      {error && <ErrorText message={error} />}
+
+      {data && !loading && (
+        <div className="mt-5 space-y-4">
+          {/* 전체 감성 요약 */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-base font-semibold">{data.name}</h2>
+            {data.ticker && <span className="text-xs text-gray-400">{data.ticker}</span>}
+          </div>
+
+          {data.articles.length === 0 ? (
+            <EmptyState icon="📭" message="최근 관련 뉴스를 찾지 못했어요." />
+          ) : (
+            <>
+              <div className="flex flex-wrap gap-2">
+                <div className="rounded-xl border border-gray-200 px-3 py-2">
+                  <div className="text-[11px] text-gray-500">전체 감성</div>
+                  <div className={`text-sm font-semibold ${overallColor(data.overall_sentiment)}`}>
+                    {data.overall_sentiment}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-gray-200 px-3 py-2">
+                  <div className="text-[11px] text-gray-500">긍정 / 부정 / 중립</div>
+                  <div className="text-sm font-semibold tabular-nums">
+                    <span className="text-red-600">{data.positive_count}</span> /{" "}
+                    <span className="text-blue-600">{data.negative_count}</span> /{" "}
+                    <span className="text-gray-500">{data.neutral_count}</span>
+                  </div>
+                </div>
+              </div>
+
+              {data.summary && (
+                <p className="rounded-xl bg-gray-50 p-3 text-xs leading-relaxed text-gray-700">
+                  {data.summary}
+                </p>
+              )}
+
+              {data.key_topics.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {data.key_topics.map((t) => (
+                    <span key={t} className="rounded-full bg-blue-50 px-2.5 py-1 text-xs text-blue-700">
+                      #{t}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* 감성 시계열 차트 (2일+ 누적 시) */}
+              {data.chart_b64 ? (
+                <ChartImage b64={data.chart_b64} alt={`${data.name} 뉴스 감성 추이`} />
+              ) : (
+                <p className="text-center text-xs text-gray-400">
+                  감성 추이 차트는 이틀 이상의 뉴스가 쌓이면 표시돼요.
+                </p>
+              )}
+
+              {/* 기사 목록 */}
+              <div className="space-y-2">
+                {data.articles.map((a, i) => (
+                  <a
+                    key={i}
+                    href={a.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-xl border border-gray-200 p-3 hover:bg-gray-50"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="text-sm text-gray-800">{a.title}</span>
+                      <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] ${sentBadge(a.sentiment)}`}>
+                        {a.sentiment}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-[11px] text-gray-400">
+                      {a.source}{a.source && a.published ? " · " : ""}{a.published}
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <DataRangeNote />
+    </main>
+  );
+}

--- a/ETF_RAG/frontend/src/components/NavBar.tsx
+++ b/ETF_RAG/frontend/src/components/NavBar.tsx
@@ -11,6 +11,7 @@ const TABS = [
   { href: "/comparison", label: "⚖️ 비교" },
   { href: "/outlook", label: "🔮 전망" },
   { href: "/sector", label: "🏭 섹터" },
+  { href: "/news", label: "📰 뉴스" },
   { href: "/invest", label: "💰 가상투자" },
 ];
 

--- a/ETF_RAG/frontend/src/lib/api.ts
+++ b/ETF_RAG/frontend/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   ComparisonResponse,
   OutlookResponse,
   SectorResponse,
+  NewsResponse,
   MoversResponse,
   OverviewResponse,
   VisitorResponse,
@@ -278,6 +279,16 @@ export async function getSector(
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`sector ${res.status}`);
   return (await res.json()) as SectorResponse;
+}
+
+/** 뉴스 감성 + 일별 시계열 차트. 404면 null. */
+export async function getNews(ticker: string): Promise<NewsResponse | null> {
+  const url = new URL(`${API_BASE}/tabs/news`);
+  url.searchParams.set("ticker", ticker);
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`news ${res.status}`);
+  return (await res.json()) as NewsResponse;
 }
 
 /** 사이드바 개요 — 데이터 현황 + ETF/주식 TOP. sector 지정 시 해당 업종 종목만. 실패 시 null. */

--- a/ETF_RAG/frontend/src/lib/types.ts
+++ b/ETF_RAG/frontend/src/lib/types.ts
@@ -179,6 +179,37 @@ export interface SectorResponse {
   trend_constituents?: number;
 }
 
+export interface NewsArticle {
+  title: string;
+  link: string;
+  source: string;
+  published: string;
+  summary: string;
+  sentiment: string; // 긍정 | 부정 | 중립 | 분석 불가
+}
+export interface NewsSentimentPoint {
+  date: string;
+  positive: number;
+  negative: number;
+  neutral: number;
+  total: number;
+  score: number; // (긍정-부정)/전체, -1~+1
+}
+export interface NewsResponse {
+  name: string;
+  ticker: string | null;
+  overall_sentiment: string;
+  positive_count: number;
+  negative_count: number;
+  neutral_count: number;
+  key_topics: string[];
+  summary: string;
+  sentiment_source?: string;
+  articles: NewsArticle[];
+  timeseries: NewsSentimentPoint[];
+  chart_b64: string | null;
+}
+
 // ── SSE structured_data 변형 (data를 JSON.parse한 결과) ──
 export interface ComparisonItem {
   name: string;

--- a/ETF_RAG/src/data/chart_generator/__init__.py
+++ b/ETF_RAG/src/data/chart_generator/__init__.py
@@ -25,6 +25,9 @@ from src.data.chart_generator.sector import (
     generate_sector_detail_chart,
     generate_sector_trend_chart,
 )
+from src.data.chart_generator.news import (
+    generate_news_sentiment_chart,
+)
 
 __all__ = [
     "generate_technical_chart",
@@ -37,4 +40,5 @@ __all__ = [
     "generate_sector_overview_chart",
     "generate_sector_detail_chart",
     "generate_sector_trend_chart",
+    "generate_news_sentiment_chart",
 ]

--- a/ETF_RAG/src/data/chart_generator/news.py
+++ b/ETF_RAG/src/data/chart_generator/news.py
@@ -1,0 +1,89 @@
+"""
+뉴스 감성 시계열 차트 — 일별 감성 점수 라인 + 긍정/부정/중립 건수 막대.
+"""
+
+import logging
+from typing import Optional
+
+import matplotlib.pyplot as plt
+
+from src.data.chart_generator._style import (
+    BG_COLOR, GRID_COLOR, TEXT_COLOR,
+    setup_font, font_kw, to_base64_tight,
+)
+
+logger = logging.getLogger(__name__)
+
+_POS = "#e8453c"   # 긍정 = 빨강(상승 톤, 국내 관례)
+_NEG = "#1a73e8"   # 부정 = 파랑(하락 톤)
+_NEU = "#9ca3af"   # 중립 = 회색
+_SCORE = "#8b5cf6"  # 감성 점수 라인
+
+
+def generate_news_sentiment_chart(
+    series: list, name: str,
+) -> Optional[str]:
+    """일별 감성 시계열 차트 → base64 PNG.
+
+    Args:
+        series: build_sentiment_timeseries 결과
+                [{date, positive, negative, neutral, total, score}]
+        name: 종목명
+    """
+    if not series or len(series) < 2:
+        return None  # 하루치뿐이면 시계열 의미 없음
+
+    setup_font()
+    try:
+        dates = [r["date"][5:] for r in series]  # MM-DD
+        n = len(dates)
+        x = list(range(n))
+        pos = [r["positive"] for r in series]
+        neg = [r["negative"] for r in series]
+        neu = [r["neutral"] for r in series]
+        score = [r["score"] for r in series]
+
+        fig, (ax1, ax2) = plt.subplots(
+            2, 1, figsize=(max(8, n * 0.9), 6), facecolor=BG_COLOR,
+            gridspec_kw={"height_ratios": [2, 2], "hspace": 0.3},
+        )
+        fp = font_kw()
+
+        # 상단: 일별 감성 점수 라인 (-1~+1)
+        ax1.set_facecolor(BG_COLOR)
+        ax1.plot(x, score, color=_SCORE, linewidth=2.0, marker="o",
+                 markersize=5, zorder=3)
+        ax1.fill_between(x, score, 0, color=_SCORE, alpha=0.12, zorder=2)
+        ax1.axhline(y=0, color="#999999", linewidth=0.7, zorder=2)
+        ax1.set_ylabel("감성 점수", fontsize=10, color=TEXT_COLOR, **fp)
+        ax1.set_ylim(-1.1, 1.1)
+        ax1.set_title(f"{name} 뉴스 감성 추이", fontsize=13, fontweight="bold",
+                      color=TEXT_COLOR, pad=10, **fp)
+        ax1.grid(True, axis="y", alpha=0.3, color=GRID_COLOR, zorder=0)
+        ax1.set_xticks(x)
+        ax1.set_xticklabels(dates, fontsize=8, color=TEXT_COLOR)
+        ax1.tick_params(colors=TEXT_COLOR, labelsize=8)
+        for s in ax1.spines.values():
+            s.set_visible(False)
+
+        # 하단: 긍정/부정/중립 스택 막대
+        ax2.set_facecolor(BG_COLOR)
+        ax2.bar(x, pos, color=_POS, label="긍정", alpha=0.85, zorder=3)
+        ax2.bar(x, neg, bottom=pos, color=_NEG, label="부정", alpha=0.85, zorder=3)
+        bottom2 = [p + ng for p, ng in zip(pos, neg)]
+        ax2.bar(x, neu, bottom=bottom2, color=_NEU, label="중립", alpha=0.7, zorder=3)
+        ax2.set_ylabel("기사 수", fontsize=10, color=TEXT_COLOR, **fp)
+        ax2.legend(fontsize=8, loc="upper left", framealpha=0.8)
+        ax2.grid(True, axis="y", alpha=0.3, color=GRID_COLOR, zorder=0)
+        ax2.set_xticks(x)
+        ax2.set_xticklabels(dates, fontsize=8, color=TEXT_COLOR)
+        ax2.tick_params(colors=TEXT_COLOR, labelsize=8)
+        for s in ax2.spines.values():
+            s.set_visible(False)
+
+        fig.subplots_adjust(left=0.10, right=0.96, top=0.90, bottom=0.10)
+        return to_base64_tight(fig)
+
+    except Exception as e:
+        logger.error(f"뉴스 감성 차트 생성 실패: {e}")
+        return None

--- a/ETF_RAG/src/data/news.py
+++ b/ETF_RAG/src/data/news.py
@@ -315,3 +315,46 @@ def get_stock_news_summary(
         articles = articles[:max_articles]
 
     return analyze_sentiment_batch(articles, stock_name)
+
+
+# ── 감성 시계열 집계 ──────────────────────────────────────
+
+def build_sentiment_timeseries(articles: list[dict]) -> list[dict]:
+    """기사별 (발행일 + 감성)을 날짜별로 집계한 시계열.
+
+    Google News RSS는 최근 ~7일치를 주므로 시계열도 그 범위. 별도 스냅샷
+    누적 없이 기사에 이미 있는 published/sentiment로 집계한다.
+
+    Args:
+        articles: analyze_sentiment_batch가 채운 [{published, sentiment, ...}]
+
+    Returns:
+        날짜 오름차순 [{date: "YYYY-MM-DD", positive, negative, neutral, total,
+                       score: float}]. score = (긍정-부정)/전체, -1~+1.
+    """
+    by_date: dict = {}
+    for a in articles or []:
+        pub = a.get("published", "")
+        # "YYYY-MM-DD HH:MM" 또는 "YYYY-MM-DD..." → 앞 10자
+        date = pub[:10] if len(pub) >= 10 and pub[4] == "-" else ""
+        if not date:
+            continue
+        sent = a.get("sentiment", "중립")
+        d = by_date.setdefault(date, {"positive": 0, "negative": 0, "neutral": 0})
+        if sent == "긍정":
+            d["positive"] += 1
+        elif sent == "부정":
+            d["negative"] += 1
+        else:  # 중립/분석 불가 등
+            d["neutral"] += 1
+
+    series = []
+    for date in sorted(by_date):
+        d = by_date[date]
+        total = d["positive"] + d["negative"] + d["neutral"]
+        score = round((d["positive"] - d["negative"]) / total, 3) if total else 0.0
+        series.append({
+            "date": date, "positive": d["positive"], "negative": d["negative"],
+            "neutral": d["neutral"], "total": total, "score": score,
+        })
+    return series

--- a/ETF_RAG/tests/test_news.py
+++ b/ETF_RAG/tests/test_news.py
@@ -321,3 +321,45 @@ def test_fetch_feed_fallback_on_certifi_failure(mock_urlopen):
 
     # fallback은 URL 문자열로 feedparser.parse 호출
     mock_parse.assert_called_once_with("https://news.google.com/rss/search?q=x")
+
+
+# ── 감성 시계열 집계 ──────────────────────────────────────
+
+def test_build_sentiment_timeseries_basic():
+    from src.data.news import build_sentiment_timeseries
+    arts = [
+        {"published": "2026-06-30 09:00", "sentiment": "긍정"},
+        {"published": "2026-06-30 15:00", "sentiment": "부정"},
+        {"published": "2026-06-30 18:00", "sentiment": "긍정"},
+        {"published": "2026-07-01 10:00", "sentiment": "중립"},
+    ]
+    s = build_sentiment_timeseries(arts)
+    assert [r["date"] for r in s] == ["2026-06-30", "2026-07-01"]  # 날짜 오름차순
+    d0 = s[0]
+    assert d0["positive"] == 2 and d0["negative"] == 1 and d0["total"] == 3
+    assert d0["score"] == round((2 - 1) / 3, 3)  # (긍-부)/전체
+    assert s[1]["score"] == 0.0  # 중립만
+
+
+def test_build_sentiment_timeseries_skips_undated():
+    from src.data.news import build_sentiment_timeseries
+    arts = [
+        {"published": "", "sentiment": "긍정"},
+        {"published": "날짜아님", "sentiment": "부정"},
+        {"published": "2026-06-30 09:00", "sentiment": "긍정"},
+    ]
+    s = build_sentiment_timeseries(arts)
+    assert len(s) == 1 and s[0]["date"] == "2026-06-30"
+
+
+def test_build_sentiment_timeseries_empty():
+    from src.data.news import build_sentiment_timeseries
+    assert build_sentiment_timeseries([]) == []
+
+
+def test_news_sentiment_chart_needs_two_days():
+    """하루치뿐이면 시계열 차트 None(의미 없음)."""
+    from src.data.chart_generator import generate_news_sentiment_chart
+    one = [{"date": "2026-06-30", "positive": 1, "negative": 0, "neutral": 0,
+            "total": 1, "score": 1.0}]
+    assert generate_news_sentiment_chart(one, "삼성전자") is None


### PR DESCRIPTION
## 배경
뉴스는 채팅 도구(`get_stock_news`)로만 있고 전용 UI/API/차트가 없었음. 기사별 **(발행일 + 감성)** 이 이미 있어, 날짜별 집계로 시계열을 구성(별도 스냅샷 누적 불필요).

## 변경
- `news.py` `build_sentiment_timeseries`: 기사 published/sentiment를 날짜별 긍/부/중 집계 + 감성점수 `(긍-부)/전체`(-1~+1). 날짜 없는 기사 제외
- `chart_generator/news.py` `generate_news_sentiment_chart`: 일별 감성점수 라인 + 긍/부/중 스택 막대(2일+ 누적 시)
- `api/tabs.py` `GET /tabs/news`: 종목 해석 → 뉴스 요약 + 시계열 + 차트
- **프론트 📰 뉴스 탭 신설**(NavBar 8탭): 전체 감성 요약 + 키워드 + 시계열 차트 + 기사 목록(감성 배지, 클릭 시 원문)

## 검증
- 테스트 +4(집계/날짜없음 제외/빈/차트 최소2일). 백엔드 **882**, 프론트 17, `next build` 14 라우트

🤖 Generated with [Claude Code](https://claude.com/claude-code)