### PR TITLE
chore(eval): 6/26~6/29 측정 결과 커밋

### DIFF
--- a/ETF_RAG/eval/results/eval_20260626_113538.json
+++ b/ETF_RAG/eval/results/eval_20260626_113538.json
@@ -1,0 +1,417 @@
+{
+  "timestamp": "20260626_113538",
+  "total_questions": 14,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.333,
+    "avg_recall": 1.0,
+    "by_type": {
+      "forecast": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      },
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 14,
+        "hits": 14
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "009155",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "034730",
+        "005389"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "100790",
+        "001500"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "009450",
+        "006805"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "025560",
+        "006805"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "051915"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "383800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "034730",
+        "044450"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "389650",
+        "007340"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ],
+  "ragas": {
+    "faithfulness": 0.988,
+    "answer_relevancy": 0.711,
+    "context_recall": 1.0,
+    "faithfulness_rag_only": 0.988,
+    "context_recall_rag_only": 1.0
+  },
+  "ragas_per_question": [
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 818,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "삼성전자의 1개월 가격 전망 분석 결과입니다.\n\n1. **현재가**: 346,750원\n\n2. **종합 판단**: 강세 전망 (점수: +0.492, 신뢰도: B등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 56% (목표 +34.9%) — 기술적 모멘텀과 펀더멘털 지지 시\n   - ➡️ 횡보: 30% (예상 +8.7%)\n   - 📉 하락: 14% ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.899,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 772,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "SK하이닉스(티커: 000660)의 3개월 후 주가 전망입니다.\n\n1. **현재가**: 2,804,000원\n\n2. **종합 판단**: 약한 강세 (점수: +0.236, 신뢰도: B등급)\n\n3. **시나리오별 확률**:\n   - 📈 **상승**: 51% (목표 +134.9%) — 기술적 모멘텀과 펀더멘털이 지지할 경우\n   - ➡️ **횡보**: 30% (예",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.827,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 864,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현대차(005380)의 향후 6개월 전망 분석 결과입니다.\n\n1. **현재가**: 493,500원\n\n2. **종합 판단**: 중립 (점수: -0.093, 신뢰도: B등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 33% (목표 +149.1%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +31.6%)\n   - 📉 하락: 37% (목",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.885,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 806,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "NAVER(035420)의 1년 전망 예측 결과입니다.\n\n1. **종합 판단**: 약한 강세 (점수: +0.142, 신뢰도: C등급)\n\n2. **시나리오별 확률**:\n   - 📈 상승: 40% (목표 +46.7%) — 시장 전반이 강세일 경우\n   - ➡️ 횡보: 30% (예상 -4.5%)\n   - 📉 하락: 30% (목표 -52.4%) — 외부 충격이나 ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.832,
+      "context_recall": 1.0
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 839,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "기아(000270)의 1개월 목표가 전망입니다.\n\n1. **현재가**: 138,200원\n\n2. **종합 판단**: 약한 약세 (점수: -0.203, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 30% (목표 +20.8%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +2.5%)\n   - 📉 하락: 40% (목표 -10",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.729,
+      "context_recall": 1.0
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 764,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "LG화학의 가격 전망 분석 결과입니다.\n\n1. **종합 판단**: 약한 약세 (점수: -0.282, 신뢰도: B등급)\n\n2. **시나리오별 확률**:\n   - 📈 상승: 22% (목표 +37.0%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +1.2%)\n   - 📉 하락: 48% (목표 -17.6%) — 기술적 약세 전환 시\n\n3. **기술",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 926,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "카카오(035720)의 1개월 가격 전망 분석 결과입니다.\n\n1. **현재가**: 33,800원\n\n2. **종합 판단**: 약한 약세 (점수: -0.230, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 30% (목표 +33.5%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +1.4%)\n   - 📉 하락: 40% (목",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.752,
+      "context_recall": 1.0
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "answer_length": 846,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "POSCO홀딩스(005490)의 3개월 가격 예측 결과입니다.\n\n1. **현재가**: 309,500원\n\n2. **종합 판단**: 약한 약세 (점수: -0.198, 신뢰도: C등급)\n\n3. **시나리오별 확률**:\n   - 📈 상승: 34% (목표 +26.6%) — 시장 전반 강세 시\n   - ➡️ 횡보: 30% (예상 +3.9%)\n   - 📉 하락: 36%",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.928,
+      "context_recall": 1.0
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 528,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "삼성전자의 최근 뉴스 분위기는 전반적으로 긍정적입니다. 긍정적인 기사가 5건, 중립적인 기사가 3건 있으며, 부정적인 기사는 없습니다. \n\n주요 키워드로는 **자사주 매입**, **주가 상승**, **반도체**, **마이크론** 등이 언급되고 있습니다. 특히 삼성전자의 자사주 매입 계획과 반도체 시장의 긍정적인 전망이 주가 상승에 기여하고 있는 것으로 보입",
+      "faithfulness": 0.923,
+      "answer_relevancy": 0.0,
+      "context_recall": 1.0
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 1008,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "SK하이닉스에 대한 최근 뉴스 여론 분석 결과입니다.\n\n### 전체 감성\n- **긍정**: 5건\n- **부정**: 0건\n- **중립**: 3건\n\n### 주요 키워드\n- 미국 ADR 상장\n- 주가 재평가\n- 반도체 주식\n- 유상증자\n- 김문수 100배 수익\n\n### 뉴스 흐름 요약\nSK하이닉스는 미국에서 ADR 상장을 추진하며 주가 재평가를 기대하고 있습니다",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.841,
+      "context_recall": 1.0
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 696,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "현대차 관련 최근 뉴스 감성 분석 결과는 다음과 같습니다.\n\n**전체 감성:** 🔴 부정\n- 긍정: 2건\n- 부정: 5건\n- 중립: 1건\n\n**주요 키워드:** \n- 주가 하락\n- 임원 주식 배분\n- 슈퍼리치 투자\n- 노조 파업\n- 주가 전망\n\n**뉴스 흐름 요약:** 최근 현대차에 대한 뉴스는 주가 하락과 임원 주식 배분에 대한 논란이 주를 이루고 있으며",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.89,
+      "context_recall": 1.0
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 654,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "NAVER에 대한 최근 뉴스 흐름 요약입니다.\n\n**전체 감성:** 부정적\n- 긍정: 0건\n- 부정: 5건\n- 중립: 3건\n\n**주요 키워드:** 주식, AI, 코스피, 마이크론, 실적\n\n**뉴스 흐름 요약:**\n최근 뉴스에서는 주식 시장의 하락과 AI 관련 주식의 불안정성이 강조되고 있으며, 마이크론의 실적 발표가 주목받고 있습니다. 전반적으로 부정적인 ",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.641,
+      "context_recall": 1.0
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 371,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "카카오에 대한 최근 뉴스 분위기는 긍정적입니다. 전체적으로 긍정적인 기사가 8건 있으며, 부정적인 기사는 없습니다. 주요 키워드로는 카카오페이, 카카오페이증권, 완전자회사, 주식 추가취득, 경영 효율성 등이 언급되고 있습니다.\n\n특히 카카오페이가 카카오페이증권의 주식을 추가 취득하여 완전자회사로 전환하며 경영 효율성을 높이고 있다는 소식이 있습니다. 또한,",
+      "faithfulness": 0.909,
+      "answer_relevancy": 0.823,
+      "context_recall": 1.0
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "answer_length": 475,
+      "model": "gpt-4o-mini",
+      "has_context": true,
+      "answer_preview": "LG에너지솔루션에 대한 최근 뉴스 감성 분석 결과입니다.\n\n- **전체 감성:** ⚪ 중립\n  - 긍정: 0건\n  - 부정: 0건\n  - 중립: 3건\n\n- **주요 키워드:** LG에너지솔루션, 투자분석, 개별주식, 위클리옵션, 상장 연기\n\n- **뉴스 흐름 요약:** 최근 LG에너지솔루션 관련 뉴스는 투자 분석과 개별주식 위클리옵션 상장 연기에 대한 내용",
+      "faithfulness": 1.0,
+      "answer_relevancy": 0.905,
+      "context_recall": 1.0
+    }
+  ]
+}

