### PR TITLE
프론트 버그 수정 + 백엔드 리팩터링(중복제거·N+1·청소)

### DIFF
--- a/ETF_RAG/api/admin.py
+++ b/ETF_RAG/api/admin.py
@@ -13,10 +13,10 @@ push/paper의 cron 엔드포인트와 동일한 인라인 토큰 검증 패턴�
 import logging
 import threading
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from api.deps import run_init, _DB_PATH
+from api.deps import run_init, verify_cron_token, _DB_PATH
 from src.data.db_downloader import ensure_db
 from src.data import technical
 
@@ -47,21 +47,13 @@ def _purge_db_files() -> None:
 
 
 @router.post("/refresh-db", response_model=RefreshDbResponse)
-def refresh_db(
-    x_cron_token: str = Header(None, alias="X-Cron-Token"),
-) -> RefreshDbResponse:
+def refresh_db(_: None = Depends(verify_cron_token)) -> RefreshDbResponse:
     """볼륨 DB를 최신 Release DB로 강제 교체 후 메모리 상태 재초기화. X-Cron-Token 보호.
 
     순서: (1) DB 파일+사이드카 삭제 → (2) ensure_db로 최신 Release 재다운로드
     → (3) technical 싱글톤 커넥션/캐시 리셋(삭제된 옛 inode 핸들 방지)
     → (4) run_init 재실행(retriever/인덱스/data_index 재구축, FAISS/BM25는 해시로 자동 재빌드).
     """
-    from config import CRON_TOKEN
-    if not CRON_TOKEN:
-        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
-    if x_cron_token != CRON_TOKEN:
-        raise HTTPException(403, "잘못된 토큰")
-
     if not _refresh_lock.acquire(blocking=False):
         # 이미 다른 refresh가 진행 중 — 중복 실행 방지
         return RefreshDbResponse(ok=True, refreshed=False, detail="이미 진행 중")

--- a/ETF_RAG/api/deps.py
+++ b/ETF_RAG/api/deps.py
@@ -11,7 +11,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from fastapi import HTTPException, Request
+from fastapi import Header, HTTPException, Request
 
 from src.llm.client import get_api_key
 from src.data.db_downloader import ensure_db
@@ -51,6 +51,21 @@ def require_ready(request: Request) -> None:
             status_code=503,
             detail=f"초기화 중/실패: {state.error or 'initializing'}",
         )
+
+
+def verify_cron_token(
+    x_cron_token: str = Header(None, alias="X-Cron-Token"),
+) -> None:
+    """cron 엔드포인트 공유 인증 의존성 (GitHub Actions 등 서버-투-서버 호출용).
+
+    CRON_TOKEN 미설정이면 403(비활성), 헤더 토큰 불일치면 403. push/paper/admin의
+    cron 엔드포인트가 동일 검증을 인라인 복붙하던 것을 하나로 통일.
+    """
+    from config import CRON_TOKEN
+    if not CRON_TOKEN:
+        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
+    if x_cron_token != CRON_TOKEN:
+        raise HTTPException(403, "잘못된 토큰")
 
 
 def run_init() -> None:

