### PR TITLE
fix(auth): 재설정 토큰 purpose 대칭 방어

### DIFF
--- a/ETF_RAG/api/auth.py
+++ b/ETF_RAG/api/auth.py
@@ -120,6 +120,10 @@ def get_current_user(
         user_id = int(payload["sub"])
     except (jwt.PyJWTError, KeyError, ValueError):
         raise cred_exc
+    # 비밀번호 재설정 전용 토큰(purpose=pwreset)은 로그인 세션으로 쓰지 못하게 거부.
+    # 토큰 종류를 분리했으므로 대칭 방어(재설정 엔드포인트도 액세스 토큰 거부).
+    if payload.get("purpose") == "pwreset":
+        raise cred_exc
     user = db.get(User, user_id)
     if user is None:
         raise cred_exc
@@ -282,6 +286,8 @@ def get_current_user_optional(
         return None
     try:
         payload = jwt.decode(creds.credentials, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        if payload.get("purpose") == "pwreset":  # 재설정 토큰은 세션 아님
+            return None
         return db.get(User, int(payload["sub"]))
     except Exception:  # noqa: BLE001 — optional 경로는 실패 시 None
         return None

--- a/ETF_RAG/tests/test_auth.py
+++ b/ETF_RAG/tests/test_auth.py
@@ -353,3 +353,17 @@ def test_password_reset_confirm_rejects_access_token(client):
     conf = client.post("/auth/password-reset/confirm",
                        json={"token": access, "new_password": "newpw12345"})
     assert conf.status_code == 400
+
+
+def test_reset_token_rejected_as_access_token(client):
+    """대칭 방어: 재설정 토큰(purpose=pwreset)은 로그인 세션으로 못 쓰게 → 401.
+
+    재설정 토큰이 일반 액세스 토큰처럼 쓰이면 30분짜리 세션이 되는 갭 방지.
+    """
+    from api.auth import create_reset_token
+    r = _signup(client, email="rt@b.com")
+    me = client.get("/auth/me", headers={"Authorization": f"Bearer {r.json()['access_token']}"})
+    reset_token = create_reset_token(me.json()["id"])
+    # 재설정 토큰으로 보호된 엔드포인트 접근 → 401
+    blocked = client.get("/auth/me", headers={"Authorization": f"Bearer {reset_token}"})
+    assert blocked.status_code == 401


### PR DESCRIPTION
코드 점검(PR #107~118)에서 발견 — 재설정 토큰(purpose=pwreset)이 get_current_user에서 purpose 미검사로 로그인 세션(30분)으로 통용되던 방어 비대칭 수정. get_current_user(+optional)가 pwreset 토큰 거부.

실악용성 낮으나(본인 메일 발송·본인 범위) 토큰 종류 분리 원칙상 대칭 방어. 테스트 +1(908 green).

발굴 에이전트 후보 4건 중 이 1건만 채택 — 나머지(Alembic latent 2건은 도달 불가, tz 1건은 기존·prod무관)는 근거 기각.

🤖 Generated with [Claude Code](https://claude.com/claude-code)