### PR TITLE
feat(admin): 가입자/방문자 통계 GET /admin/stats

### DIFF
--- a/ETF_RAG/api/admin.py
+++ b/ETF_RAG/api/admin.py
@@ -15,8 +15,12 @@ import threading
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
 
+from api.db import get_db
 from api.deps import run_init, verify_cron_token, _DB_PATH
+from api.models_db import PaperAccount, User
 from src.data.db_downloader import ensure_db
 from src.data import technical
 
@@ -79,3 +83,49 @@ def refresh_db(_: None = Depends(verify_cron_token)) -> RefreshDbResponse:
         return RefreshDbResponse(ok=True, refreshed=True, detail="최신 DB로 교체 완료")
     finally:
         _refresh_lock.release()
+
+
+class AdminStatsResponse(BaseModel):
+    total_users: int          # 총 가입자 수
+    users_with_nickname: int  # 닉네임 설정한 유저 수
+    age_groups: dict          # 나이대별 가입자 수 ({"20대": 3, ...}), 미입력은 "미입력"
+    paper_players: int        # 가상투자 계좌를 만든 유저 수
+    visitors_total: int       # 누적 방문 수(방문자 카운터, 방문≠가입)
+
+
+@router.get("/stats", response_model=AdminStatsResponse)
+def admin_stats(
+    _: None = Depends(verify_cron_token),
+    db: Session = Depends(get_db),
+) -> AdminStatsResponse:
+    """관리자용 가입자/방문자 통계. X-Cron-Token 보호(아무나 가입자 수를 못 보게).
+
+    가입자 수는 users 테이블 count. 나이대 분포는 age_group 그룹 count(NULL은 미입력).
+    가상투자 참가자는 paper_accounts 수. 방문자 수는 visitor 카운터(방문≠가입).
+    """
+    total_users = db.scalar(select(func.count()).select_from(User)) or 0
+    users_with_nickname = db.scalar(
+        select(func.count()).select_from(User).where(User.nickname.isnot(None))
+    ) or 0
+
+    age_rows = db.execute(
+        select(User.age_group, func.count()).group_by(User.age_group)
+    ).all()
+    age_groups = {(g or "미입력"): c for g, c in age_rows}
+
+    paper_players = db.scalar(select(func.count()).select_from(PaperAccount)) or 0
+
+    # 방문자 수는 별도 스토어(Supabase/파일) — 실패해도 통계 전체는 반환.
+    try:
+        from src.data.visitor import get_visitor_counts
+        _, visitors_total = get_visitor_counts()
+    except Exception:  # noqa: BLE001
+        visitors_total = 0
+
+    return AdminStatsResponse(
+        total_users=total_users,
+        users_with_nickname=users_with_nickname,
+        age_groups=age_groups,
+        paper_players=paper_players,
+        visitors_total=visitors_total,
+    )

--- a/ETF_RAG/tests/test_admin_stats.py
+++ b/ETF_RAG/tests/test_admin_stats.py
@@ -1,0 +1,59 @@
+"""관리자 통계 엔드포인트 테스트 — GET /admin/stats.
+
+가입자/방문자/나이대/가상투자 집계. DB가 필요하므로 conftest의 StaticPool
+client(인메모리 sqlite)를 그대로 사용(로컬 client 오버라이드 없음).
+X-Cron-Token 보호 — test_admin.py의 refresh-db와 동일 인증 패턴.
+"""
+
+import os
+
+os.environ["API_SKIP_INIT"] = "1"
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from unittest.mock import patch  # noqa: E402
+
+
+def test_stats_no_token(client):
+    """토큰 없음 → 403."""
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.get("/admin/stats")
+    assert r.status_code == 403
+
+
+def test_stats_wrong_token(client):
+    """토큰 불일치 → 403."""
+    with patch("config.CRON_TOKEN", "secret"):
+        r = client.get("/admin/stats", headers={"X-Cron-Token": "nope"})
+    assert r.status_code == 403
+
+
+def test_stats_empty(client):
+    """가입자 0명일 때 전부 0/빈 dict."""
+    with patch("config.CRON_TOKEN", "secret"), \
+         patch("src.data.visitor.get_visitor_counts", return_value=(0, 0)):
+        r = client.get("/admin/stats", headers={"X-Cron-Token": "secret"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_users"] == 0
+    assert body["paper_players"] == 0
+    assert body["age_groups"] == {}
+
+
+def test_stats_counts_users_and_age_groups(client):
+    """가입 후 가입자 수·나이대 분포·닉네임 수 집계."""
+    # 나이대 있는 유저 2명(20대), 나이대 없는 유저 1명
+    client.post("/auth/signup", json={"email": "a@b.com", "password": "pw123456", "age_group": "20대"})
+    client.post("/auth/signup", json={"email": "c@d.com", "password": "pw123456", "age_group": "20대"})
+    client.post("/auth/signup", json={"email": "e@f.com", "password": "pw123456"})
+
+    # 방문자 카운터는 외부 스토어라 모킹(집계에 영향 없음 확인용)
+    with patch("config.CRON_TOKEN", "secret"), \
+         patch("src.data.visitor.get_visitor_counts", return_value=(5, 42)):
+        r = client.get("/admin/stats", headers={"X-Cron-Token": "secret"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_users"] == 3
+    assert body["age_groups"].get("20대") == 2
+    assert body["age_groups"].get("미입력") == 1
+    assert body["visitors_total"] == 42


### PR DESCRIPTION
가입자 수 조회 API가 없어 실제 가입자 수를 알 수 없던 것 해결. X-Cron-Token 보호(관리자만).

- total_users(가입자) / users_with_nickname / age_groups(나이대 분포) / paper_players(가상투자 계좌) / visitors_total(방문≠가입)
- 테스트 +4 (인증 403 2건 + 빈 상태 + 집계). 전체 899 green.

머지·배포 후 `curl -H 'X-Cron-Token: <토큰>' .../admin/stats`로 실제 가입자 수 확인 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)