--- a/ETF_RAG/api/paper.py
+++ b/ETF_RAG/api/paper.py
@@ -542,6 +542,13 @@ def ranking(
                 price_cache[tk] = None
         return price_cache[tk]
 
+    # 유저를 한 번에 조회(계정 수만큼 개별 db.get 하던 N+1 제거).
+    user_ids = [acc.user_id for acc in accounts]
+    users = {
+        u.id: u
+        for u in db.scalars(select(User).where(User.id.in_(user_ids)))
+    } if user_ids else {}
+
     rows = []
     for acc in accounts:
         value = acc.cash
@@ -549,7 +556,7 @@ def ranking(
             cur = _price(h.ticker)
             if cur:
                 value += int(round(cur * h.qty))
-        u = db.get(User, acc.user_id)
+        u = users.get(acc.user_id)
         rows.append({
             "user_id": acc.user_id,
             "nickname": _display_nickname(u) if u else "?",

--- a/ETF_RAG/api/paper.py
+++ b/ETF_RAG/api/paper.py
@@ -28,12 +28,13 @@ def _to_kst(dt: Optional[datetime]) -> Optional[datetime]:
     return dt.astimezone(KST)
 
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import delete, func as safunc, select
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user, _display_nickname
 from api.db import get_db
+from api.deps import verify_cron_token
 from api.models import (
     DividendItem,
     DividendResponse,
@@ -598,19 +599,13 @@ def history(
 
 @router.post("/snapshot-all", response_model=SnapshotAllResponse)
 def snapshot_all(
-    x_cron_token: str = Header(None, alias="X-Cron-Token"),
+    _: None = Depends(verify_cron_token),
     db: Session = Depends(get_db),
 ) -> SnapshotAllResponse:
     """전 유저 당일 평가액 스냅샷 기록 (GitHub Actions 수집 후 호출). X-Cron-Token 보호.
 
     거래 안 한 날도 시세 변동을 추이에 반영하기 위함. 종목별 현재가는 1회만 조회(캐시).
     """
-    from config import CRON_TOKEN
-    if not CRON_TOKEN:
-        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
-    if x_cron_token != CRON_TOKEN:
-        raise HTTPException(403, "잘못된 토큰")
-
     price_cache: dict = {}
 
     def _cached(tk: str):

--- a/ETF_RAG/api/push.py
+++ b/ETF_RAG/api/push.py
@@ -7,12 +7,13 @@
 import json
 import logging
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user
 from api.db import get_db
+from api.deps import verify_cron_token
 from api.models import (
     PushStatusResponse,
     PushSubscribeRequest,
@@ -212,17 +213,12 @@ def run_watchlist_alerts(db: Session) -> dict:
 
 @router.post("/run-watchlist-alerts", response_model=WatchlistAlertResponse)
 def run_alerts(
-    x_cron_token: str = Header(None, alias="X-Cron-Token"),
+    _: None = Depends(verify_cron_token),
     db: Session = Depends(get_db),
 ) -> WatchlistAlertResponse:
     """관심종목 일일 알림 발송 (GitHub Actions 수집 후 호출). X-Cron-Token 보호.
 
-    CRON_TOKEN 미설정 시 403(비활성). VAPID 미설정 시 발송은 no-op(0건).
+    VAPID 미설정 시 발송은 no-op(0건).
     """
-    from config import CRON_TOKEN
-    if not CRON_TOKEN:
-        raise HTTPException(403, "CRON_TOKEN 미설정 — 비활성")
-    if x_cron_token != CRON_TOKEN:
-        raise HTTPException(403, "잘못된 토큰")
     result = run_watchlist_alerts(db)
     return WatchlistAlertResponse(ok=True, **result)

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -377,10 +377,9 @@ async def news(
     ticker: str = Query(..., min_length=1),
     max_articles: int = Query(10, ge=3, le=20),
 ):
-    result = await run_in_threadpool(_news_blocking, ticker, max_articles)
-    if result is None:
-        raise HTTPException(404, "종목을 찾을 수 없습니다.")
-    return result
+    # 뉴스는 종목 미해석 시에도 query 그대로 검색하므로 _news_blocking은 항상
+    # dict를 반환한다(다른 탭과 달리 404 없음). 종목 없어도 뉴스는 나올 수 있음.
+    return await run_in_threadpool(_news_blocking, ticker, max_articles)
 
 
 # ── 종목 자동완성 / 해석 ────────────────────────────────────────────

--- a/ETF_RAG/api/tabs.py
+++ b/ETF_RAG/api/tabs.py
@@ -88,13 +88,23 @@ def _build_sector_stats(sector_index: dict) -> list:
     return stats
 
 
+def _ticker_name(data: Optional[dict], query: str) -> tuple[str, str]:
+    """구조화 데이터에서 (ticker, name)을 추출. 없으면 query로 폴백.
+
+    _find_structured_data 결과(있을 수도, None일 수도)와 원 질의어를 받아 각 탭의
+    반복되던 `(data or {}).get("ticker") or query` 패턴을 통일. None 처리(404 vs
+    degrade)는 호출부가 data 자체로 판단하고, 이 헬퍼는 순수 추출만 한다.
+    """
+    d = data or {}
+    return (d.get("ticker") or query, d.get("name") or query)
+
+
 # ── Technical ──────────────────────────────────────────────────────
 def _technical_blocking(query: str, days: int) -> Optional[dict]:
     data = _find_structured_data(query)
     if not data:
         return None
-    ticker = data.get("ticker") or query
-    name = data.get("name") or query
+    ticker, name = _ticker_name(data, query)
     summary = get_technical_summary(ticker, days=days)  # days 전달(미전달 시 항상 250 고정 버그)
     if summary is None:
         return None
@@ -122,8 +132,7 @@ def _intraday_blocking(query: str) -> Optional[dict]:
     data = _find_structured_data(query)
     if not data:
         return None
-    ticker = data.get("ticker") or query
-    name = data.get("name") or query
+    ticker, name = _ticker_name(data, query)
     prev_close = data.get("close") or None
     chart_b64 = generate_intraday_chart(ticker, name, prev_close)
     if not chart_b64:
@@ -144,8 +153,7 @@ def _financial_blocking(query: str, quarters: int) -> Optional[dict]:
     if not DB_PATH.exists():
         return None
     data = _find_structured_data(query)
-    ticker = (data or {}).get("ticker") or query
-    name = (data or {}).get("name") or query
+    ticker, name = _ticker_name(data, query)
     conn = get_connection()
     try:
         rows = get_financial_data(conn, ticker, quarters=quarters)
@@ -209,8 +217,7 @@ async def comparison(req: ComparisonRequest):
 # ── Outlook ────────────────────────────────────────────────────────
 def _outlook_blocking(query: str, horizon: str) -> Optional[dict]:
     data = _find_structured_data(query)
-    ticker = (data or {}).get("ticker") or query
-    name = (data or {}).get("name") or query
+    ticker, name = _ticker_name(data, query)
     summary = get_technical_summary(ticker)
     if summary is None:
         return None

--- a/ETF_RAG/frontend/src/app/comparison/page.tsx
+++ b/ETF_RAG/frontend/src/app/comparison/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { postComparison, getFinancial } from "@/lib/api";
 import type {
   ComparisonResponse,
@@ -39,16 +39,21 @@ export default function ComparisonPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 요청 순번 — stale response(이전 비교 조합) 방지.
+  const reqSeq = useRef(0);
+
   const run = async (
     a: { ticker: string },
     b: { ticker: string },
     d: number,
   ) => {
+    const seq = ++reqSeq.current;
     setLoading(true);
     setError(null);
     setFin(null);
     try {
       const res = await postComparison([a.ticker, b.ticker], d);
+      if (seq !== reqSeq.current) return;
       if (!res) setError("비교할 종목을 찾을 수 없어요.");
       setData(res);
       // 최근 분기 실적 비교 (각 종목 재무제표 병렬 — 없으면 null, 표 자체 생략)
@@ -57,14 +62,16 @@ export default function ComparisonPage() {
           getFinancial(a.ticker, 8),
           getFinancial(b.ticker, 8),
         ]);
+        if (seq !== reqSeq.current) return;
         if (f1 || f2) setFin([f1, f2]);
       } catch {
         /* 재무제표 실패는 비교 자체를 막지 않음 */
       }
     } catch {
+      if (seq !== reqSeq.current) return;
       setError("데이터를 가져오지 못했어요.");
     } finally {
-      setLoading(false);
+      if (seq === reqSeq.current) setLoading(false);
     }
   };
 

--- a/ETF_RAG/frontend/src/app/financial/page.tsx
+++ b/ETF_RAG/frontend/src/app/financial/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { getFinancial } from "@/lib/api";
 import type { FinancialResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
@@ -36,17 +36,23 @@ export default function FinancialPage() {
   const [quarters, setQuarters] = useState(12);
   const [customYears, setCustomYears] = useState(""); // 직접설정(년) 입력값
 
+  // 요청 순번 — stale response(이전 종목/기간) 방지.
+  const reqSeq = useRef(0);
+
   const fetchFin = async (tk: string, q: number) => {
+    const seq = ++reqSeq.current;
     setLoading(true);
     setError(null);
     try {
       const res = await getFinancial(tk, q);
+      if (seq !== reqSeq.current) return;
       if (!res) setError("재무 데이터를 찾을 수 없어요. (재무제표는 상장 주식만 제공)");
       setData(res);
     } catch {
+      if (seq !== reqSeq.current) return;
       setError("데이터를 가져오지 못했어요.");
     } finally {
-      setLoading(false);
+      if (seq === reqSeq.current) setLoading(false);
     }
   };
 

--- a/ETF_RAG/frontend/src/app/outlook/page.tsx
+++ b/ETF_RAG/frontend/src/app/outlook/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { getOutlook } from "@/lib/api";
 import type { OutlookResponse } from "@/lib/types";
 import TickerSearch from "@/components/TickerSearch";
@@ -50,17 +50,23 @@ export default function OutlookPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 요청 순번 — stale response(이전 종목/기간 응답)가 최신을 덮어쓰지 않도록.
+  const reqSeq = useRef(0);
+
   const run = async (ticker: string, h: string) => {
+    const seq = ++reqSeq.current;
     setLoading(true);
     setError(null);
     try {
       const res = await getOutlook(ticker, h);
+      if (seq !== reqSeq.current) return;
       if (!res) setError("전망을 생성할 수 없어요.");
       setData(res);
     } catch {
+      if (seq !== reqSeq.current) return;
       setError("데이터를 가져오지 못했어요.");
     } finally {
-      setLoading(false);
+      if (seq === reqSeq.current) setLoading(false);
     }
   };
 

--- a/ETF_RAG/frontend/src/app/sector/page.tsx
+++ b/ETF_RAG/frontend/src/app/sector/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getSector } from "@/lib/api";
 import type { SectorResponse } from "@/lib/types";
 import ChartImage from "@/components/ChartImage";
@@ -34,29 +34,38 @@ export default function SectorPage() {
   const [picked, setPicked] = useState<string>("");
   const [period, setPeriod] = useState<string>("1d");
 
+  // 요청 순번 — mount 개요 로드와 섹터/기간 전환이 같은 setData를 쓰므로,
+  // 빠른 전환 시 이전(느린) 응답이 최신을 덮어쓰지 않게 공유 순번으로 가드.
+  const reqSeq = useRef(0);
+
   // mount 시 전체 개요 로드
   useEffect(() => {
+    const seq = ++reqSeq.current;
     (async () => {
       try {
         const res = await getSector();
+        if (seq !== reqSeq.current) return;
         if (!res) setError("섹터 데이터를 찾을 수 없어요.");
         setData(res);
       } catch {
+        if (seq !== reqSeq.current) return;
         setError("데이터를 가져오지 못했어요.");
       } finally {
-        setLoading(false);
+        if (seq === reqSeq.current) setLoading(false);
       }
     })();
   }, []);
 
   // 섹터/기간 변경 시 재조회 (섹터 미선택이면 전체 개요)
   const load = async (sector: string, p: string) => {
+    const seq = ++reqSeq.current;
     setLoading(true);
     try {
       const res = sector ? await getSector(sector, p) : await getSector();
+      if (seq !== reqSeq.current) return;
       if (res) setData(res);
     } finally {
-      setLoading(false);
+      if (seq === reqSeq.current) setLoading(false);
     }
   };
 

--- a/ETF_RAG/frontend/src/app/technical/page.tsx
+++ b/ETF_RAG/frontend/src/app/technical/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getTechnical, getIntraday } from "@/lib/api";
 import type { TechnicalResponse } from "@/lib/types";
@@ -41,19 +41,26 @@ function TechnicalInner() {
   const [intraday, setIntraday] = useState<string | null>(null);
   const [intradayMsg, setIntradayMsg] = useState<string | null>(null);
 
+  // 요청 순번 — 빠른 종목/기간 전환 시 이전(느린) 응답이 최신 결과를 덮어쓰지
+  // 않도록, 응답이 최신 요청일 때만 상태를 반영한다(stale response 방지).
+  const reqSeq = useRef(0);
+
   const run = async (ticker: string, d: number) => {
+    const seq = ++reqSeq.current;
     setLoading(true);
     setError(null);
     setIntraday(null);
     setIntradayMsg(null);
     try {
       const res = await getTechnical(ticker, d);
+      if (seq !== reqSeq.current) return; // 더 최신 요청이 진행 중 → 이 응답 폐기
       if (!res) setError("해당 종목의 기술적 데이터를 찾을 수 없어요.");
       setData(res);
     } catch {
+      if (seq !== reqSeq.current) return;
       setError("데이터를 가져오지 못했어요. 백엔드 상태를 확인해주세요.");
     } finally {
-      setLoading(false);
+      if (seq === reqSeq.current) setLoading(false);
     }
   };
 

--- a/ETF_RAG/frontend/src/components/PriceCard.tsx
+++ b/ETF_RAG/frontend/src/components/PriceCard.tsx
@@ -136,7 +136,7 @@ export default function PriceCard({ ticker }: { ticker: string }) {
               ? `${up ? "+" : ""}${data.change.toLocaleString("ko-KR")}원 `
               : ""}
             ({up ? "+" : ""}
-            {data.change_pct}%)
+            {data.change_pct.toFixed(2)}%)
           </span>
         )}
       </div>

--- a/ETF_RAG/frontend/src/lib/auth.ts
+++ b/ETF_RAG/frontend/src/lib/auth.ts
@@ -187,22 +187,25 @@ export async function getWatchlistDetail(): Promise<
   return (data.items ?? []) as import("./types").WatchlistDetailItem[];
 }
 
-export async function addWatchlist(ticker: string): Promise<string[]> {
+// 성공 시 정본 티커 배열, 실패 시 null(호출부가 낙관적 상태를 유지·롤백 판단).
+// 과거엔 실패 시 []를 반환해, 토글 1회 실패(예: 토큰 만료 401)로 관심종목이
+// 화면에서 전부 사라지는 버그가 있었다 → null로 실패를 구분한다.
+export async function addWatchlist(ticker: string): Promise<string[] | null> {
   const res = await fetch(`${API_BASE}/me/watchlist/${ticker}`, {
     method: "PUT",
     headers: authHeader(),
   });
-  if (!res.ok) return [];
+  if (!res.ok) return null;
   const data = await res.json();
   return (data.tickers ?? []) as string[];
 }
 
-export async function removeWatchlist(ticker: string): Promise<string[]> {
+export async function removeWatchlist(ticker: string): Promise<string[] | null> {
   const res = await fetch(`${API_BASE}/me/watchlist/${ticker}`, {
     method: "DELETE",
     headers: authHeader(),
   });
-  if (!res.ok) return [];
+  if (!res.ok) return null;
   const data = await res.json();
   return (data.tickers ?? []) as string[];
 }

--- a/ETF_RAG/frontend/src/lib/useWatchlist.ts
+++ b/ETF_RAG/frontend/src/lib/useWatchlist.ts
@@ -37,9 +37,10 @@ export function useWatchlist() {
         else next.delete(ticker);
         return next;
       });
-      // 서버 반영 → 정본으로 동기화 (실패 시 서버 응답으로 보정)
+      // 서버 반영 → 성공 시 정본으로 동기화. 실패(null)면 낙관적 상태를 유지한다.
+      // (과거엔 실패 시 []로 덮어써 관심종목이 화면에서 전부 사라지는 버그가 있었다.)
       const server = adding ? await addWatchlist(ticker) : await removeWatchlist(ticker);
-      setTickers(new Set(server));
+      if (server !== null) setTickers(new Set(server));
     },
     [user, tickers],
   );

--- a/ETF_RAG/src/data/chart_generator/financial.py
+++ b/ETF_RAG/src/data/chart_generator/financial.py
@@ -11,7 +11,7 @@ from src.data.chart_generator._style import (
     BG_COLOR, GRID_COLOR, TEXT_COLOR,
     REV_COLOR, OP_COLOR, NI_COLOR, MARGIN_COLOR,
     VAL_COLORS, PORT_COLOR, BM_COLOR, DD_COLOR, DD_FILL,
-    setup_font, font_kw, build_xlabels, to_base64_tight, FONT_PROP,
+    setup_font, font_kw, build_xlabels, to_base64_tight,
 )
 
 logger = logging.getLogger(__name__)

--- a/ETF_RAG/src/data/chart_generator/sector.py
+++ b/ETF_RAG/src/data/chart_generator/sector.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 
 from src.data.chart_generator._style import (
     BG_COLOR, GRID_COLOR, TEXT_COLOR,
-    setup_font, font_kw, to_base64_tight, FONT_PROP,
+    setup_font, font_kw, to_base64_tight,
 )
 
 logger = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ def generate_sector_detail_chart(
         # ── 오른쪽: 시가총액 바 ──
         ax2.set_facecolor(BG_COLOR)
         caps_조 = [c / 1_000_000_000_000 for c in caps]
-        bars2 = ax2.barh(y, caps_조, color="#78909C", alpha=0.7, height=0.6, zorder=3)
+        ax2.barh(y, caps_조, color="#78909C", alpha=0.7, height=0.6, zorder=3)
         for i, val in enumerate(caps_조):
             if val >= 0.1:
                 ax2.text(val + max(caps_조) * 0.02, i, f"{val:.1f}조",

--- a/ETF_RAG/src/data/chart_generator/technical.py
+++ b/ETF_RAG/src/data/chart_generator/technical.py
@@ -12,7 +12,7 @@ from src.data.chart_generator._style import (
     BG_COLOR, GRID_COLOR, TEXT_COLOR, PRICE_COLOR, MA_COLORS, BB_COLOR,
     RSI_COLOR, VOL_UP, VOL_DOWN, MACD_LINE, MACD_SIGNAL, COMPARE_COLORS,
     setup_font, apply_style, font_kw, fmt_date_full, build_xlabels,
-    to_base64, to_base64_tight, FONT_PROP,
+    to_base64, to_base64_tight,
 )
 from src.data.chart_generator._series import (
     calc_ma_series, calc_rsi_series, calc_macd_series, calc_bb_series,

--- a/ETF_RAG/src/data/database/_maintenance.py
+++ b/ETF_RAG/src/data/database/_maintenance.py
@@ -8,7 +8,6 @@ import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from src.data.database._schema import init_db
 from src.data.database._write import upsert_daily_data
 from src.data.database._read import get_latest_date
 

--- a/ETF_RAG/src/data/predictor.py
+++ b/ETF_RAG/src/data/predictor.py
@@ -9,7 +9,6 @@ tools.py의 predict_price_outlook 도구에서 호출.
 
 import logging
 import math
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/ETF_RAG/src/data/technical/_data.py
+++ b/ETF_RAG/src/data/technical/_data.py
@@ -10,7 +10,7 @@ import threading
 import time
 from typing import Optional
 
-from src.data.database import DB_PATH, get_historical_prices
+from src.data.database import DB_PATH
 
 logger = logging.getLogger(__name__)
 

--- a/ETF_RAG/src/llm/agent.py
+++ b/ETF_RAG/src/llm/agent.py
@@ -13,7 +13,6 @@ LangGraph 기반 ETF 에이전트
 - 복잡 질문 (compare, recommend, risk) → GPT-4o
 """
 
-import json
 import logging
 import operator
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/ETF_RAG/src/llm/tools/analysis.py
+++ b/ETF_RAG/src/llm/tools/analysis.py
@@ -73,7 +73,6 @@ def _calc_percentile(value: float, values: list[float]) -> float:
 
 def _format_valuation_position(stock_data: dict, sector_stocks: list) -> str:
     """종목의 업종 내 밸류에이션 상대 위치를 포맷팅."""
-    ticker = stock_data.get("ticker", "")
     parts = []
 
     # PER 위치

--- a/ETF_RAG/src/llm/tools/financial.py
+++ b/ETF_RAG/src/llm/tools/financial.py
@@ -8,7 +8,7 @@ import logging
 from langchain_core.tools import tool
 
 from src.llm.tools import _state
-from src.llm.tools._helpers import _find_structured_data, _not_found_message, _fmt_date
+from src.llm.tools._helpers import _find_structured_data, _not_found_message
 
 logger = logging.getLogger(__name__)
 

--- a/ETF_RAG/src/llm/tools/portfolio.py
+++ b/ETF_RAG/src/llm/tools/portfolio.py
@@ -37,7 +37,7 @@ def get_stock_correlation(ticker1: str, ticker2: str) -> str:
     n2 = d2.get("name", "")
 
     try:
-        from src.data.technical import calc_correlation, calc_beta, MARKET_BENCHMARK
+        from src.data.technical import calc_correlation, calc_beta
 
         lines = [f"[{n1} ({t1}) vs {n2} ({t2})] 상관관계 분석\n"]
 

--- a/ETF_RAG/src/rag/retriever.py
+++ b/ETF_RAG/src/rag/retriever.py
@@ -13,10 +13,8 @@
 import logging
 import pickle
 import re
-from pathlib import Path
 from typing import List, Tuple, Optional, Dict
 
-import numpy as np
 from kiwipiepy import Kiwi
 from rank_bm25 import BM25Okapi
 from langchain_core.documents import Document

--- a/ETF_RAG/src/ui/chat.py
+++ b/ETF_RAG/src/ui/chat.py
@@ -6,7 +6,7 @@ import traceback
 import streamlit as st
 
 from src.llm.agent import stream_agent, _make_error_message
-from src.ui.charts import try_parse_comparison, render_comparison, try_parse_structured_data, render_structured_data
+from src.ui.charts import try_parse_structured_data, render_structured_data
 from src.utils.logging import log_interaction
 
 logger = logging.getLogger(__name__)

--- a/ETF_RAG/tests/conftest.py
+++ b/ETF_RAG/tests/conftest.py
@@ -9,6 +9,64 @@ from unittest.mock import patch
 from src.data.loader import load_etf_data, create_documents
 
 
+# ── API 테스트 공용 픽스처 ─────────────────────────────────────────
+# _reset_sse_global(7개 파일 복붙)·client(StaticPool 인메모리 DB, 4개 파일 복붙)를
+# 여기로 통합. 각 test 파일 상단의 os.environ["API_SKIP_INIT"]="1" +
+# DATABASE_URL="sqlite://" 설정은 import 타이밍 때문에 파일에 남긴다(여기로 옮기면
+# 각 파일의 top-level import보다 늦게 실행될 수 있음). auth 헬퍼는 파일마다
+# 이름·이메일·시그니처가 달라 공통화하지 않는다.
+
+
+@pytest.fixture(autouse=True)
+def _reset_sse_global():
+    """sse-starlette 전역 이벤트를 테스트마다 초기화(테스트 간 누수 방지)."""
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit_event = None
+    yield
+
+
+@pytest.fixture
+def client():
+    """StaticPool 단일 공유 인메모리 sqlite로 앱 client 구성.
+
+    db.engine/SessionLocal을 테스트 엔진으로 교체 + get_db 오버라이드.
+    TestClient 컨텍스트 진입 시 lifespan(init_models)이 이 엔진에 스키마 생성.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+    from fastapi.testclient import TestClient
+    import api.db as db
+    from api.db import Base, get_db
+
+    test_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, expire_on_commit=False)
+    db.engine = test_engine
+    db.SessionLocal = TestSession
+    Base.metadata.create_all(test_engine)
+
+    from api.main import app
+
+    def _override_db():
+        s = TestSession()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_db] = _override_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(test_engine)
+
+
 @pytest.fixture(scope="session")
 def etf_data():
     """하드코딩 샘플 데이터 로드 (기존 테스트 호환용)"""

--- a/ETF_RAG/tests/test_admin.py
+++ b/ETF_RAG/tests/test_admin.py
@@ -15,12 +15,7 @@ import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    from sse_starlette.sse import AppStatus
-
-    AppStatus.should_exit_event = None
-    yield
+# _reset_sse_global(autouse)은 tests/conftest.py에 공통 정의됨.
 
 
 @pytest.fixture

--- a/ETF_RAG/tests/test_api.py
+++ b/ETF_RAG/tests/test_api.py
@@ -17,14 +17,8 @@ from fastapi.testclient import TestClient  # noqa: E402
 from api.main import app  # noqa: E402
 
 
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    """sse-starlette의 AppStatus.should_exit_event는 모듈 전역이라 첫 이벤트 루프에
-    바인딩된다. TestClient는 테스트마다 새 루프를 만들어 'attached to a different loop'
-    에러가 난다 → 매 테스트 전 리셋해서 현재 루프에 새로 생성되게 한다."""
-    from sse_starlette.sse import AppStatus
-    AppStatus.should_exit_event = None
-    yield
+# _reset_sse_global(autouse)은 tests/conftest.py에 공통 정의됨(sse-starlette의
+# AppStatus.should_exit_event가 모듈 전역이라 테스트마다 리셋 — 'different loop' 방지).
 
 
 @pytest.fixture

--- a/ETF_RAG/tests/test_api_tabs.py
+++ b/ETF_RAG/tests/test_api_tabs.py
@@ -15,12 +15,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 from api.main import app  # noqa: E402
 
 
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    from sse_starlette.sse import AppStatus
-
-    AppStatus.should_exit_event = None
-    yield
+# _reset_sse_global(autouse)은 tests/conftest.py에 공통 정의됨.
 
 
 @pytest.fixture

--- a/ETF_RAG/tests/test_auth.py
+++ b/ETF_RAG/tests/test_auth.py
@@ -7,56 +7,9 @@ import 전 API_SKIP_INIT=1 + DATABASE_URL=sqlite://(인메모리).
 import os
 
 os.environ["API_SKIP_INIT"] = "1"
-os.environ["DATABASE_URL"] = "sqlite://"  # 인메모리; fixture에서 실제 엔진 교체
+os.environ["DATABASE_URL"] = "sqlite://"  # 인메모리; conftest client 픽스처가 엔진 교체
 
-import pytest  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import create_engine  # noqa: E402
-from sqlalchemy.orm import sessionmaker  # noqa: E402
-from sqlalchemy.pool import StaticPool  # noqa: E402
-
-import api.db as db  # noqa: E402
-from api.db import Base, get_db  # noqa: E402
-
-
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    from sse_starlette.sse import AppStatus
-
-    AppStatus.should_exit_event = None
-    yield
-
-
-@pytest.fixture
-def client():
-    # 단일 공유 인메모리 커넥션 (StaticPool) — 테이블이 요청 간 유지됨
-    test_engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-        future=True,
-    )
-    TestSession = sessionmaker(
-        bind=test_engine, autoflush=False, expire_on_commit=False
-    )
-    db.engine = test_engine  # init_models()가 이 엔진에 create_all
-    db.SessionLocal = TestSession
-    Base.metadata.create_all(test_engine)
-
-    from api.main import app
-
-    def _override_db():
-        s = TestSession()
-        try:
-            yield s
-        finally:
-            s.close()
-
-    app.dependency_overrides[get_db] = _override_db
-    with TestClient(app) as c:  # 컨텍스트 매니저 → lifespan(init_models) 실행
-        yield c
-    app.dependency_overrides.clear()
-    Base.metadata.drop_all(test_engine)
+# client / _reset_sse_global 픽스처는 tests/conftest.py에 공통 정의됨.
 
 
 def _signup(client, email="a@b.com", pw="pw123456"):

--- a/ETF_RAG/tests/test_paper.py
+++ b/ETF_RAG/tests/test_paper.py
@@ -12,48 +12,10 @@ os.environ["DATABASE_URL"] = "sqlite://"
 from unittest.mock import patch  # noqa: E402
 
 import pytest  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import create_engine  # noqa: E402
-from sqlalchemy.orm import sessionmaker  # noqa: E402
-from sqlalchemy.pool import StaticPool  # noqa: E402
 
-import api.db as db  # noqa: E402
-from api.db import Base, get_db  # noqa: E402
 from api.models_db import INITIAL_CASH  # noqa: E402
 
-
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    from sse_starlette.sse import AppStatus
-    AppStatus.should_exit_event = None
-    yield
-
-
-@pytest.fixture
-def client():
-    test_engine = create_engine(
-        "sqlite://", connect_args={"check_same_thread": False},
-        poolclass=StaticPool, future=True,
-    )
-    TestSession = sessionmaker(bind=test_engine, autoflush=False, expire_on_commit=False)
-    db.engine = test_engine
-    db.SessionLocal = TestSession
-    Base.metadata.create_all(test_engine)
-
-    from api.main import app
-
-    def _override_db():
-        s = TestSession()
-        try:
-            yield s
-        finally:
-            s.close()
-
-    app.dependency_overrides[get_db] = _override_db
-    with TestClient(app) as c:
-        yield c
-    app.dependency_overrides.clear()
-    Base.metadata.drop_all(test_engine)
+# client / _reset_sse_global 픽스처는 tests/conftest.py에 공통 정의됨.
 
 
 def _auth(client, email="u@b.com"):

--- a/ETF_RAG/tests/test_push.py
+++ b/ETF_RAG/tests/test_push.py
@@ -11,50 +11,10 @@ os.environ["DATABASE_URL"] = "sqlite://"
 from unittest.mock import patch  # noqa: E402
 
 import pytest  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import create_engine  # noqa: E402
-from sqlalchemy.orm import sessionmaker  # noqa: E402
-from sqlalchemy.pool import StaticPool  # noqa: E402
 
-import api.db as db  # noqa: E402
-from api.db import Base, get_db  # noqa: E402
+import api.db as db  # noqa: E402 — 테스트 본문이 db.SessionLocal()로 직접 세팅
 
-
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    from sse_starlette.sse import AppStatus
-
-    AppStatus.should_exit_event = None
-    yield
-
-
-@pytest.fixture
-def client():
-    test_engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-        future=True,
-    )
-    TestSession = sessionmaker(bind=test_engine, autoflush=False, expire_on_commit=False)
-    db.engine = test_engine
-    db.SessionLocal = TestSession
-    Base.metadata.create_all(test_engine)
-
-    from api.main import app
-
-    def _override_db():
-        s = TestSession()
-        try:
-            yield s
-        finally:
-            s.close()
-
-    app.dependency_overrides[get_db] = _override_db
-    with TestClient(app) as c:
-        yield c
-    app.dependency_overrides.clear()
-    Base.metadata.drop_all(test_engine)
+# client / _reset_sse_global 픽스처는 tests/conftest.py에 공통 정의됨.
 
 
 @pytest.fixture

--- a/ETF_RAG/tests/test_user_data.py
+++ b/ETF_RAG/tests/test_user_data.py
@@ -9,50 +9,8 @@ os.environ["API_SKIP_INIT"] = "1"
 os.environ["DATABASE_URL"] = "sqlite://"
 
 import pytest  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import create_engine  # noqa: E402
-from sqlalchemy.orm import sessionmaker  # noqa: E402
-from sqlalchemy.pool import StaticPool  # noqa: E402
 
-import api.db as db  # noqa: E402
-from api.db import Base, get_db  # noqa: E402
-
-
-@pytest.fixture(autouse=True)
-def _reset_sse_global():
-    from sse_starlette.sse import AppStatus
-
-    AppStatus.should_exit_event = None
-    yield
-
-
-@pytest.fixture
-def client():
-    test_engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-        future=True,
-    )
-    TestSession = sessionmaker(bind=test_engine, autoflush=False, expire_on_commit=False)
-    db.engine = test_engine
-    db.SessionLocal = TestSession
-    Base.metadata.create_all(test_engine)
-
-    from api.main import app
-
-    def _override_db():
-        s = TestSession()
-        try:
-            yield s
-        finally:
-            s.close()
-
-    app.dependency_overrides[get_db] = _override_db
-    with TestClient(app) as c:
-        yield c
-    app.dependency_overrides.clear()
-    Base.metadata.drop_all(test_engine)
+# client / _reset_sse_global 픽스처는 tests/conftest.py에 공통 정의됨.
 
 
 @pytest.fixture


### PR DESCRIPTION
"성공적인 프로젝트 기준" 리팩터링 + 코드 점검(프론트). 전부 **동작 보존**, 895 테스트 green.

## A. 프론트엔드 실버그 3건 (코드 점검 첫 라운드 → 직접 검증)
1. **관심종목 소실**: `add/removeWatchlist`가 실패 시 `[]` 반환 → 토글 1회 실패(토큰 만료 등)로 `setTickers(new Set([]))`가 되어 관심종목이 화면에서 전부 사라짐. 실패 시 `null` 반환 → 낙관적 상태 유지로 수정.
2. **데이터 탭 5종 stale response race**: 빠른 종목/기간 전환 시 이전 응답이 최신을 덮어씀 → 요청 순번(`useRef`) 가드.
3. **PriceCard change_pct 미포맷**: 실시간 카드만 `.toFixed(2)` 누락 → 정규화.
(검증: tsc·Vitest 17·next build 14라우트)

## B. 백엔드 리팩터링 (진단 → 안전·고가치순)
- **TIER3 청소**: 미사용 import/변수 제거(pyflakes clean) + `/tabs/news` 도달 불가 404 분기 제거.
- **cron 토큰 검증 통합**: push/paper/admin 3곳 인라인 복붙 → `deps.verify_cron_token` 공통 Depends.
- **테스트 conftest 공통화**: `_reset_sse_global`(7곳)·`client` StaticPool fixture(4곳) → conftest 통합(~100줄 제거).
- **tabs 종목해석 헬퍼**: `(data or {}).get(...)` 패턴 4곳 → `_ticker_name` 헬퍼.
- **paper 랭킹 N+1 제거**: 루프 안 `db.get(User)` → 배치 `select(User).in_(ids)`.

**비권장(안 함)**: predictor/collector/agent 파일 분할(응집도 좋아 이득<리스크).

## 검증
전체 **895** 테스트 green. 프론트 tsc+build 정상. 각 단계 커밋 분리(버그/청소·cron/conftest/tabs·paper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)