### PR TITLE
fix(ops): 재부팅 없이 프로덕션 DB 새로고침 (stale 방지)

### DIFF
--- a/.github/workflows/daily-collect.yml
+++ b/.github/workflows/daily-collect.yml
@@ -162,6 +162,27 @@ jobs:
           git pull --rebase origin main
           git push
 
+      # ── 프로덕션 DB 새로고침 트리거 (Railway 백엔드 호출) ──────
+      # 백엔드는 부팅 시에만 최신 Release DB를 받는다. keep-alive로 재부팅이
+      # 안 일어나면 볼륨 DB가 며칠 stale해지므로(라이브가 옛 날짜 서빙), Release
+      # 갱신 직후 여기서 재부팅 없이 최신 DB로 교체·재초기화하게 한다.
+      # 이후 알림/스냅샷이 최신 데이터를 보도록 반드시 이 트리거를 먼저 실행.
+      # REFRESH_DB_URL/CRON_TOKEN secret 미설정 시 자동 skip(무해).
+      - name: Trigger production DB refresh
+        continue-on-error: true
+        env:
+          REFRESH_DB_URL: ${{ secrets.REFRESH_DB_URL }}
+          CRON_TOKEN: ${{ secrets.CRON_TOKEN }}
+        run: |
+          if [ -z "$REFRESH_DB_URL" ] || [ -z "$CRON_TOKEN" ]; then
+            echo "REFRESH_DB_URL/CRON_TOKEN 미설정 — DB 새로고침 트리거 skip"
+            exit 0
+          fi
+          echo "프로덕션 DB 새로고침 트리거: $REFRESH_DB_URL"
+          curl -fsS -X POST "$REFRESH_DB_URL" \
+            -H "X-Cron-Token: $CRON_TOKEN" \
+            --max-time 300 || echo "DB 새로고침 트리거 실패(무시)"
+
       # ── 관심종목 푸시 알림 트리거 (Railway 백엔드 호출) ──────
       # 수집 후 백엔드가 관심종목 ±임계% 종목을 구독 유저에게 push.
       # PUSH_ALERT_URL/CRON_TOKEN secret 미설정 시 스크립트가 자동 skip(무해).

