### PR TITLE
fix(frontend): 비밀번호 찾기 UI를 '준비 중' 안내로 조정

### DIFF
--- a/ETF_RAG/frontend/src/app/login/page.tsx
+++ b/ETF_RAG/frontend/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useAuth } from "@/lib/AuthContext";
-import { AGE_GROUPS, GENDERS, requestPasswordReset } from "@/lib/auth";
+import { AGE_GROUPS, GENDERS } from "@/lib/auth";
 
 export default function LoginPage() {
   const { login, signup } = useAuth();
@@ -14,21 +14,8 @@ export default function LoginPage() {
   const [ageGroup, setAgeGroup] = useState(""); // 선택
   const [gender, setGender] = useState(""); // 필수(가입 시)
   const [showFind, setShowFind] = useState(false); // ID/비번 찾기 안내
-  const [resetEmail, setResetEmail] = useState(""); // 비번 재설정 요청 이메일
-  const [resetSent, setResetSent] = useState(false); // 발송 요청 완료 안내
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-
-  const requestReset = async () => {
-    if (!resetEmail) return;
-    setBusy(true);
-    try {
-      await requestPasswordReset(resetEmail);
-    } finally {
-      setBusy(false);
-      setResetSent(true); // 성공/실패 무관 동일 안내(이메일 열거 방지)
-    }
-  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -159,32 +146,10 @@ export default function LoginPage() {
           <p className="mb-2">
             <b>아이디</b>: 가입하신 <b>이메일이 곧 아이디</b>예요. 이메일 주소로 로그인하세요.
           </p>
-          <p className="mb-2">
-            <b>비밀번호</b>: 가입 이메일로 재설정 링크를 보내드려요.
+          <p>
+            <b>비밀번호</b>: 이메일 재설정 메일 서비스는 <b>준비 중</b>이에요. 로그인이 되는
+            상태라면 <b>계정 설정</b>에서 변경할 수 있고, 완전히 잊으셨다면 문의해 주세요.
           </p>
-          {resetSent ? (
-            <p className="text-green-700">
-              가입된 이메일이면 재설정 링크를 보냈어요. 메일함(스팸함 포함)을 확인해 주세요.
-            </p>
-          ) : (
-            <div className="flex gap-2">
-              <input
-                type="email"
-                value={resetEmail}
-                onChange={(e) => setResetEmail(e.target.value)}
-                placeholder="가입 이메일"
-                className="flex-1 rounded-lg border border-gray-300 dark:border-gray-700 px-3 py-1.5 text-xs focus:border-blue-500 focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={requestReset}
-                disabled={busy || !resetEmail}
-                className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:bg-gray-300"
-              >
-                재설정 메일
-              </button>
-            </div>
-          )}
         </div>
       )}
     </main>


### PR DESCRIPTION
Resend 무료 테스트 도메인(resend.dev)이 가입 계정 본인에게만 발송 허용 → 다른 이메일은 403(라이브 로그 확인). 도메인 인증 전까지 재설정 폼이 동작 안 하므로 '준비 중' 안내로 되돌려 사용자 혼란 방지.

백엔드 엔드포인트·/reset 페이지·auth 함수는 보존 → 도메인 인증 후 env 한 줄 + 이 UI만 되살리면 즉시 전체 동작. tsc/build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)