--- a/ETF_RAG/eval/results/eval_20260629_102048.json
+++ b/ETF_RAG/eval/results/eval_20260629_102048.json
@@ -1,0 +1,3104 @@
+{
+  "timestamp": "20260629_102048",
+  "total_questions": 192,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.528,
+    "avg_recall": 0.987,
+    "by_type": {
+      "simple": {
+        "hit_rate": 1.0,
+        "total": 44,
+        "hits": 44
+      },
+      "compare": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "recommend": {
+        "hit_rate": 1.0,
+        "total": 20,
+        "hits": 20
+      },
+      "risk": {
+        "hit_rate": 1.0,
+        "total": 5,
+        "hits": 5
+      },
+      "general": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "technical": {
+        "hit_rate": 1.0,
+        "total": 49,
+        "hits": 49
+      },
+      "correlation": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "portfolio": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "forecast": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      },
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      },
+      "sector": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "etf": {
+        "hit_rate": 1.0,
+        "total": 62,
+        "hits": 62
+      },
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 122,
+        "hits": 122
+      },
+      "mixed": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "KODEX 200 ETF의 오늘 종가는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 ETF 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "471990",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 주요 보유종목이 뭐야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "140700",
+        "390390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 ETF의 NAV는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 등락률이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "390390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "401470"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 차이나전기차 ETF 최근 성과가 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "371460",
+      "retrieved_tickers": [
+        "371460",
+        "0067Y0",
+        "396520"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "462330",
+        "409820"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 인버스 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "114800",
+      "retrieved_tickers": [
+        "114800",
+        "261260",
+        "140710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 반도체TOP10 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "396500",
+      "retrieved_tickers": [
+        "396500",
+        "091230",
+        "472160"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "229200",
+      "retrieved_tickers": [
+        "229200",
+        "360150",
+        "450910"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500 ETF 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "360750",
+      "retrieved_tickers": [
+        "360750",
+        "448290",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국S&P500 수익률 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379800",
+      "retrieved_tickers": [
+        "379800",
+        "453630",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 종가가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "252670",
+        "300950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국나스닥100 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379810",
+      "retrieved_tickers": [
+        "379810",
+        "449190",
+        "411420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ACE 200 ETF 거래량이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "105190",
+      "retrieved_tickers": [
+        "105190",
+        "332500",
+        "438080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "069500 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "329660",
+        "232080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 200이랑 KODEX 200 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "102110"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "102110",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체와 KODEX 200 중에 수익률이 더 좋은 건?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "0162L0"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "나스닥이랑 반도체 ETF 뭐가 더 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "133690",
+        "091160",
+        "368590",
+        "381180",
+        "395160",
+        "390390",
+        "0069M0",
+        "091230",
+        "367380",
+        "476030"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "0069M0",
+        "449190"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지와 KODEX 인버스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "122630",
+        "114800"
+      ],
+      "retrieved_tickers": [
+        "122630",
+        "114800",
+        "462330"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500이랑 KODEX 미국S&P500 차이가 뭐야?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "360750",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "379800",
+        "488500"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 RISE 200 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "148020"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "148020",
+        "226980"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지와 KODEX 코스닥150 비교",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "233740",
+        "229200"
+      ],
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "237350"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체레버리지와 TIGER 반도체TOP10레버리지 어떤 게 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "494310",
+        "488080"
+      ],
+      "retrieved_tickers": [
+        "488080",
+        "396500",
+        "494310"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "468380",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "안정적인 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "438080",
+        "278540"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 비중이 높은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "448330",
+        "0127V0",
+        "310970"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "해외 ETF 중에 수익률 좋은 거 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468380",
+        "0057H0",
+        "278540"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당 수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "266160",
+        "484880",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래량 많은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "433220",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방산 관련 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "490480",
+        "449450",
+        "0041E0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "466810",
+        "305540",
+        "364980"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "인버스 ETF 투자할 때 위험한 점이 뭐야?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "252670",
+        "114800",
+        "252410",
+        "251340",
+        "145670",
+        "123310"
+      ],
+      "retrieved_tickers": [
+        "145670",
+        "261270",
+        "252710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.167,
+      "num_sources": 3
+    },
+    {
+      "question": "레버리지 ETF 위험성에 대해 알려줘",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "152500",
+        "0138T0",
+        "243880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지 투자해도 되나?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "233740",
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "360150"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 장기 보유하면 어떻게 돼?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "261270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 지금 투자해도 괜찮을까?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "466810",
+        "305540",
+        "458260"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ETF란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "433880",
+        "0040Y0",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAV가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "476030",
+        "0080G0",
+        "367380"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "괴리율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "479520",
+        "495750",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "추적오차율이 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "394660",
+        "138540",
+        "496120"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "비트코인 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468370",
+        "0127V0",
+        "453630"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "테슬라 주가 알려줘",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "457480",
+        "494330",
+        "0132K0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "미국 국채 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "0083S0",
+        "114820",
+        "468370"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "금 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "139320",
+        "438080",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 ETF 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "395160",
+        "390390",
+        "381180",
+        "091230"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "219480"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "코스닥 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "354500",
+        "450910",
+        "233740"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "S&P500 추종하는 ETF 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "360200",
+        "488500",
+        "0052S0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 오늘 종가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 주가 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 PER이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 시가총액이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "006660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 배당수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "028260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "170030",
+        "267250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차와 삼성SDI 중에 PER이 낮은 건?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "006400",
+        "005380",
+        "005389"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래대금 많은 주식이 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "003540",
+        "024060",
+        "001680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당수익률 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "097950",
+        "003547",
+        "036000"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "PBR이 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "004840",
+        "368770",
+        "048770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 ETF에 많이 들어가 있어?",
+      "question_type": "simple",
+      "asset_type": "mixed",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "448330",
+        "310970",
+        "102780",
+        "005930",
+        "222080",
+        "028050"
+      ],
+      "hit": true,
+      "precision": 0.167,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 관련 주식이랑 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "183710",
+        "475310",
+        "080220",
+        "254490",
+        "042700"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "한화에어로스페이스 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "451800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER랑 카카오 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "자동차 관련 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "005387",
+        "347860",
+        "031210"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "바이오 관련 주식 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "067370",
+        "063160",
+        "314930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 PER이랑 PBR 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "278470",
+        "415640"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "031980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "024110",
+        "211050",
+        "090460"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "시가총액 큰 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267290",
+        "036030",
+        "004410"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 주가랑 KODEX 반도체 ETF 비교하면 어때?",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "091160"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "278540",
+        "102780",
+        "005930",
+        "082210",
+        "022100"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "삼성전자 RSI가 얼마야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 골든크로스 났어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 MACD 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "494890",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 볼린저 밴드 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 기술적 분석 해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "010140",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 이동평균선 추세가 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "005387",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 데드크로스 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 RSI가 과매수야 과매도야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "155660",
+        "491000"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 기술적 지표 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 MACD 신호 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "151860"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 이동평균선 위에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "417200"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 RSI 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "409820",
+        "261250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 볼린저 밴드 돌파했어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "042420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 골든크로스 나왔나?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "117730",
+        "310210"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 기술적 분석 부탁해",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "030530"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 추세가 상승이야 하락이야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "037350",
+        "000810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 기술적 지표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "200030",
+        "251350"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 RSI랑 MACD 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "267270",
+        "155660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자와 SK하이닉스 상관관계가 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차랑 기아 주가 연동성이 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "025620"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 베타가 얼마야?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER와 카카오 상관계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 같이 움직여?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 베타 계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 KODEX 200 상관관계는?",
+      "question_type": "correlation",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "102780",
+        "005930",
+        "052900",
+        "022100"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "KB금융이랑 신한지주 같이 움직이나?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 베타가 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "365330"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스랑 현대제철 상관관계 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005490",
+        "004020"
+      ],
+      "retrieved_tickers": [
+        "005490",
+        "004020",
+        "192400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온이랑 삼성바이오로직스 연관성 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "068270",
+        "207940"
+      ],
+      "retrieved_tickers": [
+        "207940",
+        "068270",
+        "338840"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 베타 계수가 1보다 커?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "126700",
+        "083790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 50% SK하이닉스 50%로 포트폴리오 시뮬레이션 해줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 30% 현대차 30% KODEX 200 40% 백테스트 해줘",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "005380",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "278530",
+        "448330",
+        "005930",
+        "005380",
+        "095610"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 주식으로만 포트폴리오 만들면 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "080220",
+        "320000",
+        "214680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 TIGER 미국S&P500 반반 넣으면 수익률이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "360750"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "069500",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 SK하이닉스 NAVER 균등 비중으로 3년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660",
+        "035420"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "035420",
+        "005930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 50% 기아 50% 포트폴리오 MDD가 어떻게 돼?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "080160"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 100% 단일 종목 투자하면 샤프 비율이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "000810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 포트폴리오 시뮬레이션 해줘. KB금융 50% 신한지주 50%",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "228670"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 60% KODEX 미국S&P500 40%로 2년 시뮬레이션",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "379800",
+        "069500",
+        "463690"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 삼성SDI 포스코홀딩스 균등 비중 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400",
+        "005490"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "005490",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방어적인 포트폴리오 만들어줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "010640",
+        "047050",
+        "119500"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 40% KODEX 200 30% TIGER 미국나스닥100 30% 5년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500",
+        "133690"
+      ],
+      "retrieved_tickers": [
+        "133690",
+        "069500",
+        "449190",
+        "005930",
+        "095610",
+        "006200"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "골든크로스가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "117730",
+        "141080",
+        "066430"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "RSI가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "067730",
+        "177900",
+        "069730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MACD는 어떻게 해석해?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "015590",
+        "067310",
+        "305090"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "볼린저 밴드가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "013990",
+        "279570",
+        "047770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "베타 계수가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "402340",
+        "317690",
+        "139670"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "샤프 비율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "007460",
+        "082920",
+        "045340"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MDD가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "086960",
+        "0088M0",
+        "118990"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "상관계수가 1이면 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "209640",
+        "004800",
+        "067830"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 분기 매출이랑 영업이익 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "006660",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 영업이익률 추이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 실적 보여줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 매출 성장률이 어떻게 돼?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "145170",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 영업이익률 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "영업이익률이 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267980",
+        "008500",
+        "024110"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 재무제표 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "066570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 순이익이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 관련 종목 실적 비교해줘",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "471990",
+        "080220",
+        "320000",
+        "254490"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "영업이익률이란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267980",
+        "008500",
+        "092780"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 스토캐스틱 지표 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 과매수 과매도 상태 확인",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 일목균형표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 구름대 위에 있어? 아래에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 CCI 지표가 어떻게 되나요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 추세 강도 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "151860"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 거래량 추세 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 변동성이 요즘 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "209640",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 앞으로 전망 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "049950",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 목표가 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 일목균형표 어떻게 돼?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "0100K0",
+        "266390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 가격 예측",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 다음주 오를까 내릴까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 향후 전망이 어떤가요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "117700",
+        "226980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "407400",
+        "340360"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 어때? 살만해?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 투자해도 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체주 전반적으로 전망이 어때?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "469150",
+        "080220",
+        "254490",
+        "042700"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "TIGER 미국나스닥100 ETF 향후 전망은?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 3개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "00279K",
+        "060310"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 1주일 뒤에 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "153490"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 앞으로 어떻게 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 ETF 전망이 어때?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "219480",
+        "251350"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 지금 사도 돼?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "034120",
+        "241560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 6개월 뒤 주가 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "006660",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 투자 전망 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "100790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "066575"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 관련 이슈가 뭐야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 뉴스 감성 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 최근 소식이랑 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "097520",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 호재 악재 뭐가 있어?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "0015N0",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 Prophet 모델로 3개월 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "417970",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 1년 뒤 주가 전망",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "051905"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 뉴스 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "0190G0",
+        "117700"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 뉴스랑 기술적 분석 같이 봐줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "462310",
+        "463020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 시계열 예측 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "009155"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "100790",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "396690",
+        "024940"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "025560",
+        "396690"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "051915"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "006840"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "263810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "137940",
+        "051370"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "222080",
+        "028050"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "039010",
+        "307950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "005250",
+        "006840"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "137940",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ]
+}

--- a/ETF_RAG/eval/results/eval_20260629_102223.json
+++ b/ETF_RAG/eval/results/eval_20260629_102223.json
@@ -1,0 +1,3104 @@
+{
+  "timestamp": "20260629_102223",
+  "total_questions": 192,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.528,
+    "avg_recall": 0.987,
+    "by_type": {
+      "simple": {
+        "hit_rate": 1.0,
+        "total": 44,
+        "hits": 44
+      },
+      "compare": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "recommend": {
+        "hit_rate": 1.0,
+        "total": 20,
+        "hits": 20
+      },
+      "risk": {
+        "hit_rate": 1.0,
+        "total": 5,
+        "hits": 5
+      },
+      "general": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "technical": {
+        "hit_rate": 1.0,
+        "total": 49,
+        "hits": 49
+      },
+      "correlation": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "portfolio": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "forecast": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      },
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      },
+      "sector": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "etf": {
+        "hit_rate": 1.0,
+        "total": 62,
+        "hits": 62
+      },
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 122,
+        "hits": 122
+      },
+      "mixed": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "KODEX 200 ETF의 오늘 종가는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 ETF 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "471990",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 주요 보유종목이 뭐야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "140700",
+        "390390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 ETF의 NAV는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 등락률이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "390390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "401470"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 차이나전기차 ETF 최근 성과가 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "371460",
+      "retrieved_tickers": [
+        "371460",
+        "0067Y0",
+        "396520"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "462330",
+        "409820"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 인버스 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "114800",
+      "retrieved_tickers": [
+        "114800",
+        "261260",
+        "140710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 반도체TOP10 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "396500",
+      "retrieved_tickers": [
+        "396500",
+        "091230",
+        "472160"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "229200",
+      "retrieved_tickers": [
+        "229200",
+        "360150",
+        "450910"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500 ETF 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "360750",
+      "retrieved_tickers": [
+        "360750",
+        "448290",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국S&P500 수익률 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379800",
+      "retrieved_tickers": [
+        "379800",
+        "453630",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 종가가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "252670",
+        "300950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국나스닥100 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379810",
+      "retrieved_tickers": [
+        "379810",
+        "449190",
+        "411420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ACE 200 ETF 거래량이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "105190",
+      "retrieved_tickers": [
+        "105190",
+        "332500",
+        "438080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "069500 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "329660",
+        "232080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 200이랑 KODEX 200 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "102110"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "102110",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체와 KODEX 200 중에 수익률이 더 좋은 건?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "0162L0"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "나스닥이랑 반도체 ETF 뭐가 더 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "133690",
+        "091160",
+        "368590",
+        "381180",
+        "395160",
+        "390390",
+        "0069M0",
+        "091230",
+        "367380",
+        "476030"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "0069M0",
+        "449190"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지와 KODEX 인버스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "122630",
+        "114800"
+      ],
+      "retrieved_tickers": [
+        "122630",
+        "114800",
+        "462330"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500이랑 KODEX 미국S&P500 차이가 뭐야?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "360750",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "379800",
+        "488500"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 RISE 200 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "148020"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "148020",
+        "226980"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지와 KODEX 코스닥150 비교",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "233740",
+        "229200"
+      ],
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "237350"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체레버리지와 TIGER 반도체TOP10레버리지 어떤 게 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "494310",
+        "488080"
+      ],
+      "retrieved_tickers": [
+        "488080",
+        "396500",
+        "494310"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "468380",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "안정적인 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "438080",
+        "278540"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 비중이 높은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "448330",
+        "0127V0",
+        "310970"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "해외 ETF 중에 수익률 좋은 거 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468380",
+        "0057H0",
+        "278540"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당 수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "266160",
+        "484880",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래량 많은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "433220",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방산 관련 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "490480",
+        "449450",
+        "0041E0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "466810",
+        "305540",
+        "364980"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "인버스 ETF 투자할 때 위험한 점이 뭐야?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "252670",
+        "114800",
+        "252410",
+        "251340",
+        "145670",
+        "123310"
+      ],
+      "retrieved_tickers": [
+        "145670",
+        "261270",
+        "252710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.167,
+      "num_sources": 3
+    },
+    {
+      "question": "레버리지 ETF 위험성에 대해 알려줘",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "152500",
+        "0138T0",
+        "243880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지 투자해도 되나?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "233740",
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "360150"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 장기 보유하면 어떻게 돼?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "261270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 지금 투자해도 괜찮을까?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "466810",
+        "305540",
+        "458260"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ETF란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "433880",
+        "0040Y0",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAV가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "476030",
+        "0080G0",
+        "367380"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "괴리율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "479520",
+        "495750",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "추적오차율이 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "394660",
+        "138540",
+        "496120"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "비트코인 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468370",
+        "0127V0",
+        "453630"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "테슬라 주가 알려줘",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "457480",
+        "494330",
+        "0132K0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "미국 국채 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "0083S0",
+        "114820",
+        "468370"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "금 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "139320",
+        "438080",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 ETF 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "395160",
+        "390390",
+        "381180",
+        "091230"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "219480"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "코스닥 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "354500",
+        "450910",
+        "233740"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "S&P500 추종하는 ETF 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "360200",
+        "488500",
+        "0052S0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 오늘 종가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 주가 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 PER이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 시가총액이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "006660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 배당수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "028260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "170030",
+        "267250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차와 삼성SDI 중에 PER이 낮은 건?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "006400",
+        "005380",
+        "005389"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래대금 많은 주식이 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "003540",
+        "024060",
+        "001680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당수익률 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "097950",
+        "003547",
+        "036000"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "PBR이 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "004840",
+        "368770",
+        "048770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 ETF에 많이 들어가 있어?",
+      "question_type": "simple",
+      "asset_type": "mixed",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "448330",
+        "310970",
+        "102780",
+        "005930",
+        "222080",
+        "028050"
+      ],
+      "hit": true,
+      "precision": 0.167,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 관련 주식이랑 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "183710",
+        "475310",
+        "080220",
+        "254490",
+        "042700"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "한화에어로스페이스 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "451800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER랑 카카오 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "자동차 관련 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "005387",
+        "347860",
+        "005830"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "바이오 관련 주식 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "067370",
+        "063160",
+        "314930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 PER이랑 PBR 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "278470",
+        "415640"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "031980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "024110",
+        "211050",
+        "090460"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "시가총액 큰 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267290",
+        "036030",
+        "264900"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 주가랑 KODEX 반도체 ETF 비교하면 어때?",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "091160"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "278540",
+        "102780",
+        "005930",
+        "082210",
+        "022100"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "삼성전자 RSI가 얼마야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 골든크로스 났어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 MACD 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "494890",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 볼린저 밴드 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 기술적 분석 해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "010140",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 이동평균선 추세가 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "005387",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 데드크로스 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 RSI가 과매수야 과매도야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "155660",
+        "491000"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 기술적 지표 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 MACD 신호 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "151860"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 이동평균선 위에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "417200"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 RSI 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "409820",
+        "261250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 볼린저 밴드 돌파했어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "042420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 골든크로스 나왔나?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "117730",
+        "310210"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 기술적 분석 부탁해",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "030530"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 추세가 상승이야 하락이야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "037350",
+        "000810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 기술적 지표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "200030",
+        "251350"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 RSI랑 MACD 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "267270",
+        "155660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자와 SK하이닉스 상관관계가 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차랑 기아 주가 연동성이 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "025620"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 베타가 얼마야?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER와 카카오 상관계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 같이 움직여?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 베타 계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 KODEX 200 상관관계는?",
+      "question_type": "correlation",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "102780",
+        "005930",
+        "052900",
+        "022100"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "KB금융이랑 신한지주 같이 움직이나?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 베타가 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "365330"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스랑 현대제철 상관관계 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005490",
+        "004020"
+      ],
+      "retrieved_tickers": [
+        "005490",
+        "004020",
+        "192400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온이랑 삼성바이오로직스 연관성 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "068270",
+        "207940"
+      ],
+      "retrieved_tickers": [
+        "207940",
+        "068270",
+        "338840"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 베타 계수가 1보다 커?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "126700",
+        "083790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 50% SK하이닉스 50%로 포트폴리오 시뮬레이션 해줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 30% 현대차 30% KODEX 200 40% 백테스트 해줘",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "005380",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "278530",
+        "448330",
+        "005930",
+        "005380",
+        "095610"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 주식으로만 포트폴리오 만들면 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "080220",
+        "320000",
+        "214680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 TIGER 미국S&P500 반반 넣으면 수익률이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "360750"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "069500",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 SK하이닉스 NAVER 균등 비중으로 3년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660",
+        "035420"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "035420",
+        "005930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 50% 기아 50% 포트폴리오 MDD가 어떻게 돼?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "080160"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 100% 단일 종목 투자하면 샤프 비율이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "000810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 포트폴리오 시뮬레이션 해줘. KB금융 50% 신한지주 50%",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "228670"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 60% KODEX 미국S&P500 40%로 2년 시뮬레이션",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "379800",
+        "069500",
+        "463690"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 삼성SDI 포스코홀딩스 균등 비중 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400",
+        "005490"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "005490",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방어적인 포트폴리오 만들어줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "010640",
+        "047050",
+        "119500"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 40% KODEX 200 30% TIGER 미국나스닥100 30% 5년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500",
+        "133690"
+      ],
+      "retrieved_tickers": [
+        "133690",
+        "069500",
+        "449190",
+        "005930",
+        "095610",
+        "006200"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "골든크로스가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "117730",
+        "141080",
+        "066430"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "RSI가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "067730",
+        "177900",
+        "069730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MACD는 어떻게 해석해?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "015590",
+        "067310",
+        "305090"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "볼린저 밴드가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "013990",
+        "279570",
+        "047770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "베타 계수가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "402340",
+        "317690",
+        "139670"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "샤프 비율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "007460",
+        "082920",
+        "045340"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MDD가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "086960",
+        "0088M0",
+        "118990"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "상관계수가 1이면 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "209640",
+        "004800",
+        "067830"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 분기 매출이랑 영업이익 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "006660",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 영업이익률 추이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 실적 보여줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 매출 성장률이 어떻게 돼?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "145170",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 영업이익률 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "영업이익률이 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267980",
+        "008500",
+        "024110"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 재무제표 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "066570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 순이익이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "053210",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 관련 종목 실적 비교해줘",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "471990",
+        "080220",
+        "320000",
+        "254490"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "영업이익률이란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267980",
+        "008500",
+        "092780"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 스토캐스틱 지표 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 과매수 과매도 상태 확인",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 일목균형표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 구름대 위에 있어? 아래에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 CCI 지표가 어떻게 되나요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 추세 강도 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "151860"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 거래량 추세 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 변동성이 요즘 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "209640",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 앞으로 전망 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "049950",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 목표가 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 일목균형표 어떻게 돼?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "0100K0",
+        "266390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 가격 예측",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 다음주 오를까 내릴까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 향후 전망이 어떤가요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "117700",
+        "226980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "407400",
+        "340360"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 어때? 살만해?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 투자해도 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체주 전반적으로 전망이 어때?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "469150",
+        "080220",
+        "254490",
+        "042700"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "TIGER 미국나스닥100 ETF 향후 전망은?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 3개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "00279K",
+        "060310"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 1주일 뒤에 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "153490"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 앞으로 어떻게 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "001940",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 ETF 전망이 어때?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "219480",
+        "251350"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 지금 사도 돼?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "034120",
+        "241560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 6개월 뒤 주가 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "006660",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 투자 전망 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "100790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "066575"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 관련 이슈가 뭐야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 뉴스 감성 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 최근 소식이랑 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "097520",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 호재 악재 뭐가 있어?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "0015N0",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 Prophet 모델로 3개월 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "417970",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 1년 뒤 주가 전망",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "051905"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 뉴스 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "0190G0",
+        "117700"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 뉴스랑 기술적 분석 같이 봐줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "462310",
+        "463020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 시계열 예측 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "009155"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "100790",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "396690",
+        "024940"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "025560",
+        "396690"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "051915"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "006840"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "068290",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "137940",
+        "051370"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "222080",
+        "028050"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "039010",
+        "307950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "005250",
+        "006840"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "137940",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ]
+}

--- a/ETF_RAG/eval/results/eval_20260629_102349.json
+++ b/ETF_RAG/eval/results/eval_20260629_102349.json
@@ -1,0 +1,3104 @@
+{
+  "timestamp": "20260629_102349",
+  "total_questions": 192,
+  "retrieval": {
+    "hit_rate": 1.0,
+    "avg_precision": 0.528,
+    "avg_recall": 0.987,
+    "by_type": {
+      "simple": {
+        "hit_rate": 1.0,
+        "total": 44,
+        "hits": 44
+      },
+      "compare": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "recommend": {
+        "hit_rate": 1.0,
+        "total": 20,
+        "hits": 20
+      },
+      "risk": {
+        "hit_rate": 1.0,
+        "total": 5,
+        "hits": 5
+      },
+      "general": {
+        "hit_rate": 1.0,
+        "total": 15,
+        "hits": 15
+      },
+      "technical": {
+        "hit_rate": 1.0,
+        "total": 49,
+        "hits": 49
+      },
+      "correlation": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "portfolio": {
+        "hit_rate": 1.0,
+        "total": 12,
+        "hits": 12
+      },
+      "forecast": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      },
+      "news": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      },
+      "sector": {
+        "hit_rate": 1.0,
+        "total": 6,
+        "hits": 6
+      }
+    },
+    "by_asset": {
+      "etf": {
+        "hit_rate": 1.0,
+        "total": 62,
+        "hits": 62
+      },
+      "stock": {
+        "hit_rate": 1.0,
+        "total": 122,
+        "hits": 122
+      },
+      "mixed": {
+        "hit_rate": 1.0,
+        "total": 8,
+        "hits": 8
+      }
+    }
+  },
+  "retrieval_details": [
+    {
+      "question": "KODEX 200 ETF의 오늘 종가는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 ETF 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "471990",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 주요 보유종목이 뭐야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "140700",
+        "390390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 ETF의 NAV는 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 등락률이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "390390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "401470"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 차이나전기차 ETF 최근 성과가 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "371460",
+      "retrieved_tickers": [
+        "371460",
+        "0067Y0",
+        "396520"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "462330",
+        "409820"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 인버스 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "114800",
+      "retrieved_tickers": [
+        "114800",
+        "261260",
+        "140710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 반도체TOP10 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "396500",
+      "retrieved_tickers": [
+        "396500",
+        "091230",
+        "472160"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150 수익률은?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "229200",
+      "retrieved_tickers": [
+        "229200",
+        "360150",
+        "450910"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500 ETF 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "360750",
+      "retrieved_tickers": [
+        "360750",
+        "448290",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국S&P500 수익률 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379800",
+      "retrieved_tickers": [
+        "379800",
+        "453630",
+        "200030"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 종가가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "252670",
+        "300950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 미국나스닥100 수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "379810",
+      "retrieved_tickers": [
+        "379810",
+        "449190",
+        "411420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ACE 200 ETF 거래량이 어때?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "105190",
+      "retrieved_tickers": [
+        "105190",
+        "332500",
+        "438080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "069500 종가 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "329660",
+        "232080"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 200이랑 KODEX 200 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "102110"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "102110",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체와 KODEX 200 중에 수익률이 더 좋은 건?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "0162L0"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "나스닥이랑 반도체 ETF 뭐가 더 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "133690",
+        "091160",
+        "368590",
+        "381180",
+        "395160",
+        "390390",
+        "0069M0",
+        "091230",
+        "367380",
+        "476030"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "0069M0",
+        "449190"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지와 KODEX 인버스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "122630",
+        "114800"
+      ],
+      "retrieved_tickers": [
+        "122630",
+        "114800",
+        "462330"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국S&P500이랑 KODEX 미국S&P500 차이가 뭐야?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "360750",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "379800",
+        "488500"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 RISE 200 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "148020"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "148020",
+        "226980"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지와 KODEX 코스닥150 비교",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "233740",
+        "229200"
+      ],
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "237350"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체레버리지와 TIGER 반도체TOP10레버리지 어떤 게 좋아?",
+      "question_type": "compare",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "494310",
+        "488080"
+      ],
+      "retrieved_tickers": [
+        "488080",
+        "396500",
+        "494310"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "468380",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "안정적인 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "438080",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 비중이 높은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "448330",
+        "0127V0",
+        "0195R0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "해외 ETF 중에 수익률 좋은 거 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468380",
+        "0057H0",
+        "278540"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당 수익률 높은 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "266160",
+        "484880",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래량 많은 ETF가 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "399110",
+        "433220",
+        "482730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방산 관련 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "490480",
+        "449450",
+        "0041E0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "466810",
+        "305540",
+        "364980"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "인버스 ETF 투자할 때 위험한 점이 뭐야?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "252670",
+        "114800",
+        "252410",
+        "251340",
+        "145670",
+        "123310"
+      ],
+      "retrieved_tickers": [
+        "145670",
+        "261270",
+        "252710"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.167,
+      "num_sources": 3
+    },
+    {
+      "question": "레버리지 ETF 위험성에 대해 알려줘",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "152500",
+        "0138T0",
+        "243880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 코스닥150레버리지 투자해도 되나?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "233740",
+      "retrieved_tickers": [
+        "233740",
+        "229200",
+        "360150"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200선물인버스2X 장기 보유하면 어떻게 돼?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": "252670",
+      "retrieved_tickers": [
+        "252670",
+        "069500",
+        "261270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "2차전지 ETF 지금 투자해도 괜찮을까?",
+      "question_type": "risk",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "466810",
+        "305540",
+        "458260"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "ETF란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "433880",
+        "0040Y0",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAV가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "476030",
+        "0080G0",
+        "367380"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "괴리율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "479520",
+        "495750",
+        "456880"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "추적오차율이 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "394660",
+        "138540",
+        "496120"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "비트코인 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "468370",
+        "0127V0",
+        "453630"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "테슬라 주가 알려줘",
+      "question_type": "general",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "457480",
+        "494330",
+        "0132K0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "미국 국채 ETF 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "0083S0",
+        "114820",
+        "468370"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "금 ETF 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "139320",
+        "438080",
+        "360750"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 ETF 보유종목 알려줘",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "091160",
+        "395160",
+        "390390",
+        "381180",
+        "091230"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "219480"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 0.2,
+      "num_sources": 3
+    },
+    {
+      "question": "코스닥 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "354500",
+        "450910",
+        "233740"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "S&P500 추종하는 ETF 알려줘",
+      "question_type": "recommend",
+      "asset_type": "etf",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "360200",
+        "488500",
+        "0052S0"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 오늘 종가 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 주가 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 PER이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 시가총액이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "005935",
+        "006660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 배당수익률 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "028050",
+        "028260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 수익률이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "170030",
+        "267250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차와 삼성SDI 중에 PER이 낮은 건?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "006400",
+        "005380",
+        "005389"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "거래대금 많은 주식이 뭐야?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "003540",
+        "024060",
+        "001680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "배당수익률 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "097950",
+        "003547",
+        "036000"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "PBR이 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "004840",
+        "368770",
+        "048770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 ETF에 많이 들어가 있어?",
+      "question_type": "simple",
+      "asset_type": "mixed",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "448330",
+        "310970",
+        "102780",
+        "005930",
+        "222080",
+        "028050"
+      ],
+      "hit": true,
+      "precision": 0.167,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 관련 주식이랑 ETF 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "183710",
+        "475310",
+        "080220",
+        "254490",
+        "042700"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "한화에어로스페이스 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "451800"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER랑 카카오 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 중에 뭐가 나아?",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "자동차 관련 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "005387",
+        "347860",
+        "031210"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "바이오 관련 주식 뭐가 있어?",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "067370",
+        "063160",
+        "314930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 PER이랑 PBR 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "278470",
+        "415640"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 주가 정보 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "031980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "024110",
+        "211050",
+        "090460"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "시가총액 큰 주식 알려줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267290",
+        "036030",
+        "004410"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 주가랑 KODEX 반도체 ETF 비교하면 어때?",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "091160"
+      ],
+      "retrieved_tickers": [
+        "091160",
+        "278540",
+        "102780",
+        "005930",
+        "082210",
+        "022100"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "삼성전자 RSI가 얼마야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 골든크로스 났어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 MACD 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "494890",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 볼린저 밴드 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 기술적 분석 해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "006405",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 이동평균선 추세가 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "005387",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 데드크로스 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 RSI가 과매수야 과매도야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "155660",
+        "491000"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "TIGER 미국나스닥100 기술적 지표 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 MACD 신호 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "151860"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 이동평균선 위에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "417200"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 RSI 알려줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "409820",
+        "261250"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 볼린저 밴드 돌파했어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "042420"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 골든크로스 나왔나?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "117730",
+        "310210"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 기술적 분석 부탁해",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "030530"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 추세가 상승이야 하락이야?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "037350",
+        "000810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 기술적 지표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "200030",
+        "251350"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대건설 RSI랑 MACD 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000720",
+      "retrieved_tickers": [
+        "000720",
+        "267270",
+        "155660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자와 SK하이닉스 상관관계가 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차랑 기아 주가 연동성이 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "025620"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 베타가 얼마야?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER와 카카오 상관계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "035420",
+        "035720"
+      ],
+      "retrieved_tickers": [
+        "035420",
+        "035720",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션이랑 삼성SDI 같이 움직여?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "006400",
+        "003550"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 베타 계수 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 KODEX 200 상관관계는?",
+      "question_type": "correlation",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "091160",
+        "102780",
+        "005930",
+        "052900",
+        "022100"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "KB금융이랑 신한지주 같이 움직이나?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 베타가 높아?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "365330"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스랑 현대제철 상관관계 어때?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005490",
+        "004020"
+      ],
+      "retrieved_tickers": [
+        "005490",
+        "004020",
+        "192400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온이랑 삼성바이오로직스 연관성 알려줘",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "068270",
+        "207940"
+      ],
+      "retrieved_tickers": [
+        "207940",
+        "068270",
+        "338840"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 베타 계수가 1보다 커?",
+      "question_type": "correlation",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "126700",
+        "083790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 50% SK하이닉스 50%로 포트폴리오 시뮬레이션 해줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 30% 현대차 30% KODEX 200 40% 백테스트 해줘",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "005380",
+        "069500"
+      ],
+      "retrieved_tickers": [
+        "069500",
+        "278530",
+        "448330",
+        "005930",
+        "005380",
+        "095610"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "반도체 주식으로만 포트폴리오 만들면 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "080220",
+        "320000",
+        "214680"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200이랑 TIGER 미국S&P500 반반 넣으면 수익률이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "360750"
+      ],
+      "retrieved_tickers": [
+        "360750",
+        "069500",
+        "379800"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 SK하이닉스 NAVER 균등 비중으로 3년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005930",
+        "000660",
+        "035420"
+      ],
+      "retrieved_tickers": [
+        "000660",
+        "035420",
+        "005930"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 50% 기아 50% 포트폴리오 MDD가 어떻게 돼?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "005380",
+        "000270"
+      ],
+      "retrieved_tickers": [
+        "005380",
+        "000270",
+        "080160"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 100% 단일 종목 투자하면 샤프 비율이 어때?",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "372170",
+        "000810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "은행주 포트폴리오 시뮬레이션 해줘. KB금융 50% 신한지주 50%",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "105560",
+        "055550"
+      ],
+      "retrieved_tickers": [
+        "105560",
+        "055550",
+        "228670"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 60% KODEX 미국S&P500 40%로 2년 시뮬레이션",
+      "question_type": "portfolio",
+      "asset_type": "etf",
+      "expected_ticker": [
+        "069500",
+        "379800"
+      ],
+      "retrieved_tickers": [
+        "379800",
+        "069500",
+        "463690"
+      ],
+      "hit": true,
+      "precision": 0.667,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 삼성SDI 포스코홀딩스 균등 비중 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": [
+        "373220",
+        "006400",
+        "005490"
+      ],
+      "retrieved_tickers": [
+        "373220",
+        "005490",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "방어적인 포트폴리오 만들어줘",
+      "question_type": "portfolio",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "010640",
+        "047050",
+        "119500"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 40% KODEX 200 30% TIGER 미국나스닥100 30% 5년 백테스트",
+      "question_type": "portfolio",
+      "asset_type": "mixed",
+      "expected_ticker": [
+        "005930",
+        "069500",
+        "133690"
+      ],
+      "retrieved_tickers": [
+        "133690",
+        "069500",
+        "449190",
+        "005930",
+        "095610",
+        "006200"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "골든크로스가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "117730",
+        "141080",
+        "066430"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "RSI가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "067730",
+        "177900",
+        "069730"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MACD는 어떻게 해석해?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "015590",
+        "067310",
+        "305090"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "볼린저 밴드가 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "013990",
+        "279570",
+        "047770"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "베타 계수가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "402340",
+        "317690",
+        "139670"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "샤프 비율이 뭐야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "007460",
+        "082920",
+        "045340"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "MDD가 뭔가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "086960",
+        "0088M0",
+        "118990"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "상관계수가 1이면 무슨 뜻이야?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "209640",
+        "004800",
+        "067830"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 분기 매출이랑 영업이익 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "006660",
+        "006405"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 영업이익률 추이 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 실적 보여줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 매출 성장률이 어떻게 돼?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "145170",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자랑 SK하이닉스 영업이익률 비교해줘",
+      "question_type": "compare",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "000660",
+        "005930",
+        "452400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "영업이익률이 높은 주식 추천해줘",
+      "question_type": "recommend",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "008500",
+        "267980",
+        "024110"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 재무제표 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "066570"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 순이익이 얼마야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "053210",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체 관련 종목 실적 비교해줘",
+      "question_type": "compare",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "471990",
+        "080220",
+        "320000",
+        "254490"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "영업이익률이란 무엇인가요?",
+      "question_type": "general",
+      "asset_type": "stock",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "267980",
+        "008500",
+        "092780"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 스토캐스틱 지표 확인해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "006400"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 과매수 과매도 상태 확인",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 일목균형표 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 구름대 위에 있어? 아래에 있어?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200의 CCI 지표가 어떻게 되나요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "226980",
+        "363580"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 추세 강도 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "151860"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 거래량 추세 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 변동성이 요즘 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "209640",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 앞으로 전망 어때?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "049950",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 목표가 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 레버리지 일목균형표 어떻게 돼?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "122630",
+      "retrieved_tickers": [
+        "122630",
+        "0100K0",
+        "266390"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 가격 예측",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 다음주 오를까 내릴까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 200 향후 전망이 어떤가요?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "069500",
+      "retrieved_tickers": [
+        "069500",
+        "117700",
+        "226980"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "407400",
+        "340360"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 어때? 살만해?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 투자해도 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "반도체주 전반적으로 전망이 어때?",
+      "question_type": "recommend",
+      "asset_type": "mixed",
+      "expected_ticker": null,
+      "retrieved_tickers": [
+        "091160",
+        "475310",
+        "469150",
+        "080220",
+        "254490",
+        "042700"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "num_sources": 6
+    },
+    {
+      "question": "TIGER 미국나스닥100 ETF 향후 전망은?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "133690",
+      "retrieved_tickers": [
+        "133690",
+        "448300",
+        "486290"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 3개월 전망 분석해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "00279K",
+        "060310"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 주가 1주일 뒤에 오를까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "212560",
+        "153490"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 앞으로 어떻게 될까?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "001940",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 2차전지산업 ETF 전망이 어때?",
+      "question_type": "technical",
+      "asset_type": "etf",
+      "expected_ticker": "305720",
+      "retrieved_tickers": [
+        "305720",
+        "219480",
+        "251350"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 지금 사도 돼?",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "034120",
+        "241560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성SDI 6개월 뒤 주가 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "006400",
+      "retrieved_tickers": [
+        "006400",
+        "006660",
+        "018260"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "한화에어로스페이스 투자 전망 알려줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "012450",
+      "retrieved_tickers": [
+        "012450",
+        "000880",
+        "100790"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 알려줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "066575"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 관련 이슈가 뭐야?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 뉴스 감성 분석해줘",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 최근 소식이랑 주가 어때?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "097520",
+        "001740"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 호재 악재 뭐가 있어?",
+      "question_type": "simple",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "0015N0",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 Prophet 모델로 3개월 예측해줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "417970",
+        "017900"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 1년 뒤 주가 전망",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "051905"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KODEX 반도체 뉴스 있어?",
+      "question_type": "simple",
+      "asset_type": "etf",
+      "expected_ticker": "091160",
+      "retrieved_tickers": [
+        "091160",
+        "0190G0",
+        "117700"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "셀트리온 뉴스랑 기술적 분석 같이 봐줘",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "068270",
+      "retrieved_tickers": [
+        "068270",
+        "462310",
+        "463020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "포스코홀딩스 시계열 예측 분석",
+      "question_type": "technical",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "000480",
+        "081660"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 1개월 가격 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "009155"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 3개월 뒤 주가 어떻게 될까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 향후 6개월 전망 분석해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "100790",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 주가 1년 전망 예측",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "396690",
+        "024940"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "기아 목표가 전망 알려줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "000270",
+      "retrieved_tickers": [
+        "000270",
+        "025560",
+        "396690"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG화학 앞으로 오를까 내릴까?",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "051910",
+      "retrieved_tickers": [
+        "051910",
+        "003550",
+        "051915"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 단기 가격 전망 분석",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "377300",
+        "381970"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 3개월 가격 예측해줘",
+      "question_type": "forecast",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "042420",
+        "006840"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자 최근 뉴스 분위기 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "018260",
+        "263810"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스 뉴스 여론 분석해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 관련 최근 뉴스 감성 어때?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "001500",
+        "004020"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER 뉴스 흐름 요약해줘",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "137940",
+        "051370"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "카카오 요즘 뉴스 분위기 긍정적이야?",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "035720",
+      "retrieved_tickers": [
+        "035720",
+        "348340",
+        "377300"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "LG에너지솔루션 뉴스 감성 분석",
+      "question_type": "news",
+      "asset_type": "stock",
+      "expected_ticker": "373220",
+      "retrieved_tickers": [
+        "373220",
+        "003550",
+        "037560"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "삼성전자는 어떤 ETF에 많이 담겨 있어?",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005930",
+      "retrieved_tickers": [
+        "005930",
+        "222080",
+        "028050"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "SK하이닉스가 편입된 ETF랑 섹터 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "000660",
+      "retrieved_tickers": [
+        "000660",
+        "452400",
+        "034730"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "현대차 섹터 내 밸류에이션 위치 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005380",
+      "retrieved_tickers": [
+        "005380",
+        "039010",
+        "307950"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "KB금융 업종 분석과 보유 ETF 알려줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "105560",
+      "retrieved_tickers": [
+        "105560",
+        "211050",
+        "138930"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "POSCO홀딩스 섹터 분석",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "005490",
+      "retrieved_tickers": [
+        "005490",
+        "005250",
+        "006840"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    },
+    {
+      "question": "NAVER가 들어있는 ETF와 업종 위치 분석해줘",
+      "question_type": "sector",
+      "asset_type": "stock",
+      "expected_ticker": "035420",
+      "retrieved_tickers": [
+        "035420",
+        "137940",
+        "396270"
+      ],
+      "hit": true,
+      "precision": 0.333,
+      "recall": 1.0,
+      "num_sources": 3
+    }
+  ]
+}

--- a/ETF_RAG/eval/results/exp_embedding_ab_1782695807.json
+++ b/ETF_RAG/eval/results/exp_embedding_ab_1782695807.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "dataset_size": 62,
+    "models": {
+      "small": "text-embedding-3-small",
+      "large": "text-embedding-3-large"
+    },
+    "modes": [
+      "full (실서비스)",
+      "dense_only (직접매칭off + sparse=0)"
+    ],
+    "note": "Hit@5 천장 효과 → dense_only MRR/Hit@1로 판정. bge-m3는 한국어 특화 비교용."
+  },
+  "models": {
+    "small": {
+      "full": {
+        "n": 42,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "full_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "dense_only": {
+        "n": 42,
+        "mrr": 0.4948,
+        "hit@1": 0.4286,
+        "hit@3": 0.5238,
+        "hit@5": 0.619
+      },
+      "dense_only_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "elapsed_sec": 37.4
+    },
+    "large": {
+      "full": {
+        "n": 42,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "full_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "dense_only": {
+        "n": 42,
+        "mrr": 0.8738,
+        "hit@1": 0.8571,
+        "hit@3": 0.881,
+        "hit@5": 0.9048
+      },
+      "dense_only_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "elapsed_sec": 57.6
+    }
+  },
+  "skipped": [
+    "bge-m3 (langchain-huggingface/sentence-transformers 미설치)"
+  ],
+  "delta_vs_small_dense_only": {
+    "large": {
+      "mrr": 0.379,
+      "hit@1": 0.4285,
+      "hit@3": 0.3572,
+      "hit@5": 0.2858
+    }
+  }
+}

--- a/ETF_RAG/eval/results/exp_embedding_ab_1782700495.json
+++ b/ETF_RAG/eval/results/exp_embedding_ab_1782700495.json
@@ -1,0 +1,125 @@
+{
+  "config": {
+    "dataset_size": 62,
+    "models": {
+      "small": "text-embedding-3-small",
+      "large": "text-embedding-3-large",
+      "bge-m3": "BAAI/bge-m3"
+    },
+    "modes": [
+      "full (실서비스)",
+      "dense_only (직접매칭off + sparse=0)"
+    ],
+    "note": "Hit@5 천장 효과 → dense_only MRR/Hit@1로 판정. bge-m3는 한국어 특화 비교용."
+  },
+  "models": {
+    "small": {
+      "full": {
+        "n": 42,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "full_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "dense_only": {
+        "n": 42,
+        "mrr": 0.4948,
+        "hit@1": 0.4286,
+        "hit@3": 0.5238,
+        "hit@5": 0.619
+      },
+      "dense_only_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "elapsed_sec": 38.5
+    },
+    "large": {
+      "full": {
+        "n": 42,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "full_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "dense_only": {
+        "n": 42,
+        "mrr": 0.8738,
+        "hit@1": 0.8571,
+        "hit@3": 0.881,
+        "hit@5": 0.9048
+      },
+      "dense_only_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "elapsed_sec": 58.9
+    },
+    "bge-m3": {
+      "full": {
+        "n": 42,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "full_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "dense_only": {
+        "n": 42,
+        "mrr": 0.5762,
+        "hit@1": 0.5714,
+        "hit@3": 0.5714,
+        "hit@5": 0.5952
+      },
+      "dense_only_hard": {
+        "n": 3,
+        "mrr": 1.0,
+        "hit@1": 1.0,
+        "hit@3": 1.0,
+        "hit@5": 1.0
+      },
+      "elapsed_sec": 47.0
+    }
+  },
+  "skipped": [],
+  "delta_vs_small_dense_only": {
+    "large": {
+      "mrr": 0.379,
+      "hit@1": 0.4285,
+      "hit@3": 0.3572,
+      "hit@5": 0.2858
+    },
+    "bge-m3": {
+      "mrr": 0.0814,
+      "hit@1": 0.1428,
+      "hit@3": 0.0476,
+      "hit@5": -0.0238
+    }
+  }
+}


### PR DESCRIPTION
eval/results 추적 정책에 맞춰 untracked였던 RAGAS 재측정 3개 + 임베딩 A/B 2개 + 6/26 eval 1개 커밋. 측정 이력 보존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)