--- a/ETF_RAG/api/admin.py
+++ b/ETF_RAG/api/admin.py
@@ -1,0 +1,89 @@
+"""
+운영용 cron 엔드포인트 — 재부팅 없이 DB를 최신 Release DB로 교체.
+
+배경: 프로덕션 백엔드는 부팅 시(run_init)에만 ensure_db로 DB를 받는다.
+keep-alive ping이 컨테이너를 계속 깨워두면 재부팅이 안 일어나 볼륨의 DB가
+며칠씩 stale해진다(신선도 검사가 있어도 트리거될 기회=재부팅이 없음).
+
+이 엔드포인트는 daily-collect가 Release DB를 갱신한 직후 X-Cron-Token으로
+호출되어, 재부팅 없이 최신 DB를 볼륨에 내려받고 메모리 상태를 재초기화한다.
+push/paper의 cron 엔드포인트와 동일한 인라인 토큰 검증 패턴을 따른다.
+"""
+
+import logging
+import threading
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel
+
+from api.deps import run_init, _DB_PATH
+from src.data.db_downloader import ensure_db
+from src.data import technical
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+# 동시에 두 refresh가 진입해 DB 파일을 지우는 중 재초기화가 겹치는 것을 막는다.
+# 단일 워커 전제라도 daily-collect 재시도 등으로 요청이 겹칠 수 있다.
+_refresh_lock = threading.Lock()
+
+
+class RefreshDbResponse(BaseModel):
+    ok: bool
+    refreshed: bool  # 실제로 DB를 내려받아 교체했는지
+    detail: str
+
+
+def _purge_db_files() -> None:
+    """DB 본체 + WAL/SHM 사이드카를 삭제. ensure_db가 이후 새 파일을 받게 한다.
+
+    ensure_db 내부 unlink는 .db 본체만 지운다. WAL 모드라 잔여 -wal/-shm이
+    새 DB와 섞이면 손상으로 이어질 수 있어 사이드카까지 명시적으로 정리한다.
+    """
+    for suffix in ("", "-wal", "-shm"):
+        p = _DB_PATH.parent / (_DB_PATH.name + suffix)
+        p.unlink(missing_ok=True)
+
+
+@router.post("/refresh-db", response_model=RefreshDbResponse)
+def refresh_db(
+    x_cron_token: str = Header(None, alias="X-Cron-Token"),
+) -> RefreshDbResponse:
+    """볼륨 DB를 최신 Release DB로 강제 교체 후 메모리 상태 재초기화. X-Cron-Token 보호.
+
+    순서: (1) DB 파일+사이드카 삭제 → (2) ensure_db로 최신 Release 재다운로드
+    → (3) technical 싱글톤 커넥션/캐시 리셋(삭제된 옛 inode 핸들 방지)
+    → (4) run_init 재실행(retriever/인덱스/data_index 재구축, FAISS/BM25는 해시로 자동 재빌드).
+    """
+    from config import CRON_TOKEN
+    if not CRON_TOKEN:
+        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
+    if x_cron_token != CRON_TOKEN:
+        raise HTTPException(403, "잘못된 토큰")
+
+    if not _refresh_lock.acquire(blocking=False):
+        # 이미 다른 refresh가 진행 중 — 중복 실행 방지
+        return RefreshDbResponse(ok=True, refreshed=False, detail="이미 진행 중")
+
+    try:
+        logger.info("DB 새로고침 시작 — 볼륨 DB 삭제 후 최신 Release 재다운로드")
+        _purge_db_files()
+
+        downloaded = ensure_db(_DB_PATH)
+        if not downloaded:
+            # 다운로드 실패 — DB가 사라진 상태이므로 다음 부팅/재시도에서 복구.
+            # 여기서 예외를 던져 cron이 실패로 인지하게 한다.
+            raise HTTPException(503, "DB 다운로드 실패 — 다음 재시도 필요")
+
+        # 삭제된 옛 파일 핸들을 잡고 있는 technical 싱글톤을 리셋(가장 위험한 stale 지점).
+        technical.reset_db_connection()
+
+        # retriever/인덱스/data_index 재구축. ensure_db 재호출은 방금 받은 신선한
+        # DB에 대해 통과하므로 재다운로드 없음(idempotent).
+        run_init()
+
+        logger.info("DB 새로고침 완료 — 최신 데이터 반영")
+        return RefreshDbResponse(ok=True, refreshed=True, detail="최신 DB로 교체 완료")
+    finally:
+        _refresh_lock.release()

--- a/ETF_RAG/api/main.py
+++ b/ETF_RAG/api/main.py
@@ -46,6 +46,7 @@ from api.auth import router as auth_router, get_current_user_optional
 from api.user_data import router as user_data_router
 from api.push import router as push_router
 from api.paper import router as paper_router
+from api.admin import router as admin_router
 from api.models_db import User
 from src.utils.logging import log_feedback
 
@@ -98,6 +99,8 @@ app.include_router(user_data_router)
 app.include_router(push_router)
 # 가상투자(모의투자) — 매수/매도/포트폴리오/랭킹 (/me/paper/*)
 app.include_router(paper_router)
+# 운영 cron — 재부팅 없이 DB 새로고침 (/admin/refresh-db)
+app.include_router(admin_router)
 
 
 def _require_ready() -> None:

--- a/ETF_RAG/src/data/technical/__init__.py
+++ b/ETF_RAG/src/data/technical/__init__.py
@@ -21,6 +21,7 @@ from src.data.technical._data import (
     _get_db_conn,
     _ohlcv_cache,
     _closes_cache,
+    reset_db_connection,
 )
 
 # ── 기본 지표 ──
@@ -60,7 +61,7 @@ __all__ = [
     "MARKET_BENCHMARK", "BENCHMARK_TICKER",
     # 데이터 접근
     "_get_closes", "_get_ohlcv", "_yfinance_ohlcv", "_db_available",
-    "_get_db_conn", "_ohlcv_cache", "_closes_cache",
+    "_get_db_conn", "_ohlcv_cache", "_closes_cache", "reset_db_connection",
     # 기본 지표
     "calc_ma", "calc_ema", "calc_rsi", "calc_macd", "calc_bollinger",
     "detect_cross",

--- a/ETF_RAG/src/data/technical/_data.py
+++ b/ETF_RAG/src/data/technical/_data.py
@@ -34,6 +34,27 @@ def _get_db_conn() -> sqlite3.Connection:
         return _db_conn
 
 
+def reset_db_connection() -> None:
+    """DB 파일이 교체됐을 때 싱글톤 커넥션·TTL 캐시를 리셋한다.
+
+    DB 파일을 unlink→재다운로드로 갈아끼우면, 이 싱글톤은 삭제된 옛 inode의
+    열린 핸들을 계속 잡고 있어 새 데이터가 절대 반영되지 않는다. 커넥션을 닫고
+    None으로 되돌려 다음 조회 시 새 파일로 재연결하게 하고, stale 값을 서빙하지
+    않도록 OHLCV/종가 캐시도 비운다. (DB 새로고침 cron 엔드포인트에서 호출)
+    """
+    global _db_conn
+    with _db_lock:
+        if _db_conn is not None:
+            try:
+                _db_conn.close()
+            except Exception:  # noqa: BLE001 — 닫기 실패해도 None 리셋은 진행
+                logger.warning("기존 DB 커넥션 close 실패 — 무시하고 리셋", exc_info=True)
+            _db_conn = None
+        _ohlcv_cache.clear()
+        _closes_cache.clear()
+    logger.info("technical DB 커넥션·캐시 리셋 완료")
+
+
 # ── 간단한 TTL 캐시 (동일 질문 내 중복 DB 쿼리 방지) ──
 _CACHE_TTL = 300  # 5분
 _ohlcv_cache: dict[tuple, tuple] = {}  # (ticker, days) → (timestamp, data)

--- a/ETF_RAG/tests/test_admin.py
+++ b/ETF_RAG/tests/test_admin.py
@@ -1,0 +1,120 @@
+"""운영 cron 엔드포인트 테스트 — /admin/refresh-db (재부팅 없이 DB 새로고침).
+
+test_push.py의 X-Cron-Token 검증 패턴을 따른다. 실제 DB 다운로드/재초기화는
+절대 태우지 않고 ensure_db·run_init·reset·_purge를 전부 모킹한다.
+"""
+
+import os
+
+os.environ["API_SKIP_INIT"] = "1"
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from unittest.mock import patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_sse_global():
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit_event = None
+    yield
+
+
+@pytest.fixture
+def client():
+    from api.main import app
+
+    with TestClient(app) as c:
+        yield c
+
+
+def test_refresh_db_no_token(client):
+    """토큰 헤더 없음 → 403 (CRON_TOKEN 설정 상태에서)."""
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.post("/admin/refresh-db")
+    assert r.status_code == 403
+
+
+def test_refresh_db_cron_token_unset(client):
+    """CRON_TOKEN 미설정 → 403 (비활성)."""
+    with patch("config.CRON_TOKEN", ""):
+        r = client.post("/admin/refresh-db", headers={"X-Cron-Token": "anything"})
+    assert r.status_code == 403
+
+
+def test_refresh_db_wrong_token(client):
+    """토큰 불일치 → 403."""
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.post("/admin/refresh-db", headers={"X-Cron-Token": "nope"})
+    assert r.status_code == 403
+
+
+def test_refresh_db_success(client):
+    """정상 토큰 → 파일정리·재다운로드·리셋·재init 순서대로 호출 후 refreshed=True."""
+    with patch("config.CRON_TOKEN", "secret"), \
+         patch("api.admin._purge_db_files") as m_purge, \
+         patch("api.admin.ensure_db", return_value=True) as m_ensure, \
+         patch("api.admin.technical.reset_db_connection") as m_reset, \
+         patch("api.admin.run_init") as m_init:
+        r = client.post("/admin/refresh-db", headers={"X-Cron-Token": "secret"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["refreshed"] is True
+    m_purge.assert_called_once()
+    m_ensure.assert_called_once()
+    m_reset.assert_called_once()
+    m_init.assert_called_once()
+
+
+def test_refresh_db_download_fail(client):
+    """ensure_db가 False(다운로드 실패) → 503, 이후 리셋/재init은 호출 안 함."""
+    with patch("config.CRON_TOKEN", "secret"), \
+         patch("api.admin._purge_db_files"), \
+         patch("api.admin.ensure_db", return_value=False), \
+         patch("api.admin.technical.reset_db_connection") as m_reset, \
+         patch("api.admin.run_init") as m_init:
+        r = client.post("/admin/refresh-db", headers={"X-Cron-Token": "secret"})
+
+    assert r.status_code == 503
+    m_reset.assert_not_called()
+    m_init.assert_not_called()
+
+
+def test_refresh_db_lock_busy(client):
+    """이미 refresh 진행 중(Lock 점유) → 200 refreshed=False, 재init 호출 안 함."""
+    import api.admin as admin
+
+    admin._refresh_lock.acquire()
+    try:
+        with patch("config.CRON_TOKEN", "secret"), \
+             patch("api.admin.run_init") as m_init:
+            r = client.post("/admin/refresh-db", headers={"X-Cron-Token": "secret"})
+    finally:
+        admin._refresh_lock.release()
+
+    assert r.status_code == 200
+    assert r.json()["refreshed"] is False
+    m_init.assert_not_called()
+
+
+def test_reset_db_connection_clears_singleton_and_cache():
+    """reset_db_connection: 싱글톤 close+None + TTL 캐시 clear."""
+    from src.data import technical
+    from src.data.technical import _data
+
+    # 커넥션 싱글톤을 강제로 하나 열고 캐시에 값을 채운다.
+    conn = _data._get_db_conn()
+    assert _data._db_conn is conn
+    _data._ohlcv_cache[("005930", 20)] = (0.0, ["dummy"])
+    _data._closes_cache[("005930", 20)] = (0.0, ["dummy"])
+
+    technical.reset_db_connection()
+
+    assert _data._db_conn is None
+    assert _data._ohlcv_cache == {}
+    assert _data._closes_cache == {}


### PR DESCRIPTION
## 배경 / 문제
프로덕션 백엔드가 부팅 시(`run_init`)에만 `ensure_db`로 최신 Release DB를 받는데, keep-alive ping이 컨테이너를 계속 깨워두면 **재부팅이 안 일어나 볼륨 DB가 며칠씩 stale**해짐. 라이브가 7/7 데이터에 멈춰 서빙된 사례 발생(수집·Release DB는 7/9까지 최신이었음). 신선도 검사(#98)가 있어도 트리거될 기회(재부팅)가 없던 게 근본 원인.

## 변경
- **`POST /admin/refresh-db`** (`api/admin.py`, X-Cron-Token 보호 — push/paper와 동일 인라인 패턴): DB 파일+WAL/SHM 사이드카 삭제 → `ensure_db` 강제 재다운로드 → `technical` 싱글톤/캐시 리셋 → `run_init` 재실행(retriever/인덱스/data_index 재구축, FAISS/BM25는 해시로 자동 재빌드). `threading.Lock`으로 중복 진입 차단, 다운로드 실패 시 503.
- **`technical.reset_db_connection()`** 신설: DB 파일 교체 시 삭제된 옛 inode 핸들을 계속 잡는 싱글톤 커넥션을 close+None + OHLCV/종가 TTL 캐시 clear. 이게 없으면 기술지표/상관/포트폴리오/전망이 영구 stale(가장 위험한 함정).
- **`daily-collect.yml`**: Release DB 갱신 직후 refresh-db 트리거(알림/스냅샷보다 **먼저** 실행해 최신 데이터 반영). `REFRESH_DB_URL`/`CRON_TOKEN` 미설정 시 skip(무해).

## 테스트
+7 (전체 **889** green): 토큰 없음/미설정/오답 403, 정상 호출 순서, 다운로드 실패 503, Lock 점유 시 no-op, reset 싱글톤/캐시 클리어.

## 배포 체크리스트 (머지 후)
- [x] GitHub secret `REFRESH_DB_URL` 등록
- [ ] **`CRON_TOKEN`** — GitHub secret + Railway 백엔드 env 양쪽에 같은 값 필요 (현재 GitHub에 미등록 확인됨 → 기존 알림/스냅샷도 그동안 skip됐을 가능성)
- [ ] Railway 백엔드 재배포로 `/admin/refresh-db` 라이브 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)